### PR TITLE
Migrate example packages to --namespace; require non-empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,6 @@ installed, the same commands work via `cub install ...`.
 
 - Bundling
 - Secrets
-- Use for worker installation
 - Interactive wizard (e.g., `survey`).
 - `installer plan` — diff next render vs. previous render and vs. ConfigHub.
 - `installer preflight` — evaluate `externalRequires` against a live cluster.

--- a/examples/gaie/installer.yaml
+++ b/examples/gaie/installer.yaml
@@ -30,21 +30,15 @@ spec:
     - { kind: CRD, name: inferencemodelrewrites.inference.networking.x-k8s.io }
     - { kind: CRD, name: inferencepoolimports.inference.networking.x-k8s.io }
 
-  inputs:
-    - name: namespace
-      type: string
-      default: inference
-      prompt: Namespace for InferencePool/InferenceObjective custom resources (only used by sample-pool)
-      required: true
-
   functionChainTemplate:
     # Rename the sample-pool Namespace resource (when sample-pool is selected)
-    # and set metadata.namespace on every namespace-scoped resource. The base
-    # is CRDs only (cluster-scoped), so this is a no-op when no components
-    # are selected.
+    # and set metadata.namespace on every namespace-scoped resource. The
+    # namespace comes from the wizard's --namespace flag. The base is CRDs
+    # only (cluster-scoped), so this is a no-op when no components are
+    # selected.
     - toolchain: Kubernetes/YAML
       whereResource: ""
       description: Set the namespace on every namespaced resource.
       invocations:
         - name: set-namespace
-          args: ["{{ .Inputs.namespace }}"]
+          args: ["{{ .Namespace }}"]

--- a/examples/hello-app/installer.yaml
+++ b/examples/hello-app/installer.yaml
@@ -30,19 +30,13 @@ spec:
           name: cert-manager
           issuerKind: ClusterIssuer
 
-  inputs:
-    - name: namespace
-      type: string
-      default: hello
-      prompt: Kubernetes namespace
-      required: true
-
   functionChainTemplate:
     # Rename the Namespace resource and set metadata.namespace on every
-    # namespace-scoped resource.
+    # namespace-scoped resource. The namespace comes from the wizard's
+    # --namespace flag.
     - toolchain: Kubernetes/YAML
       whereResource: ""
       description: Set the namespace on every namespaced resource.
       invocations:
         - name: set-namespace
-          args: ["{{ .Inputs.namespace }}"]
+          args: ["{{ .Namespace }}"]

--- a/examples/kuberay/installer.yaml
+++ b/examples/kuberay/installer.yaml
@@ -31,24 +31,18 @@ spec:
     - kind: leader-election-lease
       name: kuberay-operator
 
-  inputs:
-    - name: namespace
-      type: string
-      default: kuberay-system
-      prompt: Namespace for the KubeRay operator
-      required: true
-
   functionChainTemplate:
     # Rename the operator's Namespace resource, set metadata.namespace on
     # every namespace-scoped resource, and upsert subjects[].namespace on
     # every ServiceAccount subject in the operator's RoleBinding and
-    # ClusterRoleBinding.
+    # ClusterRoleBinding. The namespace comes from the wizard's --namespace
+    # flag.
     - toolchain: Kubernetes/YAML
       whereResource: ""
       description: Set the namespace on every namespaced resource and RBAC ServiceAccount subject.
       invocations:
         - name: set-namespace
-          args: ["{{ .Inputs.namespace }}"]
+          args: ["{{ .Namespace }}"]
 
     # Rewrite the operator image to a fully-qualified, version-pinned ref.
     # Upstream manager.yaml ships `image: kuberay/operator` (no registry, no

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -104,7 +104,8 @@ Only --non-interactive mode is implemented today: pass --base, --select, and
 	}
 	cmd.Flags().StringVar(&workDir, "work-dir", ".", "working directory (gets ./package and ./out subdirs)")
 	cmd.Flags().StringVar(&baseName, "base", "", "base name (default: package's default base)")
-	cmd.Flags().StringVar(&namespace, "namespace", "", "Kubernetes namespace for the install (exposed to chain templates as {{ .Namespace }})")
+	cmd.Flags().StringVar(&namespace, "namespace", "", "Kubernetes namespace for the install (exposed to chain templates as {{ .Namespace }}). Required and must be non-empty.")
+	_ = cmd.MarkFlagRequired("namespace")
 	cmd.Flags().StringSliceVar(&selectFlags, "select", nil, "component to select (repeatable; required-deps closed automatically)")
 	cmd.Flags().StringSliceVar(&inputFlags, "input", nil, "input value as key=value (repeatable)")
 	cmd.Flags().BoolVar(&nonInteractive, "non-interactive", false, "do not prompt; require --input/--select for everything")

--- a/internal/render/e2e_test.go
+++ b/internal/render/e2e_test.go
@@ -38,7 +38,7 @@ func TestEndToEnd_HelloApp(t *testing.T) {
 	outDir := filepath.Join(tmp, "out")
 
 	wres, err := wizard.Run(context.Background(), loaded.Package, wizard.RawAnswers{
-		Inputs:             map[string]string{"namespace": "demo"},
+		Namespace:          "demo",
 		SelectedComponents: []string{"monitoring"},
 	}, loaded.Root, outDir)
 	if err != nil {
@@ -132,7 +132,7 @@ func TestEndToEnd_KubeRay(t *testing.T) {
 	outDir := filepath.Join(tmp, "out")
 
 	wres, err := wizard.Run(context.Background(), loaded.Package, wizard.RawAnswers{
-		Inputs:             map[string]string{"namespace": "raysystem"},
+		Namespace:          "raysystem",
 		SelectedComponents: []string{"sample-cluster"},
 	}, loaded.Root, outDir)
 	if err != nil {
@@ -231,7 +231,7 @@ func TestEndToEnd_GAIE(t *testing.T) {
 	outDir := filepath.Join(tmp, "out")
 
 	wres, err := wizard.Run(context.Background(), loaded.Package, wizard.RawAnswers{
-		Inputs:             map[string]string{"namespace": "inferdemo"},
+		Namespace:          "inferdemo",
 		SelectedComponents: []string{"sample-pool"},
 	}, loaded.Root, outDir)
 	if err != nil {

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -47,6 +47,9 @@ type Result struct {
 // packageDir is the absolute path to the loaded package working copy; the
 // collector runs with that as its working directory.
 func Run(ctx context.Context, pkg *api.Package, raw RawAnswers, packageDir, outDir string) (*Result, error) {
+	if raw.Namespace == "" {
+		return nil, fmt.Errorf("namespace is required and must be non-empty")
+	}
 	values, err := coerceInputs(pkg, raw.Inputs)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- `examples/{hello-app,kuberay,gaie}` drop their per-package `namespace` input and reference `{{ .Namespace }}` instead. The wizard's `--namespace` is now the single source of truth.
- `--namespace` is marked required (cobra `MarkFlagRequired`) and validated non-empty in `wizard.Run` for programmatic callers.
- `internal/render/e2e_test.go` passes `Namespace` on `RawAnswers`.
- README roadmap: drop "Use for worker installation" — landed in #5.

## Motivation

Mirrors what Helm actually does: charts read `.Release.Namespace`; the value comes from `--namespace` at install time, not a chart-baked default. The previous per-package defaults (`hello`, `kuberay-system`, `inference`) were closer to a documented convention than a real default and were never as ergonomic as just passing `--namespace`. If we want to surface a recommended namespace (à la `cert-manager → cert-manager`), that's a separate `spec.recommendedNamespace` metadata field that `installer doc` would print but not auto-apply — not in scope here.

## Test plan

- [x] `go test ./...` — all three example-package e2e renders green
- [x] `installer wizard ./examples/hello-app --select monitoring` (no `--namespace`) → cobra error: `required flag(s) "namespace" not set`
- [x] `installer wizard ./examples/hello-app --namespace= --select monitoring` → wizard error: `namespace is required and must be non-empty`
- [x] `installer wizard ./examples/hello-app --namespace demo --select monitoring` → succeeds; `inputs.yaml` carries `namespace: demo`, `values: {}`; rendered `Namespace` resource has `name: demo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)