### PR TITLE
Package and dependency management (Phases 0-8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ settings are deferred until after installation. Configuration as data makes this
 by storing the configuration data rather than re-rendering from scratch. That decouples
 [configuration authoring](https://docs.confighub.com/guide/authoring-config/) from
 [configuration editing](https://itnext.io/configuration-editing-is-imperative-fa9db379fbe4).
+Changes [can be merged](https://docs.confighub.com/guide/variants/#merging-external-sources-into-confighub).
 
 An installer should only present the minimal number of high-level decisions, such as
 which components to install and where to install them. To simplify the component decision,
@@ -20,7 +21,7 @@ recommended to set reasonable defaults as much as possible.
 
 For cases where installation decisions depend on hardware, operating system, networking,
 or other details of the deployment Target, we plan to add a mechanism for retrieving discovered
-Target facts.
+Target facts. Currently there's a local fact collection extension point.
 
 This tool renders kustomize-based packages — wrapped with an `installer.yaml`
 manifest that declares components, dependencies, inputs, and a function chain —
@@ -30,10 +31,10 @@ can be uploaded to ConfigHub for delivery via ArgoCD, Flux, or direct apply.
 
 The "code" lives in the installer (kustomize composition + ConfigHub function
 chain). The "config" stays as data (literal YAML in ConfigHub Units). For post-installation
-customization, [ConfigHub's function suite](https://docs.confighub.com/guide/functions/#frequently-used-functions) includes functions for changing
-commonly changed Kubernetes resource properties, such as `set-container-image`,
-`set-container-resources`, `set-replicas`, and `set-env-var`, and general-purpose
-editing functions, such as `yq-i`, `set-string-path`, `delete-path`, and `set-starlark`.
+customization, [ConfigHub's function suite](https://docs.confighub.com/guide/functions/#frequently-used-functions)
+includes functions for changing commonly changed Kubernetes resource properties, such as
+`set-container-image`, `set-container-resources`, `set-replicas`, `set-env`, and `set-hostname`,
+and general-purpose editing functions, such as `yq-i`, `set-string-path`, `delete-path`, and `set-starlark`.
 
 Why not just [kustomize](https://kustomize.io), or [kpt](https://kpt.dev)? Neither tool
 was really designed to be an installer. A lot was learned from kustomize and kpt, but
@@ -72,9 +73,7 @@ bin/installer wizard ./examples/hello-app \
   --work-dir /tmp/hello \
   --non-interactive \
   --select monitoring --select ingress \
-  --input namespace=demo \
-  --input image=nginxdemos/hello:latest \
-  --input hostname=greet.example.com
+  --namespace demo
 
 # 3. Render: composes the kustomization, runs kustomize, runs the function
 #    chain, writes one file per resource to /tmp/hello/out/manifests/.
@@ -144,26 +143,13 @@ spec:
   provides: [] # cluster-scope resources this package installs (CRDs, etc.)
   clusterSingleton: [] # leader-election leases this package claims
   externalManifests: [] # remote release-tarball manifests to fetch + merge
-  inputs: # wizard prompts
-    - { name: namespace, type: string, default: my-app }
-    - { name: app_name, type: string, required: true }
+  inputs: [] # wizard prompts
   functionChainTemplate: # one or more groups of function invocations
-    - toolchain: Kubernetes/YAML
-      whereResource: "ConfigHub.ResourceType = 'v1/Namespace'"
-      invocations:
-        - name: set-name
-          args: ["{{ .Inputs.namespace }}"]
     - toolchain: Kubernetes/YAML
       whereResource: ""
       invocations:
-        - name: ensure-namespaces
         - name: set-namespace
-          args: ["{{ .Inputs.namespace }}"]
-    - toolchain: Kubernetes/YAML
-      whereResource: "ConfigHub.ResourceType = 'apps/v1/Deployment'"
-      invocations:
-        - name: set-container-image
-          args: ["app", "{{ .Inputs.image }}"]
+          args: ["{{ .Namespace }}"]
 ```
 
 See `examples/hello-app/` for a complete working package.
@@ -203,10 +189,20 @@ installed, the same commands work via `cub install ...`.
 └── cub-plugin.yaml             # cub plugin manifest
 ```
 
+## Design docs
+
+- [Package and dependency management](docs/package-management.md) — spec for
+  bundling, OCI publish, dependency declaration, and resolution.
+- [Implementation plan](docs/package-management-plan.md) — phased build plan;
+  Phase 0 (CLI scaffolding) is in place. Commands marked
+  "(not yet implemented)" in `installer --help` correspond to phases here.
+
 ## Roadmap
 
-- Bundling
-- Secrets
+- Bundling — see [package-management-plan.md](docs/package-management-plan.md)
+  Phase 1.
+- Secrets (currently we use a hack during fact collection)
+- Annotate created units with package metadata and add a change description
 - Interactive wizard (e.g., `survey`).
 - `installer plan` — diff next render vs. previous render and vs. ConfigHub.
 - `installer preflight` — evaluate `externalRequires` against a live cluster.
@@ -217,6 +213,7 @@ installed, the same commands work via `cub install ...`.
   (KubeRay and Gateway API Inference Extension shipped — see `examples/`).
 - AppConfig support.
 - Change of selections and inputs
-- TBD: Hooks
-- TBD: upgrade
-- TBD: variant creation
+- TBD: Hooks, in-cluster and local
+- TBD: image upgrades using cub function set set-container-image or other function
+- TBD: config updates using cub unit update --merge-external-source
+- TBD: variant creation and promotion

--- a/README.md
+++ b/README.md
@@ -193,18 +193,36 @@ installed, the same commands work via `cub install ...`.
 
 - [Package and dependency management](docs/package-management.md) — spec for
   bundling, OCI publish, dependency declaration, and resolution.
-- [Implementation plan](docs/package-management-plan.md) — phased build plan;
-  Phase 0 (CLI scaffolding) is in place. Commands marked
-  "(not yet implemented)" in `installer --help` correspond to phases here.
+- [Implementation plan](docs/package-management-plan.md) — phased build plan.
+  Phases 0–7 are in place: `installer package` (deterministic bundle),
+  `push` / `pull` / `inspect` / `list` / `tag` / `login` / `logout` (OCI
+  artifacts), `deps update` / `deps tree` (SemVer resolver + lock),
+  multi-package render and upload (per-dep Spaces + cross-Space Links),
+  and `sign` / `verify` with a `~/.config/installer/policy.yaml` trust
+  policy that gates `pull` and `deps update`.
+
+## Multi-package example
+
+`examples/example-stack` depends on `examples/example-base`. To exercise
+the full pipeline locally:
+
+```bash
+test/e2e/package-and-deps.sh
+```
+
+That script starts `registry:2`, pushes `example-base`, runs
+`wizard → deps update → render`, asserts the output layout + digest
+stability, and (when `INSTALLER_E2E_CONFIGHUB=1`) also runs
+`installer upload --space-pattern 'installer-e2e-{{.PackageName}}'` and
+cleans the resulting Spaces on exit.
 
 ## Roadmap
 
-- Bundling — see [package-management-plan.md](docs/package-management-plan.md)
-  Phase 1.
-- Secrets (currently we use a hack during fact collection)
 - Annotate created units with package metadata and add a change description
 - Interactive wizard (e.g., `survey`).
 - `installer plan` — diff next render vs. previous render and vs. ConfigHub.
+  Use cub unit update --merge-external-source "source" --dry-run -o mutations
+- Secrets (currently we use a hack during fact collection)
 - `installer preflight` — evaluate `externalRequires` against a live cluster.
 - Automatic apply ordering (CRDs before custom resources, Namespace before
   namespaced resources, etc.) inferred from resource kind plus the existing

--- a/docs/package-management-plan.md
+++ b/docs/package-management-plan.md
@@ -1,0 +1,151 @@
+# Package and Dependency Management — Implementation Plan
+
+Companion to [`package-management.md`](./package-management.md). That doc is
+the spec; this one is the build plan. Phases are ordered so each leaves the
+installer working end-to-end with the existing examples; no phase requires
+the next to land.
+
+## Phase 0 — Scaffolding
+
+Visible CLI surface, stubs only. Lets later phases land in small PRs without
+touching `root.go` each time.
+
+- New: `internal/cli/{package.go, push.go, inspect.go, list.go, tag.go, login.go, logout.go, deps.go, sign.go, verify.go}` — cobra commands returning "not yet implemented" with `--help` text taken from the spec.
+- Modify: `internal/cli/root.go` — register the new subcommands. Group `deps update|build|tree` under `installer deps`.
+- Modify: `internal/cli/stubs.go` — remove the stub-only helper once each command moves to its own file.
+- Modify: `README.md` Roadmap — link to the design doc; mark the new commands "planned" until their phase ships.
+
+No tests yet. Acceptance: `installer --help` lists every command in the spec.
+
+## Phase 1 — Deterministic bundler + `installer package`
+
+Goal: a `.tgz` of the source tree that is byte-identical across machines.
+
+- New: `internal/bundle/bundle.go`
+  - `Bundle(srcDir, dstFile string, opts Options) (digest string, err error)`.
+  - Deterministic tar: sorted entries; zeroed `mtime`, `uid`, `gid`, `uname`, `gname`; canonicalized mode (0644 / 0755); gzip with no original-filename and zeroed mtime.
+  - Reject: `*.env.secret` anywhere; anything under `out/`; anything matched by `.installerignore` (gitignore syntax via `go-git/go-billy`'s gitignore or a small in-tree matcher).
+  - Include: `installer.yaml` + every directory referenced by `bases[].path`, `components[].path`, `validation.*`, `collector.command` (if relative), plus an opt-in `examples/` (gated by a `package.bundleExamples` field in `installer.yaml`, default true).
+- New: `internal/bundle/bundle_test.go` — two `Bundle` invocations of the same source tree produce equal digests; rename of a single file changes the digest; `.env.secret` triggers a refusal.
+- Modify: `internal/cli/package.go` — `-o`, default output filename `<metadata.name>-<metadata.version>.tgz` in cwd; print the digest on success.
+- Decision deferred: reachability-scan vs ignore-list. v1 ships ignore-list; reachability becomes a `installer package --strict` follow-up.
+
+Acceptance: `installer package examples/hello-app` produces a tarball whose `sha256` is reproducible across machines.
+
+## Phase 2 — OCI publish (`push`, `inspect`, `list`, `tag`, hardened `pull`)
+
+Goal: round-trip native artifacts; existing Helm-OCI pull keeps working.
+
+- New: `pkg/api/oci.go` — exported constants for media types (`ArtifactType`, `ConfigMediaType`, `LayerMediaType`) and annotation keys.
+- New: `pkg/api/configblob.go` — `ConfigBlob` type (bundle header + parsed `Package`), serialize/deserialize.
+- New: `internal/pkg/oci.go`
+  - `Push(ctx, tgz, ref) (manifestDigest string, err error)` — builds an oras manifest with the package layer, the config blob, and annotations.
+  - `Inspect(ctx, ref) (*api.ConfigBlob, error)` — fetches only the manifest + config blob (no layer pull).
+  - `List(ctx, repoRef) ([]string, error)` — `/tags/list`.
+  - `Tag(ctx, srcRef, dstTag) error`.
+- Modify: `internal/pkg/pull.go`
+  - Detect native `artifactType` first; fall back to current Helm heuristic only when the artifact does not identify as ours.
+  - Parse `@sha256:...` suffix on refs; verify on pull, error on mismatch.
+- Modify: `internal/cli/{push.go, inspect.go, list.go, tag.go, pull.go}` — wire to `internal/pkg`.
+- New: `internal/cli/login.go`, `logout.go` — reuse docker config (`~/.docker/config.json`); no custom credential file in v1.
+- Tests:
+  - `internal/pkg/oci_test.go` against a `zot` or `registry:2` container started by the test (skip if Docker unavailable).
+  - `internal/pkg/pull_test.go` regression: pulling an existing Helm-OCI chart still works.
+
+Acceptance: `installer package` → `installer push` → `installer pull` on a fresh machine yields a byte-identical source tree.
+
+## Phase 3 — Schema additions (parse-only)
+
+Goal: packages can *declare* dependencies; nothing acts on them yet.
+
+- Modify: `pkg/api/package.go`
+  - `Metadata`: add `KubeVersion`, `InstallerVersion` (SemVer ranges, strings).
+  - `PackageSpec`: add `Dependencies []Dependency`, `Conflicts []ConflictRef`, `Replaces []ReplaceRef`, `BundleExamples *bool`.
+- New types in `pkg/api/dependency.go`: `Dependency`, `ConflictRef`, `ReplaceRef` (fields per the design doc).
+- New: `pkg/api/lock.go` — `Lock`, `LockedDependency`.
+- Modify: `pkg/api/parse.go` and `parse_test.go` — round-trip tests.
+- Modify: `internal/cli/doc.go` — render `dependencies`, `conflicts`, `replaces`, `kubeVersion`, `installerVersion` in `installer doc`.
+- No changes to `wizard`, `render`, `upload`.
+
+Acceptance: a fixture package with the new fields parses and `installer doc` shows them; the existing examples still parse unchanged.
+
+## Phase 4 — Resolver + `installer deps update`
+
+Goal: produce `out/spec/lock.yaml` from `installer.yaml` + the current `Selection`.
+
+- New: `internal/deps/semver.go` — wrap `github.com/Masterminds/semver/v3`.
+- New: `internal/deps/resolver.go`
+  - DAG walk: for each `Dependency`, call `pkg.Inspect` to read the dep's manifest from the config blob (no layer fetch), recurse.
+  - One version per package name. Conflict report names the chain of parents that produced each incompatible constraint.
+  - `optional: true` + `whenComponent: <name>` honored against the current `out/spec/selection.yaml`. Missing selection ⇒ resolver treats all optionals as not-followed and notes them in `deps tree` output.
+  - `conflicts`, `replaces`, and `satisfies → externalRequires` linkage all applied at resolve time.
+  - Cycle detection ⇒ hard error.
+- New: `internal/deps/lock.go` — write `out/spec/lock.yaml`; reject load if the parent's `dependencies:` summary disagrees with the lock (stale-lock detection).
+- Modify: `internal/cli/deps.go` — wire `update`, `tree`, `build`. `build` populates `out/vendor/<name>@<version>/` from the OCI cache.
+- New: shared content-addressed cache under `~/.cache/installer/oci/sha256/...`, used by `pull` and `deps build` (a small helper in `internal/pkg/cache.go`).
+- Tests: `internal/deps/testdata/` with golden-file fixtures: linear chain, diamond, conflict, optional toggled by component, channel-tag pinning.
+
+Acceptance: a fixture parent that depends on two published packages resolves and writes a lock with stable digests across runs.
+
+## Phase 5 — Multi-package render
+
+Goal: parent and each dep render into their own subtrees, deterministically.
+
+- Modify: `internal/render/` — factor the current single-package render path into `RenderPackage(loaded *pkg.Loaded, selection, inputs, outDir)` used for both the parent and every locked dep.
+- Modify: `internal/cli/render.go`
+  - Require a lock when `Dependencies` is non-empty; otherwise behave as today.
+  - Render parent into `out/manifests/` + `out/spec/` (unchanged).
+  - For each `LockedDependency`: ensure the dep is fetched (use the cache, populated either by `deps build` or fetched on demand), then `RenderPackage` into `out/<dep-name>/manifests/` + `out/<dep-name>/spec/` using the lock's `selection` and `inputs` as wizard pre-answers.
+- Tests: render a 2-level fixture; assert subtree layout, manifest counts, and deterministic file digests.
+
+Acceptance: re-rendering the same lock + inputs produces byte-identical `out/` trees.
+
+## Phase 6 — Upload: per-dep Spaces + installer-record Unit + cross-Space links
+
+Goal: each package gets its own Space; the lock survives as a Unit.
+
+- Modify: `internal/cli/upload.go`
+  - Iterate packages in dependency-topological order (parent last is fine; cross-Space Links are created after both Spaces exist).
+  - `--space-pattern <go-template>` with vars `{{.PackageName}} {{.PackageVersion}} {{.Variant}}` (no variant resolution yet — left empty). Default: `"{{.PackageName}}"`.
+  - For each package:
+    - Build a multi-doc YAML stream from `installer.yaml` + every file in `<pkg>/spec/` (selection, inputs, function-chain, manifest-index, and — for the parent — the lock). Create one `Kubernetes/YAML` Unit holding the stream; do **not** assign a Target.
+    - Upload rendered manifests as today, one Unit per file. `--target` applies to these only.
+    - Run the existing intra-Space link inference on the new Units.
+  - After all Spaces exist, for every dep edge in the lock create a Link from the parent's installer-record Unit to the dep's installer-record Unit (Link slug derived from the edge, idempotent).
+- Decision: the parent's installer-record Unit embeds the full lock; each dep's installer-record Unit holds only its own slice (its `installer.yaml` + `out/<dep>/spec/*`). This makes a dep's Space self-describing.
+
+Acceptance: `installer upload` on a fixture multi-package render creates N Spaces, N untargeted installer-record Units, M rendered Units, and the expected cross-Space Links.
+
+## Phase 7 — Signing
+
+Goal: trust at the artifact level.
+
+- New: `internal/cli/sign.go`, `verify.go`. v1 shells out to the `cosign` binary; the Go SDK is large and re-pulls a lot of sigstore dependencies. Document the requirement in `installer doc` output and README.
+- New: `~/.config/installer/policy.yaml` — list of trusted issuers / keys, plus an `enforce: true|false` flag. Loaded by `pull` and `deps update` to enforce verification before trusting any digest.
+- Tests: integration test gated on `cosign` being on PATH.
+
+Acceptance: signed artifact verifies; tampered artifact fails verification with a clear error.
+
+## Phase 8 — Hardening and docs
+
+- Add a multi-package fixture under `examples/` (a small "stack" that depends on a shared base package), used by the e2e script.
+- New: `test/e2e/package-and-deps.sh` (or whatever the existing convention is) — `package` → push to a local `zot` started by the test → `deps update` → `render` → `upload` against a mocked ConfigHub or a real local one.
+- Update README Roadmap: drop the "Bundling" item; link the design doc; mention the multi-package example.
+
+## Cross-cutting concerns (apply across phases)
+
+- **Caching**: one content-addressed OCI cache under `~/.cache/installer/oci/sha256/...`, used by `pull`, `inspect`, and `deps build`. Concurrency-safe via per-digest temp + rename.
+- **Backwards compatibility**: every existing example must keep working through phase 6 with no edits. The renderer only requires a lock when `Dependencies` is non-empty.
+- **Determinism budget**: every step that hashes (bundler, lock, render output) must produce stable digests across machines. Each phase adds a determinism test before claiming acceptance.
+- **Error surface**: resolver, signer, and pull errors include the full chain of refs and reasons. No silent fallbacks once a native artifactType is observed.
+- **Skipped because deferred**: hooks/triggers, variants, Helm chart interop, mirror, yanking. None of the phases introduce schema or CLI surface that pre-commits us to a design for these.
+
+## What ships when
+
+| Cut    | Phases | User-visible value |
+|--------|--------|--------------------|
+| 0.3    | 0, 1   | `installer package` produces shippable tarballs. |
+| 0.4    | 2      | OCI publish round-trips; existing Helm pull still works. |
+| 0.5    | 3, 4   | Packages can declare deps; lock is generated. No behavior change at render. |
+| 0.6    | 5, 6   | Multi-package render + upload with per-dep Spaces and installer-record Units. |
+| 0.7    | 7, 8   | Signed artifacts and the multi-package example. |

--- a/docs/package-management-plan.md
+++ b/docs/package-management-plan.md
@@ -100,6 +100,18 @@ Goal: parent and each dep render into their own subtrees, deterministically.
 
 Acceptance: re-rendering the same lock + inputs produces byte-identical `out/` trees.
 
+### Phase 5 limits
+
+- **Collectors on dependencies are not supported.** Collectors run via the
+  wizard, which is not invoked per-dep — the dep's Selection/Inputs come
+  straight from the lock. `installer deps update` rejects any candidate
+  whose installer.yaml declares `spec.collector` so the user discovers the
+  limit at resolve time, not at render. Lifting the limit means either
+  running the collector at render time for deps (and dragging the
+  collector's runtime requirements — e.g. `cub` on PATH — into render) or
+  defining a smaller resolve-time fact-collection contract. Deferred until
+  a real dep needs it.
+
 ## Phase 6 — Upload: per-dep Spaces + installer-record Unit + cross-Space links
 
 Goal: each package gets its own Space; the lock survives as a Unit.

--- a/docs/package-management.md
+++ b/docs/package-management.md
@@ -1,0 +1,353 @@
+# Package and Dependency Management — Design
+
+Status: design — not yet implemented. The current installer ships with `pull`
+(local + OCI) and a wizard/render/upload pipeline. This document covers
+_bundling_, _publishing_, and _dependency resolution_ for installer packages,
+none of which are implemented yet beyond `pull`.
+
+## Goals
+
+- Distribute installer packages as immutable OCI artifacts that round-trip
+  through `package` → `push` → `pull` → `wizard` → `render` without ever
+  re-rendering at distribution time.
+- Let one package declare hard dependencies on other installer packages, with
+  SemVer constraints, conflicts, and provides — resolved into a lock that
+  pins each dep to a digest.
+- Render a dependency tree into one ConfigHub Space per dependency, so each
+  package keeps its own ownership and apply-time identity.
+- Make every install reproducible: same source + same lock + same inputs =
+  byte-identical rendered output.
+
+## Non-goals
+
+- **Hooks and triggers.** Deferred. We expect to need two kinds eventually:
+  locally executed extensions (fact collection, secret materialization — the
+  current `collector` hook is the seed of this) and in-cluster hook jobs
+  similar to Helm's `pre-install` / `post-install`. The schema below leaves
+  room for both but does not define them.
+- **Helm chart interop as a dependency type.** Helm cannot itself drive this
+  installer because Helm packages have no way to specify a post-renderer, so
+  there is no symmetric path. We can still _pull_ a chart with `installer pull`
+  as a convenience (existing behavior), but `dependencies:` entries cannot
+  point at Helm charts.
+- **Kustomizer-style render-on-push.** Kustomizer's `push` renders first; ours
+  must not, because the function chain _is_ part of the package and runs at
+  wizard time against user-supplied inputs.
+- **Variants.** The Space layout has converged on one Space per component per
+  variant/environment, but the variant problem itself is out of scope here.
+  Bases + components + inputs cover today's needs.
+- **Server-side search/catalog.** OCI `_catalog` support is uneven across
+  registries. Discovery is convention + `installer list`. Curated indexes can
+  be added later if needed.
+
+## What a package is
+
+A package is the _source tree_ the wizard and renderer read from:
+
+```
+my-pkg/
+├── installer.yaml        # the Package manifest (pkg/api.Package)
+├── bases/
+├── components/
+├── validation/           # optional, surfaced by `installer doc`
+├── collector             # optional executable; produces facts + secrets
+└── examples/
+```
+
+It is **never** rendered before distribution. Bundling is a deterministic tar
+of the source tree. This is the same shape as a Helm chart source — different
+from Kustomizer artifacts, which are post-render YAML.
+
+## OCI artifact format
+
+Push one OCI artifact per published version, with a media type that is
+unmistakably ours so other tools (Helm, Kustomizer, generic OCI clients) do
+not misinterpret it.
+
+| Slot           | Value                                                                                                                                                                                  |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `artifactType` | `application/vnd.confighub.installer.package.v1+json`                                                                                                                                  |
+| Config blob    | Computed metadata document (see below). `mediaType: application/vnd.confighub.installer.package.config.v1+json`                                                                        |
+| Single layer   | `package.tar.gz` of the source tree. `mediaType: application/vnd.confighub.installer.package.tar+gzip`                                                                                 |
+| Annotations    | `org.opencontainers.image.title`, `…version`, plus `installer.confighub.com/{name,version,kubeVersion,installerVersion,provides,dependencies}` summaries for cheap registry-listing UX |
+
+The config blob is the parsed `installer.yaml` plus a header section computed
+at bundle time:
+
+```yaml
+# computed header (not authored)
+bundle:
+  installerVersion: 0.4.0 # the installer CLI that produced this
+  createdAt: 2026-05-13T17:02:00Z
+  files:
+    - { path: installer.yaml, sha256: ... }
+    - { path: bases/default/..., sha256: ... }
+    # one entry per file in the tar
+  digest: sha256:... # of package.tar.gz
+manifest: <the parsed installer.yaml>
+```
+
+Having the manifest in the config blob lets `installer inspect <ref>` and the
+resolver read metadata (dependencies, provides, kubeVersion) without pulling
+the layer.
+
+### Pull-time discrimination
+
+`installer pull` already handles a Helm-OCI shape heuristically (single `.tgz`
+layer named like a chart). Native installer artifacts take a deterministic
+path based on `artifactType`; the Helm fallback remains for convenience but
+must not be exercised when the artifact identifies itself as ours.
+
+### Determinism
+
+The bundler MUST produce byte-identical tars from byte-identical source trees:
+
+- Entries sorted by path.
+- `mtime`, `uid`, `gid`, `uname`, `gname` zeroed; mode bits canonicalized.
+- gzip with no original-filename and zeroed mtime.
+
+Without this, signing and digest-pinning give weak guarantees.
+
+## CLI surface
+
+```
+installer package <dir> [-o file.tgz]
+installer push    <pkg.tgz|dir> oci://registry/repo:tag
+installer pull    <ref>                                # exists; harden + add --digest
+installer inspect <ref>                                # reads config blob only
+installer list    oci://registry/repo                  # tags via /tags/list
+installer tag     <src-ref> <dst-tag>
+installer sign    <ref>                                # cosign keyed or keyless
+installer verify  <ref>
+installer login   <registry>
+installer logout  <registry>
+installer deps update <dir>                            # write installer.lock to out/spec/
+installer deps build  <dir>                            # pre-fetch locked deps for offline render
+installer deps tree   <dir>                            # render the resolved DAG
+```
+
+`installer search` is omitted in v1.
+
+`pull` accepts an optional `@sha256:...` digest after the tag and fails the
+fetch if the registry returns a different digest. Used by the resolver and by
+operators who want pinned installs.
+
+## Versioning and channels
+
+- `metadata.version` is required and parsed as SemVer 2.0. Tag-per-version
+  artifacts are immutable.
+- Channel tags (`stable`, `latest`, `0`, `0.3`) are allowed by convention only.
+  No registry-side mechanism enforces them; they are mutable aliases that
+  authors maintain.
+- The resolver always pins a channel to the digest it resolved to and records
+  that digest in the lock, so re-renders are reproducible even if the channel
+  later moves.
+
+## Dependency management
+
+The package today already has two "needs" concepts:
+
+1. **Cluster-side preconditions** — `externalRequires` (CRDs, GatewayClass,
+   WebhookCertProvider, Operator, …). Evaluated at preflight against a live
+   cluster. This stays as is.
+2. **Package-side dependencies** — other installer packages this package
+   composes with. This is new.
+
+The two are linked: a `dependencies:` entry can declare which of _this_
+package's `externalRequires` it satisfies, and the dep's own `provides:` must
+be compatible. If the user accepts the dep, those `externalRequires` are
+considered met without a separate cluster probe.
+
+### Why side-by-side, not merged
+
+Each dependency renders into its **own** ConfigHub Space (one Space per dep,
+matching the broader convergence on Space-per-component-per-variant/env). The
+installer does not melt deps into the parent's manifests. Reasons:
+
+- Preserves config-as-data: each rendered Unit has one provenance.
+- Matches Debian's behavior — apt installs a tree of packages; each stays
+  distinct.
+- Upgrade ergonomics: a dep can be re-rendered without touching the parent's
+  Units, and vice versa.
+- ConfigHub Links express the cross-package relationships explicitly.
+
+### Schema additions to `installer.yaml`
+
+```yaml
+spec:
+  dependencies:
+    - name: gateway-api # local handle
+      package: oci://ghcr.io/confighubai/gateway-api # OCI ref, no tag
+      version: "^1.2.0" # SemVer range
+      selection: # pre-answers the dep's wizard
+        base: default
+        components: [crds, kgateway]
+      inputs:
+        namespace: gateway-system
+      optional: false # default false
+      whenComponent: ingress # only follow if parent component selected
+      satisfies: # which of *this* package's externalRequires this dep covers
+        - { kind: CRD, name: gateway.networking.k8s.io }
+        - { kind: GatewayClass, capability: ext-proc }
+
+  conflicts: # hard exclusion
+    - package: oci://ghcr.io/foo/old-gateway
+      version: "*"
+
+  replaces: # smooth rename / supersession
+    - package: oci://ghcr.io/foo/old-name
+      version: "< 2.0.0"
+```
+
+`provides:` already exists and gains a second role: in addition to detecting
+double-install conflicts at apply time, it is matched against parent
+`externalRequires` during resolution so the resolver knows a dep covers a
+precondition.
+
+### Lock file
+
+The lock is not stored in git. Per the broader design, all of `out/spec/*` —
+`selection.yaml`, `inputs.yaml`, `function-chain.yaml`, `manifest-index.yaml`,
+the new `lock.yaml`, and the package's `installer.yaml` itself — are combined
+into a single multi-document YAML stream and uploaded as one
+`Kubernetes/YAML` Unit (the "installer record" Unit). That Unit has **no
+Target** because it is not deployed: it exists to reproduce a render. The
+renderer reads from `out/spec/` locally; the upload step also writes the
+record Unit alongside the rendered Units.
+
+Lock contents:
+
+```yaml
+apiVersion: installer.confighub.com/v1alpha1
+kind: Lock
+metadata:
+  name: <package name>
+spec:
+  package:
+    name: llm-stack
+    version: 0.3.0
+    digest: sha256:...
+  resolved:
+    - name: gateway-api
+      ref: oci://ghcr.io/confighubai/gateway-api:1.4.2
+      digest: sha256:bbbb...
+      requestedBy: [root]
+      version: 1.4.2
+      selection: { base: default, components: [crds, kgateway] }
+    - name: cert-manager
+      ref: oci://ghcr.io/confighubai/cert-manager:1.15.3
+      digest: sha256:cccc...
+      requestedBy: [gateway-api]
+      version: 1.15.3
+```
+
+Workflow:
+
+- `installer deps update <dir>` resolves the DAG, writes `out/spec/lock.yaml`.
+- `installer render` requires a lock; if absent or stale (root manifest's
+  declared deps disagree with the lock), it errors and instructs the user to
+  re-run `installer deps update`.
+- `installer deps build <dir>` pre-fetches each locked dep into a local
+  `out/vendor/<name>@<version>/` so a subsequent render is fully offline.
+
+### Resolver
+
+Inspired by Cargo's resolver and apt's coherent-set behavior:
+
+- One version per package name in the resolution set. Two parents asking for
+  incompatible ranges of the same package → resolution failure with a clear
+  report (chain → constraint → conflict, à la `cargo` errors).
+- `optional: true` + `whenComponent: <name>` makes a dep follow only when the
+  named component is selected in the parent's `Selection`. This is the same
+  shape as Helm's subchart `condition:` and Debian's `Recommends`.
+- `conflicts:` is hard: the resolver fails if any conflicting package appears
+  anywhere in the DAG.
+- `replaces:` lets a renamed package satisfy a request for the old name (used
+  during migrations).
+- Cycles are an error.
+
+### Apply ordering across packages
+
+ConfigHub Links + automatic apply-ordering (Roadmap item in the README) handle
+ordering inside a Space. Across Spaces, the dep tree implies an order: a Space
+is applied only after the Spaces of packages it depends on have converged. The
+installer's upload step records this in the installer-record Unit and in
+inter-Space Links; cross-Space ApplyGates enforce it at apply time.
+
+### Cluster-side `externalRequires` still apply
+
+Anything in `externalRequires` not satisfied by some dep's `provides` remains
+a cluster precondition checked by `installer preflight`. This is what keeps
+the model honest: declaring a dep is a _promise_ that the dep provides the
+precondition; preflight verifies leftovers.
+
+## Bundling rules
+
+`installer package` MUST refuse to bundle:
+
+- `*.env.secret` files anywhere in the tree (collector output; never published).
+- Anything under `out/` (rendered artifacts; not source).
+- Anything matched by `.installerignore` (optional, mirrors `.helmignore`).
+
+`installer package` MUST include:
+
+- `installer.yaml`, all referenced `bases/` and `components/` trees,
+  `validation/`, the `collector` executable if declared, and any files
+  reachable by kustomization references.
+
+`externalManifests` (remote release-tarball CRDs already pinned by digest in
+the manifest) are **not** embedded in the package tarball. They are fetched
+at render time and verified against the declared digest. Embedding would
+bloat artifacts and duplicate immutable upstream blobs.
+
+## Compatibility metadata
+
+```yaml
+metadata:
+  name: my-stack
+  version: 0.3.0
+  kubeVersion: ">= 1.28" # SemVer range, checked at resolve time
+  installerVersion: ">= 0.2.0" # range against the CLI invoking render
+  annotations:
+    confighub.com/category: gateway
+    confighub.com/maintainers: ...
+```
+
+The two `*Version` fields are evaluated at resolve time and at render time;
+mismatch is an error with an upgrade hint. Annotations are advisory and
+surfaced in `installer inspect` and `installer doc`.
+
+## Signing
+
+`installer push --sign` and `installer verify` use cosign (keyed or keyless).
+When a local policy file is present (`~/.config/installer/policy.yaml`),
+`pull` and `deps update` enforce verification before trusting an artifact's
+digest.
+
+## What this design does _not_ answer (yet)
+
+- **Mirroring / air-gap workflows.** `installer deps build` produces a
+  vendor tree, but a `installer mirror oci://src oci://dst` for moving an
+  entire dep closure between registries is left for later.
+- **Multi-arch packages.** Installer packages are platform-independent (they
+  contain YAML and an optional `collector` script). The `collector` binary
+  case is the only one where multi-arch might matter, and we can address it
+  by shipping `collector` as a remote-fetched layer when needed.
+- **Yanking.** Removing a published version. OCI registries vary in support;
+  we will document "deprecate via annotations on a new tag" as the v1 story.
+- **Hooks / triggers.** See Non-goals. Reserved for a follow-on design.
+
+## Implementation order (suggested)
+
+1. Deterministic bundler + `installer package` (no network).
+2. `installer push` / `inspect` / `list` / `tag` against an OCI registry,
+   reusing oras-go.
+3. `installer.yaml` schema additions (`dependencies`, `conflicts`,
+   `replaces`, satisfies-link on existing fields) — parse-only.
+4. Resolver + `installer deps update` writing `out/spec/lock.yaml`.
+5. Render wired to read the lock, fetch deps (cached via `deps build`), and
+   render each into its own output subtree (`out/<dep-name>/manifests/`,
+   `out/<dep-name>/spec/`).
+6. Upload step extended to create one Space per dep and one installer-record
+   Unit per package, with cross-Space Links for the dep relationships.
+7. Signing.

--- a/examples/example-base/bases/default/configmap.yaml
+++ b/examples/example-base/bases/default/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-base-defaults
+data:
+  hello: world

--- a/examples/example-base/bases/default/kustomization.yaml
+++ b/examples/example-base/bases/default/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - configmap.yaml

--- a/examples/example-base/bases/default/namespace.yaml
+++ b/examples/example-base/bases/default/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app

--- a/examples/example-base/installer.yaml
+++ b/examples/example-base/installer.yaml
@@ -1,0 +1,25 @@
+apiVersion: installer.confighub.com/v1alpha1
+kind: Package
+metadata:
+  name: example-base
+  version: 0.1.0
+spec:
+  bases:
+    - name: default
+      path: bases/default
+      default: true
+      description: Shared Namespace + ConfigMap for downstream packages.
+
+  functionChainTemplate:
+    # Rename the Namespace resource to the install-time --namespace.
+    - toolchain: Kubernetes/YAML
+      whereResource: "ConfigHub.ResourceType = 'v1/Namespace'"
+      invocations:
+        - name: set-name
+          args: ["{{ .Namespace }}"]
+    # Set metadata.namespace on every namespaced resource.
+    - toolchain: Kubernetes/YAML
+      whereResource: ""
+      invocations:
+        - name: set-namespace
+          args: ["{{ .Namespace }}"]

--- a/examples/example-stack/README.md
+++ b/examples/example-stack/README.md
@@ -1,0 +1,15 @@
+# example-stack
+
+A two-package fixture demonstrating installer dependencies.
+
+- `example-stack` is this package — an app `Deployment` whose container
+  reads env vars from a `ConfigMap` that lives in the dep.
+- The dep ref is hard-coded to `oci://localhost:5555/installer-e2e/example-base`
+  so a single `git clone` exercises the multi-package render pipeline
+  without needing to edit YAML. `test/e2e/package-and-deps.sh` starts a
+  local `registry:2` on `:5555`, pushes `examples/example-base` to it,
+  then drives `wizard → deps update → render → upload`.
+
+To use this example against a different registry, edit
+`spec.dependencies[0].package` in `installer.yaml` to point at your own
+copy of the `example-base` artifact.

--- a/examples/example-stack/bases/default/deployment.yaml
+++ b/examples/example-stack/bases/default/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-stack
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: example-stack
+  template:
+    metadata:
+      labels:
+        app: example-stack
+    spec:
+      containers:
+        - name: app
+          image: nginxdemos/hello:plain-text
+          ports:
+            - containerPort: 80
+              name: http
+          envFrom:
+            - configMapRef:
+                name: example-base-defaults

--- a/examples/example-stack/bases/default/kustomization.yaml
+++ b/examples/example-stack/bases/default/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml

--- a/examples/example-stack/installer.yaml
+++ b/examples/example-stack/installer.yaml
@@ -1,0 +1,26 @@
+apiVersion: installer.confighub.com/v1alpha1
+kind: Package
+metadata:
+  name: example-stack
+  version: 0.1.0
+spec:
+  bases:
+    - name: default
+      path: bases/default
+      default: true
+      description: An app Deployment that depends on example-base.
+
+  # The dep ref is hard-coded to the e2e registry on :5555. See README.md
+  # in this directory for how to bootstrap or how to repoint at your own
+  # registry.
+  dependencies:
+    - name: base
+      package: oci://localhost:5555/installer-e2e/example-base
+      version: "^0.1.0"
+
+  functionChainTemplate:
+    - toolchain: Kubernetes/YAML
+      whereResource: ""
+      invocations:
+        - name: set-namespace
+          args: ["{{ .Namespace }}"]

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/confighubai/installer
 go 1.25.0
 
 require (
+	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/confighub/sdk/core v0.1.42
 	github.com/confighub/sdk/function-impl v0.1.42
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,11 @@ go 1.25.0
 require (
 	github.com/confighub/sdk/core v0.1.42
 	github.com/confighub/sdk/function-impl v0.1.42
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00
+	github.com/opencontainers/go-digest v1.0.0
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/spf13/cobra v1.10.1
+	golang.org/x/term v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
 	oras.land/oras-go/v2 v2.6.0
 )
@@ -72,10 +76,7 @@ require (
 	github.com/mikefarah/yq/v4 v4.48.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.23.0 // indirect
@@ -109,7 +110,6 @@ require (
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.37.0 // indirect
-	golang.org/x/term v0.36.0 // indirect
 	golang.org/x/text v0.30.0 // indirect
 	golang.org/x/time v0.11.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250825161204-c5933d9347a5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -601,6 +601,8 @@ github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
+github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
+github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/a8m/envsubst v1.4.3 h1:kDF7paGK8QACWYaQo6KtyYBozY2jhQrTuNNuUxQkhJY=
 github.com/a8m/envsubst v1.4.3/go.mod h1:4jjHWQlZoaXPoLQUb7H2qT4iLkZDdmEQiOUogdUmqVU=

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -1,0 +1,267 @@
+// Package bundle produces deterministic, distribution-ready installer package
+// tarballs. The output is the input to `installer push` and is what an OCI
+// registry stores as a single layer of a native installer artifact.
+//
+// Determinism: same source tree → byte-identical .tgz, regardless of mtimes,
+// uids, host platform, or walk order. This is what makes signing and
+// digest-pinning meaningful.
+package bundle
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	gitignore "github.com/monochromegane/go-gitignore"
+)
+
+// IgnoreFile is the name of the per-package ignore file (gitignore syntax).
+const IgnoreFile = ".installerignore"
+
+// Result is the outcome of a Bundle call.
+type Result struct {
+	// Digest is the sha256 of the gzipped tar, hex-encoded (no "sha256:" prefix).
+	Digest string
+	// Files is the list of paths included, in tar order.
+	Files []string
+	// Size is the size of the .tgz in bytes.
+	Size int64
+}
+
+// Bundle writes a deterministic .tgz of srcDir to dstFile.
+//
+// Refuses to include:
+//   - any file matching *.env.secret anywhere in the tree
+//   - anything under <srcDir>/out/
+//   - anything matched by <srcDir>/.installerignore (gitignore syntax)
+//   - .git/, .DS_Store (default ignores; not configurable)
+//
+// dstFile's parent directory is created if needed; the file is replaced if it
+// exists.
+func Bundle(srcDir, dstFile string) (*Result, error) {
+	if srcDir == "" {
+		return nil, errors.New("srcDir required")
+	}
+	if dstFile == "" {
+		return nil, errors.New("dstFile required")
+	}
+	abs, err := filepath.Abs(srcDir)
+	if err != nil {
+		return nil, err
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%s is not a directory", abs)
+	}
+	if _, err := os.Stat(filepath.Join(abs, "installer.yaml")); err != nil {
+		return nil, fmt.Errorf("no installer.yaml in %s", abs)
+	}
+
+	ig, err := loadIgnore(abs)
+	if err != nil {
+		return nil, err
+	}
+
+	files, err := walkAndCollect(abs, ig)
+	if err != nil {
+		return nil, err
+	}
+
+	return writeTarGz(files, dstFile)
+}
+
+// fileEntry is a regular file selected for inclusion.
+type fileEntry struct {
+	rel  string // forward-slash, relative to src
+	abs  string
+	size int64
+	exec bool // include +x bit in mode
+}
+
+func walkAndCollect(src string, ig gitignore.IgnoreMatcher) ([]fileEntry, error) {
+	var out []fileEntry
+	err := filepath.Walk(src, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		relSlash := filepath.ToSlash(rel)
+
+		// Hard refusal: *.env.secret must never ship.
+		if strings.HasSuffix(relSlash, ".env.secret") {
+			return fmt.Errorf("refusing to bundle %s: *.env.secret files must never be published", relSlash)
+		}
+
+		// Hard exclusion: out/ tree is render output, not source.
+		if relSlash == "out" || strings.HasPrefix(relSlash, "out/") {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// Default ignores.
+		if relSlash == ".git" || strings.HasPrefix(relSlash, ".git/") {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Base(relSlash) == ".DS_Store" {
+			return nil
+		}
+
+		// User-supplied .installerignore (gitignore syntax).
+		if ig != nil && ig.Match(path, info.IsDir()) {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// Symlinks are rejected — the bundler must produce a self-contained
+		// tarball that pulls back identically regardless of host filesystem.
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("symlink not supported in package: %s", relSlash)
+		}
+
+		// Directories themselves are not written as tar entries; empty dirs
+		// are dropped because they're not load-bearing.
+		if info.IsDir() {
+			return nil
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("non-regular file not supported: %s", relSlash)
+		}
+
+		out = append(out, fileEntry{
+			rel:  relSlash,
+			abs:  path,
+			size: info.Size(),
+			exec: info.Mode()&0o111 != 0,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].rel < out[j].rel })
+	return out, nil
+}
+
+func writeTarGz(files []fileEntry, dst string) (*Result, error) {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return nil, err
+	}
+	f, err := os.Create(dst)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	hasher := sha256.New()
+	counter := &countingWriter{w: io.MultiWriter(f, hasher)}
+
+	gw, err := gzip.NewWriterLevel(counter, gzip.BestCompression)
+	if err != nil {
+		return nil, err
+	}
+	// Zero gzip header fields so the same input yields the same bytes.
+	gw.Name = ""
+	gw.Comment = ""
+	gw.ModTime = time.Time{}
+	gw.OS = 255 // unknown — avoids platform-dependent byte
+
+	tw := tar.NewWriter(gw)
+	for _, fe := range files {
+		mode := int64(0o644)
+		if fe.exec {
+			mode = 0o755
+		}
+		hdr := &tar.Header{
+			Name:     fe.rel,
+			Mode:     mode,
+			Size:     fe.size,
+			Typeflag: tar.TypeReg,
+			ModTime:  time.Time{},
+			Uid:      0,
+			Gid:      0,
+			Uname:    "",
+			Gname:    "",
+			Format:   tar.FormatPAX,
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return nil, fmt.Errorf("tar header %s: %w", fe.rel, err)
+		}
+		in, err := os.Open(fe.abs)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := io.Copy(tw, in); err != nil {
+			in.Close()
+			return nil, fmt.Errorf("tar copy %s: %w", fe.rel, err)
+		}
+		in.Close()
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	if err := gw.Close(); err != nil {
+		return nil, err
+	}
+
+	rels := make([]string, len(files))
+	for i, fe := range files {
+		rels[i] = fe.rel
+	}
+	return &Result{
+		Digest: hex.EncodeToString(hasher.Sum(nil)),
+		Files:  rels,
+		Size:   counter.n,
+	}, nil
+}
+
+// loadIgnore returns nil if no .installerignore exists.
+func loadIgnore(srcDir string) (gitignore.IgnoreMatcher, error) {
+	path := filepath.Join(srcDir, IgnoreFile)
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("%s is a directory; expected a file", path)
+	}
+	return gitignore.NewGitIgnore(path, srcDir)
+}
+
+type countingWriter struct {
+	w io.Writer
+	n int64
+}
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	n, err := c.w.Write(p)
+	c.n += int64(n)
+	return n, err
+}

--- a/internal/bundle/bundle_test.go
+++ b/internal/bundle/bundle_test.go
@@ -1,0 +1,250 @@
+package bundle
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// installerYAML is the minimum manifest Bundle requires to consider a
+// directory a package.
+const installerYAML = `apiVersion: installer.confighub.com/v1alpha1
+kind: Package
+metadata:
+  name: test
+  version: 0.0.1
+spec:
+  bases:
+    - {name: default, path: bases/default, default: true}
+`
+
+// writeTree creates files relative to root from a path → contents map. Paths
+// with a trailing "/" are created as directories.
+func writeTree(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for p, c := range files {
+		full := filepath.Join(root, p)
+		if strings.HasSuffix(p, "/") {
+			if err := os.MkdirAll(full, 0o755); err != nil {
+				t.Fatalf("mkdir %s: %v", full, err)
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(full), err)
+		}
+		if err := os.WriteFile(full, []byte(c), 0o644); err != nil {
+			t.Fatalf("write %s: %v", full, err)
+		}
+	}
+}
+
+// minimalPkg produces the smallest valid package: installer.yaml plus a base
+// kustomization with a single resource.
+func minimalPkg(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"installer.yaml":                  installerYAML,
+		"bases/default/kustomization.yaml": "resources:\n  - cm.yaml\n",
+		"bases/default/cm.yaml":            "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n",
+	})
+	return dir
+}
+
+func TestBundleDeterministic(t *testing.T) {
+	src := minimalPkg(t)
+	d1 := filepath.Join(t.TempDir(), "1.tgz")
+	d2 := filepath.Join(t.TempDir(), "2.tgz")
+
+	r1, err := Bundle(src, d1)
+	if err != nil {
+		t.Fatalf("bundle 1: %v", err)
+	}
+	r2, err := Bundle(src, d2)
+	if err != nil {
+		t.Fatalf("bundle 2: %v", err)
+	}
+	if r1.Digest != r2.Digest {
+		t.Fatalf("digests differ: %s != %s", r1.Digest, r2.Digest)
+	}
+	if !equalBytes(d1, d2) {
+		t.Fatalf(".tgz bytes differ for the same source tree")
+	}
+}
+
+func TestBundleStableAcrossMtimeChanges(t *testing.T) {
+	src := minimalPkg(t)
+	d1 := filepath.Join(t.TempDir(), "1.tgz")
+	d2 := filepath.Join(t.TempDir(), "2.tgz")
+
+	r1, err := Bundle(src, d1)
+	if err != nil {
+		t.Fatalf("bundle 1: %v", err)
+	}
+
+	// Touch every file with an arbitrary mtime; this must not change the
+	// resulting tar bytes.
+	stamp := time.Date(2017, 3, 14, 12, 0, 0, 0, time.UTC)
+	_ = filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		_ = os.Chtimes(path, stamp, stamp)
+		return nil
+	})
+
+	r2, err := Bundle(src, d2)
+	if err != nil {
+		t.Fatalf("bundle 2: %v", err)
+	}
+	if r1.Digest != r2.Digest {
+		t.Fatalf("digest changed after mtime touch: %s → %s", r1.Digest, r2.Digest)
+	}
+}
+
+func TestBundleChangesWhenContentChanges(t *testing.T) {
+	src := minimalPkg(t)
+	d1 := filepath.Join(t.TempDir(), "1.tgz")
+	d2 := filepath.Join(t.TempDir(), "2.tgz")
+
+	r1, err := Bundle(src, d1)
+	if err != nil {
+		t.Fatalf("bundle 1: %v", err)
+	}
+
+	// Replace one byte in cm.yaml — digest must change.
+	cm := filepath.Join(src, "bases/default/cm.yaml")
+	if err := os.WriteFile(cm, []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: y\n"), 0o644); err != nil {
+		t.Fatalf("rewrite cm: %v", err)
+	}
+	r2, err := Bundle(src, d2)
+	if err != nil {
+		t.Fatalf("bundle 2: %v", err)
+	}
+	if r1.Digest == r2.Digest {
+		t.Fatalf("digest did not change after content edit")
+	}
+}
+
+func TestBundleRefusesEnvSecret(t *testing.T) {
+	src := minimalPkg(t)
+	writeTree(t, src, map[string]string{
+		"collector/.env.secret": "PASSWORD=hunter2\n",
+	})
+	_, err := Bundle(src, filepath.Join(t.TempDir(), "p.tgz"))
+	if err == nil {
+		t.Fatalf("expected refusal for .env.secret, got nil")
+	}
+	if !strings.Contains(err.Error(), ".env.secret") {
+		t.Fatalf("error should mention .env.secret: %v", err)
+	}
+}
+
+func TestBundleExcludesOutDir(t *testing.T) {
+	src := minimalPkg(t)
+	writeTree(t, src, map[string]string{
+		"out/manifests/deploy.yaml": "junk\n",
+		"out/spec/selection.yaml":   "junk\n",
+	})
+	r, err := Bundle(src, filepath.Join(t.TempDir(), "p.tgz"))
+	if err != nil {
+		t.Fatalf("bundle: %v", err)
+	}
+	for _, f := range r.Files {
+		if strings.HasPrefix(f, "out/") {
+			t.Fatalf("out/ file leaked into bundle: %s", f)
+		}
+	}
+}
+
+func TestBundleHonoursInstallerIgnore(t *testing.T) {
+	src := minimalPkg(t)
+	writeTree(t, src, map[string]string{
+		".installerignore":      "*.bak\nlocal/\n",
+		"notes.bak":             "scratch\n",
+		"local/private.yaml":    "shh\n",
+		"bases/default/x.yaml":  "kept\n",
+	})
+	r, err := Bundle(src, filepath.Join(t.TempDir(), "p.tgz"))
+	if err != nil {
+		t.Fatalf("bundle: %v", err)
+	}
+	for _, f := range r.Files {
+		if f == "notes.bak" || strings.HasPrefix(f, "local/") {
+			t.Fatalf("ignored path %q leaked into bundle", f)
+		}
+	}
+	if !slices.Contains(r.Files, "bases/default/x.yaml") {
+		t.Fatalf("unrelated file dropped: %v", r.Files)
+	}
+}
+
+func TestBundleRequiresInstallerYAML(t *testing.T) {
+	src := t.TempDir()
+	// no installer.yaml
+	_, err := Bundle(src, filepath.Join(t.TempDir(), "p.tgz"))
+	if err == nil || !strings.Contains(err.Error(), "installer.yaml") {
+		t.Fatalf("expected installer.yaml error, got %v", err)
+	}
+}
+
+func TestBundleTarHeadersZeroed(t *testing.T) {
+	src := minimalPkg(t)
+	dst := filepath.Join(t.TempDir(), "p.tgz")
+	if _, err := Bundle(src, dst); err != nil {
+		t.Fatalf("bundle: %v", err)
+	}
+
+	f, err := os.Open(dst)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatalf("gzip: %v", err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar: %v", err)
+		}
+		// tar stores time as a Unix epoch second count, so Go's "zero
+		// Time" round-trips as 1970-01-01 UTC. Both have Unix() == 0.
+		if hdr.ModTime.Unix() != 0 {
+			t.Fatalf("non-zero mtime on %s: %v", hdr.Name, hdr.ModTime)
+		}
+		if hdr.Uid != 0 || hdr.Gid != 0 {
+			t.Fatalf("non-zero uid/gid on %s: %d/%d", hdr.Name, hdr.Uid, hdr.Gid)
+		}
+		if hdr.Uname != "" || hdr.Gname != "" {
+			t.Fatalf("non-empty uname/gname on %s: %q/%q", hdr.Name, hdr.Uname, hdr.Gname)
+		}
+	}
+}
+
+func equalBytes(a, b string) bool {
+	x, err := os.ReadFile(a)
+	if err != nil {
+		return false
+	}
+	y, err := os.ReadFile(b)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(x, y)
+}
+

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newDepsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "deps",
+		Short: "(not yet implemented) Manage installer package dependencies",
+		Long: `Deps resolves the dependency DAG declared in installer.yaml against an OCI
+registry, writes <work-dir>/out/spec/lock.yaml, and optionally vendors
+locked dependencies for offline render.
+
+See docs/package-management-plan.md (Phase 4).`,
+	}
+	cmd.AddCommand(newDepsUpdateCmd(), newDepsBuildCmd(), newDepsTreeCmd())
+	return cmd
+}
+
+func newDepsUpdateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "update <work-dir>",
+		Short: "(not yet implemented) Resolve the dependency DAG and write out/spec/lock.yaml",
+		Long: `Update walks the dependency DAG declared in
+<work-dir>/package/installer.yaml, resolves SemVer constraints against the
+OCI registry by fetching each dep's manifest + config blob (no layer pull),
+and writes <work-dir>/out/spec/lock.yaml pinning every dependency to a
+digest. Conflicts and replaces are honored.
+
+See docs/package-management-plan.md (Phase 4).`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("deps update not yet implemented; see docs/package-management-plan.md (Phase 4)")
+		},
+	}
+}
+
+func newDepsBuildCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "build <work-dir>",
+		Short: "(not yet implemented) Pre-fetch locked dependencies into out/vendor/",
+		Long: `Build fetches every dependency listed in <work-dir>/out/spec/lock.yaml into
+<work-dir>/out/vendor/<name>@<version>/ so that a subsequent installer
+render runs without network access.
+
+See docs/package-management-plan.md (Phase 4).`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("deps build not yet implemented; see docs/package-management-plan.md (Phase 4)")
+		},
+	}
+}
+
+func newDepsTreeCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "tree <work-dir>",
+		Short: "(not yet implemented) Print the resolved dependency DAG",
+		Long: `Tree prints the resolved dependency DAG from
+<work-dir>/out/spec/lock.yaml, showing parent → child relationships,
+versions, and which optional deps were followed based on the current
+selection.
+
+See docs/package-management-plan.md (Phase 4).`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("deps tree not yet implemented; see docs/package-management-plan.md (Phase 4)")
+		},
+	}
+}

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -1,20 +1,25 @@
 package cli
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
+
+	"github.com/confighubai/installer/internal/deps"
+	ipkg "github.com/confighubai/installer/internal/pkg"
+	"github.com/confighubai/installer/pkg/api"
 )
 
 func newDepsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deps",
-		Short: "(not yet implemented) Manage installer package dependencies",
+		Short: "Manage installer package dependencies",
 		Long: `Deps resolves the dependency DAG declared in installer.yaml against an OCI
 registry, writes <work-dir>/out/spec/lock.yaml, and optionally vendors
-locked dependencies for offline render.
-
-See docs/package-management-plan.md (Phase 4).`,
+locked dependencies for offline render.`,
 	}
 	cmd.AddCommand(newDepsUpdateCmd(), newDepsBuildCmd(), newDepsTreeCmd())
 	return cmd
@@ -23,17 +28,48 @@ See docs/package-management-plan.md (Phase 4).`,
 func newDepsUpdateCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "update <work-dir>",
-		Short: "(not yet implemented) Resolve the dependency DAG and write out/spec/lock.yaml",
+		Short: "Resolve the dependency DAG and write out/spec/lock.yaml",
 		Long: `Update walks the dependency DAG declared in
 <work-dir>/package/installer.yaml, resolves SemVer constraints against the
 OCI registry by fetching each dep's manifest + config blob (no layer pull),
 and writes <work-dir>/out/spec/lock.yaml pinning every dependency to a
-digest. Conflicts and replaces are honored.
+manifest digest. Conflicts are honored.
 
-See docs/package-management-plan.md (Phase 4).`,
+If <work-dir>/out/spec/selection.yaml exists, the resolver honors optional
+deps gated by whenComponent. If it does not, optional deps are skipped and
+listed in the output.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return fmt.Errorf("deps update not yet implemented; see docs/package-management-plan.md (Phase 4)")
+			workDir, err := filepath.Abs(args[0])
+			if err != nil {
+				return err
+			}
+			pkgDir := filepath.Join(workDir, "package")
+			loaded, err := ipkg.Load(pkgDir)
+			if err != nil {
+				return fmt.Errorf("load package: %w", err)
+			}
+			sel, err := loadSelectionOptional(filepath.Join(workDir, "out", "spec", "selection.yaml"))
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+			res, err := deps.Resolve(ctx, loaded.Package, deps.OCISource{}, deps.Options{Selection: sel})
+			if err != nil {
+				return err
+			}
+			if err := deps.WriteLock(workDir, loaded.Package, res.Lock); err != nil {
+				return err
+			}
+			fmt.Printf("Locked %d dependency(ies) to %s\n", len(res.Lock.Spec.Resolved), deps.LockPath(workDir))
+			for _, d := range res.Lock.Spec.Resolved {
+				fmt.Printf("  %s  %s  (%s)\n", d.Name, d.Ref, d.Digest)
+			}
+			for _, s := range res.SkippedOptional {
+				fmt.Printf("  skipped optional: %s\n", s)
+			}
+			return nil
 		},
 	}
 }
@@ -46,7 +82,8 @@ func newDepsBuildCmd() *cobra.Command {
 <work-dir>/out/vendor/<name>@<version>/ so that a subsequent installer
 render runs without network access.
 
-See docs/package-management-plan.md (Phase 4).`,
+Not yet wired in Phase 4 (resolver + lock only). Tracked under
+docs/package-management-plan.md (Phase 4 cross-cutting cache work).`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("deps build not yet implemented; see docs/package-management-plan.md (Phase 4)")
@@ -57,16 +94,71 @@ See docs/package-management-plan.md (Phase 4).`,
 func newDepsTreeCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "tree <work-dir>",
-		Short: "(not yet implemented) Print the resolved dependency DAG",
+		Short: "Print the resolved dependency DAG",
 		Long: `Tree prints the resolved dependency DAG from
-<work-dir>/out/spec/lock.yaml, showing parent → child relationships,
-versions, and which optional deps were followed based on the current
-selection.
-
-See docs/package-management-plan.md (Phase 4).`,
+<work-dir>/out/spec/lock.yaml, with each entry's pinned ref + manifest
+digest and the requester chain. Run deps update first.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return fmt.Errorf("deps tree not yet implemented; see docs/package-management-plan.md (Phase 4)")
+			workDir, err := filepath.Abs(args[0])
+			if err != nil {
+				return err
+			}
+			pkgDir := filepath.Join(workDir, "package")
+			loaded, err := ipkg.Load(pkgDir)
+			if err != nil {
+				return fmt.Errorf("load package: %w", err)
+			}
+			lock, err := deps.ReadLock(workDir)
+			if err != nil {
+				return err
+			}
+			if lock == nil {
+				return fmt.Errorf("no lock at %s — run `installer deps update %s` first", deps.LockPath(workDir), workDir)
+			}
+			if deps.IsStale(lock, loaded.Package) {
+				fmt.Fprintf(os.Stderr, "WARNING: lock is stale (installer.yaml's dependencies have changed) — re-run `installer deps update`\n\n")
+			}
+			fmt.Printf("%s@%s\n", lock.Spec.Package.Name, lock.Spec.Package.Version)
+			for _, d := range lock.Spec.Resolved {
+				fmt.Printf("  %s -> %s\n", d.Name, d.Ref)
+				fmt.Printf("    digest:       %s\n", d.Digest)
+				fmt.Printf("    requested by: %s\n", joinList(d.RequestedBy))
+				if d.Selection != nil && (d.Selection.Base != "" || len(d.Selection.Components) > 0) {
+					if d.Selection.Base != "" {
+						fmt.Printf("    base:         %s\n", d.Selection.Base)
+					}
+					if len(d.Selection.Components) > 0 {
+						fmt.Printf("    components:   %s\n", joinList(d.Selection.Components))
+					}
+				}
+			}
+			return nil
 		},
 	}
+}
+
+func loadSelectionOptional(path string) (*api.Selection, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return api.ParseSelection(data)
+}
+
+func joinList(ss []string) string {
+	if len(ss) == 0 {
+		return "(none)"
+	}
+	out := ""
+	for i, s := range ss {
+		if i > 0 {
+			out += ", "
+		}
+		out += s
+	}
+	return out
 }

--- a/internal/cli/doc.go
+++ b/internal/cli/doc.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -12,6 +13,15 @@ import (
 	ipkg "github.com/confighubai/installer/internal/pkg"
 	"github.com/confighubai/installer/pkg/api"
 )
+
+func sortedMapKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
 
 func newDocCmd() *cobra.Command {
 	var (
@@ -61,6 +71,12 @@ func printPackageDoc(p *api.Package) {
 	if p.Metadata.Version != "" {
 		fmt.Printf("Version: %s\n", p.Metadata.Version)
 	}
+	if p.Metadata.KubeVersion != "" {
+		fmt.Printf("Kubernetes: %s\n", p.Metadata.KubeVersion)
+	}
+	if p.Metadata.InstallerVersion != "" {
+		fmt.Printf("Installer:  %s\n", p.Metadata.InstallerVersion)
+	}
 	fmt.Println()
 
 	fmt.Println("Bases:")
@@ -92,6 +108,79 @@ func printPackageDoc(p *api.Package) {
 			if len(c.ValidForBases) > 0 {
 				fmt.Printf("      valid-for-bases: %s\n", strings.Join(c.ValidForBases, ", "))
 			}
+		}
+		fmt.Println()
+	}
+
+	if len(p.Spec.Dependencies) > 0 {
+		fmt.Println("Dependencies:")
+		for _, d := range p.Spec.Dependencies {
+			line := fmt.Sprintf("  - %s -> %s", d.Name, d.Package)
+			if d.Version != "" {
+				line += " " + d.Version
+			}
+			fmt.Println(line)
+			if d.Optional {
+				cond := "optional"
+				if d.WhenComponent != "" {
+					cond = "optional, follows when component " + d.WhenComponent
+				}
+				fmt.Printf("      %s\n", cond)
+			} else if d.WhenComponent != "" {
+				fmt.Printf("      follows when component %s is selected\n", d.WhenComponent)
+			}
+			if d.Selection != nil {
+				if d.Selection.Base != "" {
+					fmt.Printf("      base: %s\n", d.Selection.Base)
+				}
+				if len(d.Selection.Components) > 0 {
+					fmt.Printf("      components: %s\n", strings.Join(d.Selection.Components, ", "))
+				}
+			}
+			if len(d.Inputs) > 0 {
+				keys := sortedMapKeys(d.Inputs)
+				fmt.Printf("      inputs: %s\n", strings.Join(keys, ", "))
+			}
+			if len(d.Satisfies) > 0 {
+				parts := make([]string, 0, len(d.Satisfies))
+				for _, s := range d.Satisfies {
+					p := string(s.Kind)
+					if s.Name != "" {
+						p += "/" + s.Name
+					} else if s.Capability != "" {
+						p += " capability=" + s.Capability
+					}
+					parts = append(parts, p)
+				}
+				fmt.Printf("      satisfies: %s\n", strings.Join(parts, ", "))
+			}
+		}
+		fmt.Println()
+	}
+
+	if len(p.Spec.Conflicts) > 0 {
+		fmt.Println("Conflicts:")
+		for _, c := range p.Spec.Conflicts {
+			line := "  - " + c.Package
+			if c.Version != "" {
+				line += " " + c.Version
+			}
+			if c.Reason != "" {
+				line += "  (" + c.Reason + ")"
+			}
+			fmt.Println(line)
+		}
+		fmt.Println()
+	}
+
+	if len(p.Spec.Replaces) > 0 {
+		fmt.Println("Replaces:")
+		for _, r := range p.Spec.Replaces {
+			line := "  - " + r.Package
+			if r.Version != "" {
+				line += " " + r.Version
+			}
+			fmt.Println(line)
 		}
 		fmt.Println()
 	}

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	ipkg "github.com/confighubai/installer/internal/pkg"
+)
+
+func newInspectCmd() *cobra.Command {
+	var asJSON bool
+	cmd := &cobra.Command{
+		Use:   "inspect <ref>",
+		Short: "Print installer.yaml from an OCI artifact without pulling the layer",
+		Long: `Inspect fetches only the manifest + config blob for a native installer OCI
+artifact and prints the embedded installer.yaml plus bundle metadata
+(layer digest, file list, the installer version that produced the bundle).
+
+This is the cheap-read path used by the resolver: it avoids downloading the
+package layer when only metadata is needed.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			cb, err := ipkg.Inspect(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			if asJSON {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(cb)
+			}
+			fmt.Printf("Package: %s@%s\n", cb.Manifest.Metadata.Name, cb.Manifest.Metadata.Version)
+			if cb.Bundle.InstallerVersion != "" {
+				fmt.Printf("Built with installer %s\n", cb.Bundle.InstallerVersion)
+			}
+			fmt.Printf("Layer:    %s\n", cb.Bundle.LayerDigest)
+			fmt.Printf("Size:     %d bytes\n", cb.Bundle.LayerSize)
+			fmt.Printf("Files:    %d\n", len(cb.Bundle.Files))
+			fmt.Println()
+			printPackageDoc(cb.Manifest)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "machine-readable output")
+	return cmd
+}

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -25,16 +25,18 @@ package layer when only metadata is needed.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			cb, err := ipkg.Inspect(ctx, args[0])
+			res, err := ipkg.Inspect(ctx, args[0])
 			if err != nil {
 				return err
 			}
 			if asJSON {
 				enc := json.NewEncoder(os.Stdout)
 				enc.SetIndent("", "  ")
-				return enc.Encode(cb)
+				return enc.Encode(res)
 			}
-			fmt.Printf("Package: %s@%s\n", cb.Manifest.Metadata.Name, cb.Manifest.Metadata.Version)
+			cb := res.Config
+			fmt.Printf("Package:  %s@%s\n", cb.Manifest.Metadata.Name, cb.Manifest.Metadata.Version)
+			fmt.Printf("Manifest: %s\n", res.ManifestDigest)
 			if cb.Bundle.InstallerVersion != "" {
 				fmt.Printf("Built with installer %s\n", cb.Bundle.InstallerVersion)
 			}

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	ipkg "github.com/confighubai/installer/internal/pkg"
+)
+
+func newListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list <oci-repo>",
+		Short: "List tags of an OCI repo holding installer artifacts",
+		Long: `List queries the OCI /tags/list endpoint for the given repo and prints
+the tags.
+
+Example:
+  installer list oci://ghcr.io/confighubai/gateway-api`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			tags, err := ipkg.List(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			for _, t := range tags {
+				fmt.Println(t)
+			}
+			return nil
+		},
+	}
+	return cmd
+}

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	ipkg "github.com/confighubai/installer/internal/pkg"
+)
+
+func newLoginCmd() *cobra.Command {
+	var (
+		username      string
+		password      string
+		passwordStdin bool
+	)
+	cmd := &cobra.Command{
+		Use:   "login <registry>",
+		Short: "Store credentials for a registry",
+		Long: `Login stores a credential for the given registry in the docker-config-style
+credential store (typically ~/.docker/config.json), making it usable by
+installer push, pull, inspect, and list — plus any other tool that reads
+docker config (docker, podman, oras).
+
+If --username is omitted, it is read from stdin. If neither --password nor
+--password-stdin is set, the password is read interactively from /dev/tty
+without echo.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			registry := args[0]
+			if username == "" {
+				u, err := promptLine("Username: ")
+				if err != nil {
+					return err
+				}
+				username = strings.TrimSpace(u)
+			}
+			if passwordStdin {
+				if password != "" {
+					return fmt.Errorf("--password and --password-stdin are mutually exclusive")
+				}
+				b, err := io.ReadAll(os.Stdin)
+				if err != nil {
+					return err
+				}
+				password = strings.TrimRight(string(b), "\r\n")
+			} else if password == "" {
+				p, err := promptPassword("Password: ")
+				if err != nil {
+					return err
+				}
+				password = p
+			}
+			ctx := context.Background()
+			if err := ipkg.Login(ctx, registry, username, password); err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "Login succeeded for %s\n", registry)
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&username, "username", "u", "", "username")
+	cmd.Flags().StringVarP(&password, "password", "p", "", "password (avoid; prefer --password-stdin)")
+	cmd.Flags().BoolVar(&passwordStdin, "password-stdin", false, "read password from stdin")
+	return cmd
+}
+
+func promptLine(prompt string) (string, error) {
+	fmt.Fprint(os.Stderr, prompt)
+	r := bufio.NewReader(os.Stdin)
+	line, err := r.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+	return line, nil
+}
+
+func promptPassword(prompt string) (string, error) {
+	fmt.Fprint(os.Stderr, prompt)
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		// Non-interactive: read from stdin until newline.
+		line, err := promptLine("")
+		return strings.TrimRight(line, "\r\n"), err
+	}
+	b, err := term.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Fprintln(os.Stderr)
+	return string(b), err
+}

--- a/internal/cli/logout.go
+++ b/internal/cli/logout.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	ipkg "github.com/confighubai/installer/internal/pkg"
+)
+
+func newLogoutCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "logout <registry>",
+		Short: "Remove stored credentials for a registry",
+		Long: `Logout removes the stored credential for the given registry from the
+docker-config-style credential store.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			if err := ipkg.Logout(ctx, args[0]); err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "Removed credentials for %s\n", args[0])
+			return nil
+		},
+	}
+	return cmd
+}

--- a/internal/cli/package.go
+++ b/internal/cli/package.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/confighubai/installer/internal/bundle"
+	ipkg "github.com/confighubai/installer/internal/pkg"
+)
+
+func newPackageCmd() *cobra.Command {
+	var outFile string
+	cmd := &cobra.Command{
+		Use:   "package <dir>",
+		Short: "Bundle a package source tree into a deterministic .tgz",
+		Long: `Package bundles a package source tree (the directory containing installer.yaml,
+bases/, components/, validation/, and an optional collector) into a
+byte-deterministic .tgz suitable for installer push.
+
+Refuses to bundle: *.env.secret files, anything under out/, anything matched
+by .installerignore (gitignore syntax). The package is NOT rendered —
+distribution carries the source tree so wizard customization can run at
+install time.
+
+Determinism: the same source tree always produces a .tgz with the same
+sha256, regardless of host platform, file mtimes, or walk order. This is
+what makes signing and digest-pinning meaningful.
+
+See docs/package-management-plan.md (Phase 1).`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			src, err := filepath.Abs(args[0])
+			if err != nil {
+				return err
+			}
+			loaded, err := ipkg.Load(src)
+			if err != nil {
+				return fmt.Errorf("load %s: %w", src, err)
+			}
+			dst := outFile
+			if dst == "" {
+				name := loaded.Package.Metadata.Name
+				ver := loaded.Package.Metadata.Version
+				if name == "" {
+					return fmt.Errorf("installer.yaml is missing metadata.name; pass --out to override")
+				}
+				if ver == "" {
+					dst = name + ".tgz"
+				} else {
+					dst = name + "-" + ver + ".tgz"
+				}
+			}
+			res, err := bundle.Bundle(src, dst)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Bundled %s@%s\n", loaded.Package.Metadata.Name, loaded.Package.Metadata.Version)
+			fmt.Printf("  output: %s\n", dst)
+			fmt.Printf("  files:  %d\n", len(res.Files))
+			fmt.Printf("  size:   %d bytes\n", res.Size)
+			fmt.Printf("  digest: sha256:%s\n", res.Digest)
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&outFile, "out", "o", "", "output .tgz path (default: <name>-<version>.tgz in cwd)")
+	return cmd
+}

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	ipkg "github.com/confighubai/installer/internal/pkg"
+)
+
+func newPushCmd() *cobra.Command {
+	var sign bool
+	cmd := &cobra.Command{
+		Use:   "push <pkg.tgz|dir> <oci-ref>",
+		Short: "Push a packaged installer to an OCI registry",
+		Long: `Push uploads a packaged installer (either a .tgz produced by installer
+package, or a source directory which is packaged in-memory first) to an
+OCI registry as a native installer artifact (artifactType
+application/vnd.confighub.installer.package.v1+json).
+
+The package is NOT rendered — only bundled. This differs from Kustomizer's
+push, which renders before uploading.
+
+ref must include a tag: oci://host/repo:tag. Digest-only refs are not
+supported because registries cannot accept blob pushes to a digest.`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if sign {
+				return fmt.Errorf("--sign not yet implemented; see docs/package-management-plan.md (Phase 7)")
+			}
+			ctx := context.Background()
+			res, err := ipkg.Push(ctx, args[0], args[1])
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Pushed %s\n", res.Ref)
+			fmt.Printf("  manifest: %s\n", res.ManifestDigest)
+			fmt.Printf("  layer:    %s (%d bytes, %d files)\n", res.LayerDigest, res.LayerSize, len(res.Files))
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&sign, "sign", false, "sign the pushed artifact with cosign (Phase 7)")
+	return cmd
+}

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/confighubai/installer/internal/deps"
 	ipkg "github.com/confighubai/installer/internal/pkg"
 	"github.com/confighubai/installer/internal/render"
 	"github.com/confighubai/installer/pkg/api"
@@ -70,6 +71,26 @@ identical bytes. Re-render after editing selection.yaml or inputs.yaml.`,
 				return err
 			}
 
+			// Lock-state preflight: fail fast before any output is written
+			// if the package declares dependencies but the lock is missing
+			// or stale. Read the lock here; render reuses it after the
+			// parent renders.
+			var lock *api.Lock
+			if len(loaded.Package.Spec.Dependencies) > 0 {
+				lock, err = deps.ReadLock(workDir)
+				if err != nil {
+					return err
+				}
+				if lock == nil {
+					return fmt.Errorf("package declares dependencies but %s does not exist; run `installer deps update %s`",
+						deps.LockPath(workDir), workDir)
+				}
+				if deps.IsStale(lock, loaded.Package) {
+					return fmt.Errorf("lock at %s is stale (installer.yaml's dependencies have changed); run `installer deps update %s`",
+						deps.LockPath(workDir), workDir)
+				}
+			}
+
 			ctx := context.Background()
 			result, err := render.Render(ctx, render.Options{
 				Loaded:    loaded,
@@ -86,6 +107,26 @@ identical bytes. Re-render after editing selection.yaml or inputs.yaml.`,
 				fmt.Printf("Rendered %d secret(s) to %s/secrets (not uploaded)\n", len(result.Secrets), outDir)
 			}
 			fmt.Printf("Spec docs in %s\n", specDir)
+
+			// Multi-package render: lock was preflighted above; render each
+			// dependency into its own subtree under out/<dep-name>/.
+			if lock != nil {
+				depResults, err := render.RenderDependencies(ctx, render.DepsOptions{
+					Lock:         lock,
+					ParentInputs: inputs,
+					WorkDir:      workDir,
+				})
+				if err != nil {
+					return err
+				}
+				for _, dr := range depResults {
+					fmt.Printf("Rendered dep %s: %d manifest(s) to %s\n", dr.Name, len(dr.Manifests), filepath.Join(dr.OutDir, "manifests"))
+					if len(dr.Secrets) > 0 {
+						fmt.Printf("  secrets: %d (not uploaded)\n", len(dr.Secrets))
+					}
+				}
+			}
+
 			fmt.Printf("Next: installer upload %s --space <slug>\n", workDir)
 			return nil
 		},

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -29,13 +29,28 @@ ArgoCD, Flux, or direct Kubernetes apply.`,
 		SilenceUsage: true,
 	}
 	root.AddCommand(
+		// Inspect / discover
 		newDocCmd(),
 		newPullCmd(),
+		newInspectCmd(),
+		newListCmd(),
+		// Registry auth
+		newLoginCmd(),
+		newLogoutCmd(),
+		// Install lifecycle
 		newWizardCmd(),
+		newDepsCmd(),
 		newRenderCmd(),
 		newPlanCmd(),
 		newPreflightCmd(),
 		newUploadCmd(),
+		// Publish
+		newPackageCmd(),
+		newPushCmd(),
+		newTagCmd(),
+		// Trust
+		newSignCmd(),
+		newVerifyCmd(),
 	)
 	return root
 }

--- a/internal/cli/sign.go
+++ b/internal/cli/sign.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newSignCmd() *cobra.Command {
+	var key string
+	cmd := &cobra.Command{
+		Use:   "sign <ref>",
+		Short: "(not yet implemented) Sign an OCI artifact with cosign",
+		Long: `Sign invokes cosign to attach a signature to the given OCI artifact. Keyless
+mode (Sigstore Fulcio + Rekor) is used unless --key is provided.
+
+Requires the cosign binary on PATH.
+
+See docs/package-management-plan.md (Phase 7).`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("sign not yet implemented; see docs/package-management-plan.md (Phase 7)")
+		},
+	}
+	cmd.Flags().StringVar(&key, "key", "", "cosign key reference (default: keyless Sigstore flow)")
+	return cmd
+}

--- a/internal/cli/sign.go
+++ b/internal/cli/sign.go
@@ -1,27 +1,48 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
+
+	"github.com/confighubai/installer/internal/sign"
 )
 
 func newSignCmd() *cobra.Command {
-	var key string
+	var (
+		key       string
+		recursive bool
+		yes       bool
+	)
 	cmd := &cobra.Command{
 		Use:   "sign <ref>",
-		Short: "(not yet implemented) Sign an OCI artifact with cosign",
-		Long: `Sign invokes cosign to attach a signature to the given OCI artifact. Keyless
+		Short: "Sign an OCI artifact with cosign",
+		Long: `Sign attaches a cosign signature to the given OCI artifact. Keyless
 mode (Sigstore Fulcio + Rekor) is used unless --key is provided.
 
-Requires the cosign binary on PATH.
+Requires the cosign binary on PATH (override via INSTALLER_COSIGN_BIN).
 
-See docs/package-management-plan.md (Phase 7).`,
+Examples:
+  # Keyless (interactive OIDC flow):
+  installer sign oci://ghcr.io/me/pkg:0.1.0 --yes
+
+  # Keyed:
+  installer sign oci://ghcr.io/me/pkg:0.1.0 --key cosign.key`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return fmt.Errorf("sign not yet implemented; see docs/package-management-plan.md (Phase 7)")
+			ctx := context.Background()
+			if err := sign.Sign(ctx, args[0], sign.SignOptions{
+				Key: key, Recursive: recursive, Yes: yes,
+			}); err != nil {
+				return err
+			}
+			fmt.Printf("Signed %s\n", args[0])
+			return nil
 		},
 	}
 	cmd.Flags().StringVar(&key, "key", "", "cosign key reference (default: keyless Sigstore flow)")
+	cmd.Flags().BoolVar(&recursive, "recursive", false, "sign every layer in addition to the manifest")
+	cmd.Flags().BoolVar(&yes, "yes", false, "skip cosign's interactive confirmation prompt")
 	return cmd
 }

--- a/internal/cli/tag.go
+++ b/internal/cli/tag.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	ipkg "github.com/confighubai/installer/internal/pkg"
+)
+
+func newTagCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tag <src-ref> <dst-tag>",
+		Short: "Apply a new tag to an existing OCI artifact",
+		Long: `Tag adds a new tag (typically a channel like 'stable' or '0.3') pointing at
+the same manifest digest as src-ref. The original tag is preserved. Channel
+tags are convention-only — installer treats them as mutable aliases that
+authors maintain.
+
+Example:
+  installer tag oci://ghcr.io/confighubai/foo:0.3.2 stable`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			if err := ipkg.Tag(ctx, args[0], args[1]); err != nil {
+				return err
+			}
+			fmt.Printf("Tagged %s as %s\n", args[0], args[1])
+			return nil
+		},
+	}
+	return cmd
+}

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -14,44 +14,61 @@ import (
 	fapi "github.com/confighub/sdk/core/function/api"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
+
+	"github.com/confighubai/installer/internal/deps"
+	ipkg "github.com/confighubai/installer/internal/pkg"
+	"github.com/confighubai/installer/internal/upload"
+	"github.com/confighubai/installer/pkg/api"
 )
 
 func newUploadCmd() *cobra.Command {
 	var (
-		space       string
-		target      string
-		annotations []string
-		labels      []string
+		space        string
+		spacePattern string
+		target       string
+		annotations  []string
+		labels       []string
 	)
 	cmd := &cobra.Command{
 		Use:   "upload <work-dir>",
-		Short: "Upload rendered manifests to a ConfigHub space",
-		Long: `Upload sends <work-dir>/out/manifests/*.yaml to a ConfigHub space as one
-Unit per file. Files in <work-dir>/out/secrets/ are never uploaded — they
-hold rendered Secret resources flagged as sensitive by render.
+		Short: "Upload rendered manifests to ConfigHub Space(s)",
+		Long: `Upload sends rendered manifests to ConfigHub. The shape depends on whether
+the package declares dependencies:
 
---target, --annotation, and --label are forwarded to ` + "`cub unit create`" + ` so every
-created Unit can be bound to a destination, annotated, and labeled in a
-single command. Each --annotation and --label is repeatable and takes
-key=value.
+Single-package (no deps):
+  --space chooses the Space; one Unit per file in <work-dir>/out/manifests.
 
-After upload, the command analyzes the space with the get-resources,
-get-references, and get-workload-labels functions and creates NeedsProvides
-links between units when:
+Multi-package (parent declares dependencies):
+  --space-pattern is a Go template evaluated per package (vars:
+  .PackageName, .PackageVersion, .Variant — Variant is empty in v1).
+  Default: '{{.PackageName}}'. Each package — parent + each locked dep —
+  gets its own Space. The Units for the parent come from
+  <work-dir>/out/manifests; each dep's Units come from
+  <work-dir>/out/<dep>/manifests.
 
-  - a unit references another unit's resource by name (e.g., a Deployment
-    referencing a Namespace, ConfigMap, or ServiceAccount),
-  - a unit's pod label-selector matches another unit's pod-template labels
-    (e.g., a Service selecting the pods produced by a Deployment), or
-  - a unit contains a custom resource whose CustomResourceDefinition lives
-    in another unit.
+In both modes, every Space additionally receives one untargeted
+"installer-record" Unit holding installer.yaml + that package's spec docs
+(selection, inputs, function-chain, manifest-index, plus the lock for the
+parent). The record Unit makes a Space self-describing — it can be
+re-rendered from its own ConfigHub state.
 
-Units are never linked to themselves; duplicate edges are collapsed.`,
+Cross-Space NeedsProvides Links are created from the parent's record Unit
+to each dep's record Unit so downstream tooling can see the dependency
+relationship.
+
+Files in <work-dir>/out/secrets/ (and each <dep>/secrets/) are never
+uploaded — they hold rendered Secret resources flagged as sensitive by
+render.
+
+--target, --annotation, and --label are forwarded to ` + "`cub unit create`" + ` on
+each rendered manifest Unit. They do NOT apply to the installer-record
+Unit (which must remain untargeted).
+
+After per-Space upload, the existing get-resources / get-references /
+get-workload-labels link-inference runs once per Space to materialize
+intra-Space NeedsProvides links.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if space == "" {
-				return fmt.Errorf("--space is required")
-			}
 			if _, err := exec.LookPath("cub"); err != nil {
 				return fmt.Errorf("cub CLI not found on PATH: %w", err)
 			}
@@ -65,44 +82,188 @@ Units are never linked to themselves; duplicate edges are collapsed.`,
 			if err != nil {
 				return err
 			}
-			manifestsDir := filepath.Join(workDir, "out", "manifests")
-			entries, err := os.ReadDir(manifestsDir)
+
+			loaded, err := ipkg.Load(filepath.Join(workDir, "package"))
 			if err != nil {
-				return fmt.Errorf("read %s: %w", manifestsDir, err)
+				return fmt.Errorf("load package: %w", err)
 			}
-			for _, e := range entries {
-				if e.IsDir() {
-					continue
+
+			// Reconcile --space vs --space-pattern.
+			//
+			//   no deps:   --space S        → equivalent to pattern "S".
+			//              --space-pattern  → also fine.
+			//              both             → error.
+			//              neither          → default pattern "{{.PackageName}}".
+			//   with deps: --space          → error (one slug can't host N packages).
+			//              --space-pattern  → fine.
+			//              neither          → default pattern "{{.PackageName}}".
+			hasDeps := len(loaded.Package.Spec.Dependencies) > 0
+			pattern := spacePattern
+			if space != "" && spacePattern != "" {
+				return fmt.Errorf("--space and --space-pattern are mutually exclusive")
+			}
+			if space != "" {
+				if hasDeps {
+					return fmt.Errorf("--space cannot be used when the package declares dependencies; use --space-pattern")
 				}
-				slug := trimExt(e.Name())
-				path := filepath.Join(manifestsDir, e.Name())
-				cubArgs := []string{"unit", "create", "--space", space}
-				cubArgs = append(cubArgs, "--merge-external-source", e.Name())
-				if target != "" {
-					cubArgs = append(cubArgs, "--target", target)
+				pattern = space
+			}
+			if pattern == "" {
+				pattern = "{{.PackageName}}"
+			}
+
+			var lock *api.Lock
+			if hasDeps {
+				lock, err = deps.ReadLock(workDir)
+				if err != nil {
+					return err
 				}
-				for _, a := range annotations {
-					cubArgs = append(cubArgs, "--annotation", a)
+				if lock == nil {
+					return fmt.Errorf("package declares dependencies but %s does not exist; run `installer deps update %s` and `installer render %s` first",
+						deps.LockPath(workDir), workDir, workDir)
 				}
-				for _, l := range labels {
-					cubArgs = append(cubArgs, "--label", l)
-				}
-				cubArgs = append(cubArgs, slug, path)
-				ccmd := exec.Command("cub", cubArgs...)
-				ccmd.Stdout = os.Stdout
-				ccmd.Stderr = os.Stderr
-				if err := ccmd.Run(); err != nil {
-					return fmt.Errorf("cub unit create %s: %w", slug, err)
+				if deps.IsStale(lock, loaded.Package) {
+					return fmt.Errorf("lock at %s is stale; run `installer deps update %s` and `installer render %s` again",
+						deps.LockPath(workDir), workDir, workDir)
 				}
 			}
-			return createInferredLinks(space)
+
+			packages, err := upload.Discover(upload.DiscoverInput{
+				WorkDir:       workDir,
+				SpacePattern:  pattern,
+				ParentPackage: loaded.Package,
+				Lock:          lock,
+			})
+			if err != nil {
+				return err
+			}
+
+			for _, pkg := range packages {
+				if err := uploadOnePackage(pkg, target, annotations, labels); err != nil {
+					return err
+				}
+			}
+
+			for _, l := range upload.PlanCrossSpaceLinks(packages) {
+				if err := createCrossSpaceLink(l); err != nil {
+					return err
+				}
+			}
+			return nil
 		},
 	}
-	cmd.Flags().StringVar(&space, "space", "", "destination ConfigHub space slug")
-	cmd.Flags().StringVar(&target, "target", "", "target slug; forwarded to cub unit create --target on every Unit")
-	cmd.Flags().StringSliceVar(&annotations, "annotation", nil, "annotation key=value to set on every Unit (repeatable)")
-	cmd.Flags().StringSliceVar(&labels, "label", nil, "label key=value to set on every Unit (repeatable)")
+	cmd.Flags().StringVar(&space, "space", "", "destination ConfigHub Space slug (single-package mode)")
+	cmd.Flags().StringVar(&spacePattern, "space-pattern", "", "Go template for the Space slug per package (vars: .PackageName, .PackageVersion, .Variant). Default: '{{.PackageName}}'.")
+	cmd.Flags().StringVar(&target, "target", "", "target slug; forwarded to cub unit create --target on every rendered Unit (not the installer-record Unit)")
+	cmd.Flags().StringSliceVar(&annotations, "annotation", nil, "annotation key=value to set on every rendered Unit (repeatable)")
+	cmd.Flags().StringSliceVar(&labels, "label", nil, "label key=value to set on every rendered Unit (repeatable)")
 	return cmd
+}
+
+// uploadOnePackage creates pkg.SpaceSlug if missing, uploads each rendered
+// manifest as a Unit (with --target/--annotation/--label applied), creates
+// the untargeted installer-record Unit, and runs the intra-Space link
+// inference.
+func uploadOnePackage(pkg upload.Package, target string, annotations, labels []string) error {
+	fmt.Printf("== %s@%s → Space %s ==\n", pkg.Name, pkg.Version, pkg.SpaceSlug)
+
+	if err := ensureSpace(pkg.SpaceSlug); err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(pkg.ManifestsDir)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", pkg.ManifestsDir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		slug := trimExt(e.Name())
+		path := filepath.Join(pkg.ManifestsDir, e.Name())
+		cubArgs := []string{"unit", "create", "--space", pkg.SpaceSlug, "--merge-external-source", e.Name()}
+		if target != "" {
+			cubArgs = append(cubArgs, "--target", target)
+		}
+		for _, a := range annotations {
+			cubArgs = append(cubArgs, "--annotation", a)
+		}
+		for _, l := range labels {
+			cubArgs = append(cubArgs, "--label", l)
+		}
+		cubArgs = append(cubArgs, slug, path)
+		ccmd := exec.Command("cub", cubArgs...)
+		ccmd.Stdout = os.Stdout
+		ccmd.Stderr = os.Stderr
+		if err := ccmd.Run(); err != nil {
+			return fmt.Errorf("cub unit create %s in %s: %w", slug, pkg.SpaceSlug, err)
+		}
+	}
+
+	if err := createInstallerRecordUnit(pkg); err != nil {
+		return err
+	}
+	return createInferredLinks(pkg.SpaceSlug)
+}
+
+// ensureSpace creates the Space if it does not exist. Idempotent via
+// --allow-exists.
+func ensureSpace(slug string) error {
+	ccmd := exec.Command("cub", "space", "create", "--allow-exists", "--quiet", slug)
+	ccmd.Stderr = os.Stderr
+	if err := ccmd.Run(); err != nil {
+		return fmt.Errorf("cub space create %s: %w", slug, err)
+	}
+	return nil
+}
+
+// createInstallerRecordUnit builds the multi-doc YAML body and creates the
+// untargeted installer-record Unit. The body file is staged in a temp
+// location and passed to `cub unit create`.
+func createInstallerRecordUnit(pkg upload.Package) error {
+	body, err := upload.BuildInstallerRecord(pkg)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp("", "installer-record-*.yaml")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.Write(body); err != nil {
+		tmp.Close()
+		return err
+	}
+	tmp.Close()
+
+	ccmd := exec.Command("cub", "unit", "create",
+		"--space", pkg.SpaceSlug,
+		"--annotation", "installer.confighub.com/role=installer-record",
+		"--annotation", "installer.confighub.com/package="+pkg.Name,
+		upload.InstallerRecordSlug, tmp.Name(),
+	)
+	ccmd.Stdout = os.Stdout
+	ccmd.Stderr = os.Stderr
+	if err := ccmd.Run(); err != nil {
+		return fmt.Errorf("cub unit create installer-record in %s: %w", pkg.SpaceSlug, err)
+	}
+	return nil
+}
+
+// createCrossSpaceLink wires the parent's record Unit to a dep's record
+// Unit. The 4th positional arg to `cub link create` is the target Space.
+func createCrossSpaceLink(l upload.CrossSpaceLink) error {
+	ccmd := exec.Command("cub", "link", "create",
+		"--space", l.FromSpace, "--quiet",
+		l.Slug, l.FromUnit, l.ToUnit, l.ToSpace,
+	)
+	ccmd.Stderr = os.Stderr
+	if err := ccmd.Run(); err != nil {
+		return fmt.Errorf("cub link create %s (%s/%s -> %s/%s): %w",
+			l.Slug, l.FromSpace, l.FromUnit, l.ToSpace, l.ToUnit, err)
+	}
+	fmt.Printf("Linked %s/%s -> %s/%s (%s)\n", l.FromSpace, l.FromUnit, l.ToSpace, l.ToUnit, l.Reason)
+	return nil
 }
 
 func validateKeyValueFlags(flag string, vals []string) error {

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -77,6 +77,7 @@ Units are never linked to themselves; duplicate edges are collapsed.`,
 				slug := trimExt(e.Name())
 				path := filepath.Join(manifestsDir, e.Name())
 				cubArgs := []string{"unit", "create", "--space", space}
+				cubArgs = append(cubArgs, "--merge-external-source", e.Name())
 				if target != "" {
 					cubArgs = append(cubArgs, "--target", target)
 				}

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -1,27 +1,114 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
+
+	"github.com/confighubai/installer/internal/sign"
+	"github.com/confighubai/installer/pkg/api"
 )
 
 func newVerifyCmd() *cobra.Command {
-	var policy string
+	var (
+		key      string
+		identity string
+		issuer   string
+		policy   bool
+	)
 	cmd := &cobra.Command{
 		Use:   "verify <ref>",
-		Short: "(not yet implemented) Verify the cosign signature on an OCI artifact",
-		Long: `Verify checks the cosign signature attached to the given OCI artifact
-against the trust policy at --policy (default: ~/.config/installer/policy.yaml).
+		Short: "Verify the cosign signature on an OCI artifact",
+		Long: `Verify checks the cosign signature attached to the given OCI artifact.
 
-Requires the cosign binary on PATH.
+Verification mode is chosen by flags:
 
-See docs/package-management-plan.md (Phase 7).`,
+  --policy           run every matching entry in the trust policy (default
+                     file: ~/.config/installer/policy.yaml, override via
+                     INSTALLER_SIGNING_POLICY). Succeeds on first match.
+  --key <ref>        keyed verification against this cosign public-key ref.
+  --identity <id>    keyless verification — combine with --issuer.
+  --issuer <url>     keyless OIDC issuer URL.
+
+Exactly one mode must be specified. Requires the cosign binary on PATH.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return fmt.Errorf("verify not yet implemented; see docs/package-management-plan.md (Phase 7)")
+			ctx := context.Background()
+			ref := args[0]
+			modes := 0
+			if policy {
+				modes++
+			}
+			if key != "" {
+				modes++
+			}
+			if identity != "" || issuer != "" {
+				modes++
+			}
+			if modes == 0 {
+				return fmt.Errorf("one of --policy, --key, or --identity+--issuer is required")
+			}
+			if modes > 1 {
+				return fmt.Errorf("--policy, --key, and --identity/--issuer are mutually exclusive")
+			}
+			switch {
+			case policy:
+				p, err := sign.LoadPolicy()
+				if err != nil {
+					return err
+				}
+				if p == nil {
+					return fmt.Errorf("no signing policy file found; pass --key or --identity/--issuer")
+				}
+				// Force enforcement for the duration of this verify call,
+				// even if the file says enforce:false.
+				p.Spec.Enforce = true
+				// Re-use EnforceVerification's matching logic by writing
+				// the loaded policy back via env… simpler: just iterate
+				// the entries here and call Verify per match.
+				return verifyAgainstPolicy(ctx, ref, p)
+			case key != "":
+				return sign.Verify(ctx, ref, sign.VerifyOptions{
+					TrustedKey: &api.TrustedKey{PublicKey: key},
+				})
+			default:
+				if identity == "" || issuer == "" {
+					return fmt.Errorf("--identity and --issuer must both be set for keyless verification")
+				}
+				return sign.Verify(ctx, ref, sign.VerifyOptions{
+					TrustedKeyless: &api.TrustedKeyless{Identity: identity, Issuer: issuer},
+				})
+			}
 		},
 	}
-	cmd.Flags().StringVar(&policy, "policy", "", "trust policy file (default: ~/.config/installer/policy.yaml)")
+	cmd.Flags().BoolVar(&policy, "policy", false, "verify against the trust policy file (default: ~/.config/installer/policy.yaml)")
+	cmd.Flags().StringVar(&key, "key", "", "cosign public-key reference for keyed verification")
+	cmd.Flags().StringVar(&identity, "identity", "", "Sigstore certificate identity for keyless verification")
+	cmd.Flags().StringVar(&issuer, "issuer", "", "Sigstore OIDC issuer URL for keyless verification")
 	return cmd
+}
+
+func verifyAgainstPolicy(ctx context.Context, ref string, p *api.SigningPolicy) error {
+	if len(p.Spec.TrustedKeys) == 0 && len(p.Spec.TrustedKeyless) == 0 {
+		return fmt.Errorf("policy has no trust entries")
+	}
+	var attempts []string
+	for _, k := range p.Spec.TrustedKeys {
+		if err := sign.Verify(ctx, ref, sign.VerifyOptions{TrustedKey: &k}); err == nil {
+			fmt.Printf("Verified %s via trustedKey %s\n", ref, k.PublicKey)
+			return nil
+		} else {
+			attempts = append(attempts, fmt.Sprintf("key %s: %v", k.PublicKey, err))
+		}
+	}
+	for _, k := range p.Spec.TrustedKeyless {
+		if err := sign.Verify(ctx, ref, sign.VerifyOptions{TrustedKeyless: &k}); err == nil {
+			fmt.Printf("Verified %s via trustedKeyless %s@%s\n", ref, k.Identity, k.Issuer)
+			return nil
+		} else {
+			attempts = append(attempts, fmt.Sprintf("identity %s: %v", k.Identity, err))
+		}
+	}
+	return fmt.Errorf("no trust entry verified %s: %v", ref, attempts)
 }

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newVerifyCmd() *cobra.Command {
+	var policy string
+	cmd := &cobra.Command{
+		Use:   "verify <ref>",
+		Short: "(not yet implemented) Verify the cosign signature on an OCI artifact",
+		Long: `Verify checks the cosign signature attached to the given OCI artifact
+against the trust policy at --policy (default: ~/.config/installer/policy.yaml).
+
+Requires the cosign binary on PATH.
+
+See docs/package-management-plan.md (Phase 7).`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("verify not yet implemented; see docs/package-management-plan.md (Phase 7)")
+		},
+	}
+	cmd.Flags().StringVar(&policy, "policy", "", "trust policy file (default: ~/.config/installer/policy.yaml)")
+	return cmd
+}

--- a/internal/deps/lock.go
+++ b/internal/deps/lock.go
@@ -1,0 +1,92 @@
+package deps
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/confighubai/installer/pkg/api"
+)
+
+// Annotation key under which the resolver records a hash of the root
+// package's spec.dependencies list. The renderer compares the lock's hash
+// to a fresh recomputation on load and refuses to render if they differ
+// (stale-lock detection).
+const AnnotationRootDepsHash = "installer.confighub.com/root-dependencies-hash"
+
+// LockPath returns the canonical path where deps update writes the lock.
+func LockPath(workDir string) string {
+	return filepath.Join(workDir, "out", "spec", "lock.yaml")
+}
+
+// WriteLock stamps the root-deps hash onto lock and writes it under workDir.
+func WriteLock(workDir string, pkg *api.Package, lock *api.Lock) error {
+	if lock.Metadata.Annotations == nil {
+		lock.Metadata.Annotations = map[string]string{}
+	}
+	lock.Metadata.Annotations[AnnotationRootDepsHash] = RootDepsHash(pkg)
+
+	data, err := api.MarshalYAML(lock)
+	if err != nil {
+		return err
+	}
+	path := LockPath(workDir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+// ReadLock returns the lock at workDir/out/spec/lock.yaml, or (nil, nil)
+// if absent.
+func ReadLock(workDir string) (*api.Lock, error) {
+	data, err := os.ReadFile(LockPath(workDir))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return api.ParseLock(data)
+}
+
+// IsStale reports whether lock is missing or out-of-date relative to pkg's
+// declared dependencies. A nil lock is stale by definition.
+func IsStale(lock *api.Lock, pkg *api.Package) bool {
+	if lock == nil {
+		return true
+	}
+	have := lock.Metadata.Annotations[AnnotationRootDepsHash]
+	return have != RootDepsHash(pkg)
+}
+
+// RootDepsHash computes a canonical hash of pkg's spec.dependencies. Two
+// packages with the same set of (Name, Package, Version, WhenComponent,
+// Optional) fields — in any order — produce the same hash.
+func RootDepsHash(pkg *api.Package) string {
+	type entry struct {
+		Name, Package, Version, WhenComponent string
+		Optional                              bool
+	}
+	deps := make([]entry, 0, len(pkg.Spec.Dependencies))
+	for _, d := range pkg.Spec.Dependencies {
+		deps = append(deps, entry{
+			Name:          d.Name,
+			Package:       d.Package,
+			Version:       d.Version,
+			WhenComponent: d.WhenComponent,
+			Optional:      d.Optional,
+		})
+	}
+	sort.Slice(deps, func(i, j int) bool { return deps[i].Name < deps[j].Name })
+	var b strings.Builder
+	for _, d := range deps {
+		fmt.Fprintf(&b, "%s|%s|%s|%s|%v\n", d.Name, d.Package, d.Version, d.WhenComponent, d.Optional)
+	}
+	sum := sha256.Sum256([]byte(b.String()))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/deps/resolver.go
+++ b/internal/deps/resolver.go
@@ -188,6 +188,15 @@ func (r *resolver) visit(ctx context.Context, parent *api.Package, parentName st
 		return fmt.Errorf("%s/%s: inspect %s: %w", parentName, dep.Name, ref, err)
 	}
 
+	// Collectors are not supported on dependencies yet: they only run via
+	// the wizard, which is not invoked per-dep. Reject at resolve time so
+	// the user discovers the limit immediately rather than at render. See
+	// docs/package-management-plan.md (Phase 5 limits).
+	if res.Config != nil && res.Config.Manifest != nil && res.Config.Manifest.Spec.Collector != nil {
+		return fmt.Errorf("%s/%s: package %s declares spec.collector; collectors are not yet supported on dependencies — pick a version without one or open an issue",
+			parentName, dep.Name, ref)
+	}
+
 	entry := &resolvedEntry{
 		repo:        repo,
 		name:        dep.Name,

--- a/internal/deps/resolver.go
+++ b/internal/deps/resolver.go
@@ -1,0 +1,353 @@
+package deps
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+
+	"github.com/confighubai/installer/pkg/api"
+)
+
+// Options configure a Resolve call.
+type Options struct {
+	// Selection is the parent's wizard selection. When non-nil, the
+	// resolver uses Selection.Spec.Components to gate optional deps
+	// (whenComponent). When nil, optional deps are NOT followed and are
+	// listed in Result.SkippedOptional so the caller can surface them.
+	Selection *api.Selection
+}
+
+// Result is what Resolve returns.
+type Result struct {
+	// Lock is the pinned dependency tree, ready to write to lock.yaml.
+	Lock *api.Lock
+	// SkippedOptional records optional deps the resolver did not follow,
+	// either because no Selection was supplied or because the gating
+	// component was not selected. Format: "<parent>/<dep-name>".
+	SkippedOptional []string
+}
+
+// Resolve walks pkg's dependency DAG, picks versions, and returns a Lock.
+//
+// Resolution rules in Phase 4:
+//   - One version per package repo. If two parents pick incompatible
+//     constraints for the same repo, resolution fails with a chain.
+//   - Optional deps are followed iff Options.Selection contains
+//     WhenComponent (or WhenComponent is empty and a Selection is provided).
+//   - Non-optional deps are always followed.
+//   - Cycles are an error.
+//   - Root-level Conflicts are enforced anywhere in the resolved DAG.
+//   - Replaces are parsed but not yet acted on (TODO).
+func Resolve(ctx context.Context, pkg *api.Package, src Source, opts Options) (*Result, error) {
+	r := &resolver{
+		src:             src,
+		selected:        selectedComponents(opts.Selection),
+		hasSelection:    opts.Selection != nil,
+		rootConflicts:   pkg.Spec.Conflicts,
+		resolved:        map[string]*resolvedEntry{},
+		path:            []string{"root"},
+		skippedOptional: nil,
+	}
+	if err := r.walk(ctx, pkg, "root"); err != nil {
+		return nil, err
+	}
+
+	lock := &api.Lock{
+		APIVersion: api.APIVersion,
+		Kind:       api.KindLock,
+		Metadata:   api.Metadata{Name: pkg.Metadata.Name, Version: pkg.Metadata.Version},
+		Spec: api.LockSpec{
+			Package: api.LockedPackage{
+				Name:    pkg.Metadata.Name,
+				Version: pkg.Metadata.Version,
+			},
+			Resolved: r.flatten(),
+		},
+	}
+	return &Result{Lock: lock, SkippedOptional: r.skippedOptional}, nil
+}
+
+// resolvedEntry is the resolver's in-flight state per chosen package.
+type resolvedEntry struct {
+	// repo is the OCI ref without tag, e.g. "ghcr.io/o/r".
+	repo string
+	// name is the local handle the parent used (the first parent's).
+	name string
+	// version is the chosen SemVer.
+	version *semver.Version
+	// tag is the OCI tag corresponding to version.
+	tag string
+	// digest is the manifest digest sha256:...
+	digest string
+	// pkg is the parsed Package for recursion + sanity checks.
+	pkg *api.Package
+	// constraints is every constraint imposed so far, with the requester
+	// chain that imposed it (for error reporting).
+	constraints []constraintEntry
+	// requestedBy lists the names of parents that requested this dep.
+	requestedBy []string
+	// selection and inputs are the merged pre-answers across requesters.
+	selection *api.DependencySelection
+	inputs    map[string]any
+	// order is the position in flatten output (topological).
+	order int
+}
+
+type constraintEntry struct {
+	by   []string // requester chain, root → leaf
+	expr string   // the version expression
+}
+
+type resolver struct {
+	src             Source
+	selected        map[string]struct{}
+	hasSelection    bool
+	rootConflicts   []api.ConflictRef
+	resolved        map[string]*resolvedEntry // key: stripped repo ref
+	path            []string                  // current DFS path of dep names
+	skippedOptional []string
+	orderCounter    int
+}
+
+// walk visits parent's Dependencies, resolving and recursing as needed.
+func (r *resolver) walk(ctx context.Context, parent *api.Package, parentName string) error {
+	for _, dep := range parent.Spec.Dependencies {
+		if err := r.visit(ctx, parent, parentName, dep); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *resolver) visit(ctx context.Context, parent *api.Package, parentName string, dep api.Dependency) error {
+	// Optional gating.
+	if dep.Optional {
+		if !r.hasSelection {
+			r.skippedOptional = append(r.skippedOptional, parentName+"/"+dep.Name+" (no selection yet)")
+			return nil
+		}
+		if dep.WhenComponent != "" {
+			if _, ok := r.selected[dep.WhenComponent]; !ok {
+				r.skippedOptional = append(r.skippedOptional, parentName+"/"+dep.Name+" (component "+dep.WhenComponent+" not selected)")
+				return nil
+			}
+		}
+	}
+
+	// Conflict check against root-level conflicts.
+	if err := r.checkRootConflict(dep, parentName); err != nil {
+		return err
+	}
+
+	repo := stripOCIPrefix(dep.Package)
+	constraint, err := parseConstraint(dep.Version)
+	if err != nil {
+		return fmt.Errorf("%s/%s: %w", parentName, dep.Name, err)
+	}
+
+	if existing, ok := r.resolved[repo]; ok {
+		// Same repo seen before — verify the existing pick satisfies the new
+		// constraint, then merge requester metadata.
+		if !constraint.Check(existing.version) {
+			return r.versionConflictError(existing, parentName, dep)
+		}
+		existing.constraints = append(existing.constraints, constraintEntry{
+			by:   append(slices.Clone(r.path), dep.Name),
+			expr: dep.Version,
+		})
+		existing.requestedBy = appendUnique(existing.requestedBy, parentName)
+		mergeSelection(existing, dep.Selection)
+		mergeInputs(existing, dep.Inputs)
+		return nil
+	}
+
+	// Cycle check: if dep.Name is already on the DFS path, the resolver is
+	// looping. (Repos cycle == same OCI ref; for nice errors we check by
+	// dep name on the path stack too.)
+	if slices.Contains(r.path, dep.Name) {
+		return fmt.Errorf("dependency cycle: %s -> %s", strings.Join(r.path, " -> "), dep.Name)
+	}
+
+	// Pick a version + fetch the manifest.
+	tags, err := r.src.ListVersions(ctx, dep.Package)
+	if err != nil {
+		return fmt.Errorf("%s/%s: list versions: %w", parentName, dep.Name, err)
+	}
+	tag, version, err := pickBest(tags, constraint)
+	if err != nil {
+		return fmt.Errorf("%s/%s: %w for %s (available: %s)",
+			parentName, dep.Name, err, dep.Version, strings.Join(tags, ", "))
+	}
+	ref := joinRef(repo, tag)
+	res, err := r.src.Inspect(ctx, ref)
+	if err != nil {
+		return fmt.Errorf("%s/%s: inspect %s: %w", parentName, dep.Name, ref, err)
+	}
+
+	entry := &resolvedEntry{
+		repo:        repo,
+		name:        dep.Name,
+		version:     version,
+		tag:         tag,
+		digest:      res.ManifestDigest,
+		pkg:         res.Config.Manifest,
+		constraints: []constraintEntry{{by: append(slices.Clone(r.path), dep.Name), expr: dep.Version}},
+		requestedBy: []string{parentName},
+		selection:   cloneDependencySelection(dep.Selection),
+		inputs:      cloneMap(dep.Inputs),
+		order:       r.nextOrder(),
+	}
+	r.resolved[repo] = entry
+
+	// Recurse.
+	r.path = append(r.path, dep.Name)
+	defer func() { r.path = r.path[:len(r.path)-1] }()
+	return r.walk(ctx, entry.pkg, dep.Name)
+}
+
+func (r *resolver) nextOrder() int {
+	r.orderCounter++
+	return r.orderCounter
+}
+
+// checkRootConflict fails if dep names a package listed in the root's
+// Conflicts. Phase 4 only checks root-level conflicts; transitive ones can
+// come later.
+func (r *resolver) checkRootConflict(dep api.Dependency, parentName string) error {
+	if len(r.rootConflicts) == 0 {
+		return nil
+	}
+	depRepo := stripOCIPrefix(dep.Package)
+	for _, c := range r.rootConflicts {
+		if stripOCIPrefix(c.Package) != depRepo {
+			continue
+		}
+		// Phase 4: treat version-less or "*" as match-all; otherwise we
+		// would need the resolved version to fully evaluate. Since the
+		// conflict points at a *repo* the user wants excluded, repo match
+		// is enough — the user can refine with a range later.
+		reason := c.Reason
+		if reason == "" {
+			reason = "explicit conflict"
+		}
+		return fmt.Errorf("%s/%s conflicts with root: %s (%s)", parentName, dep.Name, dep.Package, reason)
+	}
+	return nil
+}
+
+func (r *resolver) versionConflictError(existing *resolvedEntry, parent string, dep api.Dependency) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "incompatible constraints on %s:\n", existing.repo)
+	for _, c := range existing.constraints {
+		fmt.Fprintf(&b, "  %s wants %s (via %s)\n", strings.Join(c.by, " -> "), niceConstraint(c.expr), c.by[len(c.by)-1])
+	}
+	fmt.Fprintf(&b, "  %s/%s wants %s, but %s was already picked", parent, dep.Name, niceConstraint(dep.Version), existing.version)
+	return errors.New(b.String())
+}
+
+func niceConstraint(expr string) string {
+	if expr == "" {
+		return "*"
+	}
+	return expr
+}
+
+func (r *resolver) flatten() []api.LockedDependency {
+	if len(r.resolved) == 0 {
+		return nil
+	}
+	out := make([]*resolvedEntry, 0, len(r.resolved))
+	for _, e := range r.resolved {
+		out = append(out, e)
+	}
+	slices.SortFunc(out, func(a, b *resolvedEntry) int { return a.order - b.order })
+	locked := make([]api.LockedDependency, 0, len(out))
+	for _, e := range out {
+		locked = append(locked, api.LockedDependency{
+			Name:        e.name,
+			Ref:         joinRef(e.repo, e.tag),
+			Digest:      e.digest,
+			Version:     e.version.String(),
+			RequestedBy: e.requestedBy,
+			Selection:   e.selection,
+			Inputs:      e.inputs,
+		})
+	}
+	return locked
+}
+
+func selectedComponents(sel *api.Selection) map[string]struct{} {
+	if sel == nil {
+		return nil
+	}
+	out := make(map[string]struct{}, len(sel.Spec.Components))
+	for _, c := range sel.Spec.Components {
+		out[c] = struct{}{}
+	}
+	return out
+}
+
+func appendUnique(slice []string, v string) []string {
+	for _, s := range slice {
+		if s == v {
+			return slice
+		}
+	}
+	return append(slice, v)
+}
+
+func mergeSelection(e *resolvedEntry, sel *api.DependencySelection) {
+	if sel == nil {
+		return
+	}
+	if e.selection == nil {
+		e.selection = cloneDependencySelection(sel)
+		return
+	}
+	if sel.Base != "" && e.selection.Base == "" {
+		e.selection.Base = sel.Base
+	}
+	for _, c := range sel.Components {
+		if !slices.Contains(e.selection.Components, c) {
+			e.selection.Components = append(e.selection.Components, c)
+		}
+	}
+}
+
+func mergeInputs(e *resolvedEntry, inputs map[string]any) {
+	if len(inputs) == 0 {
+		return
+	}
+	if e.inputs == nil {
+		e.inputs = make(map[string]any, len(inputs))
+	}
+	for k, v := range inputs {
+		if _, exists := e.inputs[k]; !exists {
+			e.inputs[k] = v
+		}
+	}
+}
+
+func cloneDependencySelection(sel *api.DependencySelection) *api.DependencySelection {
+	if sel == nil {
+		return nil
+	}
+	out := *sel
+	out.Components = slices.Clone(sel.Components)
+	return &out
+}
+
+func cloneMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/deps/resolver.go
+++ b/internal/deps/resolver.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 
+	"github.com/confighubai/installer/internal/sign"
 	"github.com/confighubai/installer/pkg/api"
 )
 
@@ -186,6 +187,14 @@ func (r *resolver) visit(ctx context.Context, parent *api.Package, parentName st
 	res, err := r.src.Inspect(ctx, ref)
 	if err != nil {
 		return fmt.Errorf("%s/%s: inspect %s: %w", parentName, dep.Name, ref, err)
+	}
+
+	// Policy gate: if a signing policy is configured to enforce, verify
+	// the resolved manifest digest before pinning it in the lock. We
+	// build a digest-pinned ref so retagging upstream cannot bypass.
+	pinned := pinDigestRef(ref, res.ManifestDigest)
+	if err := sign.EnforceVerification(ctx, pinned); err != nil {
+		return fmt.Errorf("%s/%s: verify %s: %w", parentName, dep.Name, pinned, err)
 	}
 
 	// Collectors are not supported on dependencies yet: they only run via

--- a/internal/deps/resolver_test.go
+++ b/internal/deps/resolver_test.go
@@ -1,0 +1,295 @@
+package deps
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	ipkg "github.com/confighubai/installer/internal/pkg"
+	"github.com/confighubai/installer/pkg/api"
+)
+
+// mockSource implements Source by returning canned manifests + tag lists,
+// keyed by the OCI repo (without scheme or tag).
+type mockSource struct {
+	// versions[repo] is the published tag list (must include the tag that
+	// each entry in manifests uses).
+	versions map[string][]string
+	// manifests[repo:tag] is the parsed Package returned by Inspect.
+	manifests map[string]*api.Package
+}
+
+func newMockSource() *mockSource {
+	return &mockSource{
+		versions:  map[string][]string{},
+		manifests: map[string]*api.Package{},
+	}
+}
+
+func (m *mockSource) publish(repo, tag string, pkg *api.Package) {
+	repo = strings.TrimPrefix(repo, "oci://")
+	m.versions[repo] = append(m.versions[repo], tag)
+	m.manifests[repo+":"+tag] = pkg
+}
+
+func (m *mockSource) ListVersions(_ context.Context, ref string) ([]string, error) {
+	ref = strings.TrimPrefix(ref, "oci://")
+	vs, ok := m.versions[ref]
+	if !ok {
+		return nil, fmt.Errorf("mock: no repo %q", ref)
+	}
+	return vs, nil
+}
+
+func (m *mockSource) Inspect(_ context.Context, ref string) (*ipkg.InspectResult, error) {
+	ref = strings.TrimPrefix(ref, "oci://")
+	pkg, ok := m.manifests[ref]
+	if !ok {
+		return nil, fmt.Errorf("mock: no manifest at %q", ref)
+	}
+	// Deterministic synthetic digest derived from the ref.
+	digest := "sha256:" + strings.Repeat("a", 56) + fmt.Sprintf("%08x", hash32(ref))
+	return &ipkg.InspectResult{
+		ManifestDigest: digest,
+		Config: &api.ConfigBlob{
+			Bundle:   api.BundleInfo{LayerDigest: digest, LayerSize: 0, InstallerVersion: "test"},
+			Manifest: pkg,
+		},
+	}, nil
+}
+
+// minimal hash for synthetic digests.
+func hash32(s string) uint32 {
+	var h uint32 = 2166136261
+	for i := 0; i < len(s); i++ {
+		h = (h ^ uint32(s[i])) * 16777619
+	}
+	return h
+}
+
+// pkgWith builds a minimal Package with the supplied name/version/deps.
+func pkgWith(name, version string, deps ...api.Dependency) *api.Package {
+	return &api.Package{
+		APIVersion: api.APIVersion,
+		Kind:       api.KindPackage,
+		Metadata:   api.Metadata{Name: name, Version: version},
+		Spec: api.PackageSpec{
+			Bases:        []api.Base{{Name: "default", Path: "bases/default", Default: true}},
+			Dependencies: deps,
+		},
+	}
+}
+
+func TestResolveLinearChain(t *testing.T) {
+	ctx := context.Background()
+	src := newMockSource()
+	c := pkgWith("c", "0.3.0")
+	b := pkgWith("b", "0.2.0", api.Dependency{Name: "c", Package: "oci://reg/c", Version: ">= 0.3.0"})
+	a := pkgWith("a", "0.1.0", api.Dependency{Name: "b", Package: "oci://reg/b", Version: "^0.2.0"})
+	src.publish("reg/b", "0.2.0", b)
+	src.publish("reg/c", "0.3.0", c)
+
+	got, err := Resolve(ctx, a, src, Options{})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(got.Lock.Spec.Resolved) != 2 {
+		t.Fatalf("resolved count = %d, want 2: %+v", len(got.Lock.Spec.Resolved), got.Lock.Spec.Resolved)
+	}
+	// b before c — DFS pre-order from root.
+	if got.Lock.Spec.Resolved[0].Name != "b" || got.Lock.Spec.Resolved[1].Name != "c" {
+		t.Errorf("order = %s,%s; want b,c", got.Lock.Spec.Resolved[0].Name, got.Lock.Spec.Resolved[1].Name)
+	}
+	if got.Lock.Spec.Resolved[1].RequestedBy[0] != "b" {
+		t.Errorf("c.requestedBy = %v; want [b]", got.Lock.Spec.Resolved[1].RequestedBy)
+	}
+}
+
+func TestResolveDiamondSharedDep(t *testing.T) {
+	// a -> b -> d
+	// a -> c -> d
+	// d should appear once with requestedBy [b, c].
+	ctx := context.Background()
+	src := newMockSource()
+	d := pkgWith("d", "1.0.0")
+	b := pkgWith("b", "0.2.0", api.Dependency{Name: "d", Package: "oci://reg/d", Version: ">= 1.0.0"})
+	c := pkgWith("c", "0.3.0", api.Dependency{Name: "d", Package: "oci://reg/d", Version: "^1.0.0"})
+	a := pkgWith("a", "0.1.0",
+		api.Dependency{Name: "b", Package: "oci://reg/b", Version: "*"},
+		api.Dependency{Name: "c", Package: "oci://reg/c", Version: "*"},
+	)
+	src.publish("reg/b", "0.2.0", b)
+	src.publish("reg/c", "0.3.0", c)
+	src.publish("reg/d", "1.0.0", d)
+
+	got, err := Resolve(ctx, a, src, Options{})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	// 3 entries: b, c, d
+	if len(got.Lock.Spec.Resolved) != 3 {
+		t.Fatalf("resolved = %d, want 3: %+v", len(got.Lock.Spec.Resolved), got.Lock.Spec.Resolved)
+	}
+	var dEntry *api.LockedDependency
+	for i := range got.Lock.Spec.Resolved {
+		if got.Lock.Spec.Resolved[i].Name == "d" {
+			dEntry = &got.Lock.Spec.Resolved[i]
+		}
+	}
+	if dEntry == nil {
+		t.Fatalf("no d entry")
+	}
+	if len(dEntry.RequestedBy) != 2 {
+		t.Errorf("d.requestedBy = %v, want [b, c]", dEntry.RequestedBy)
+	}
+}
+
+func TestResolveVersionConflict(t *testing.T) {
+	ctx := context.Background()
+	src := newMockSource()
+	d10 := pkgWith("d", "1.0.0")
+	d20 := pkgWith("d", "2.0.0")
+	b := pkgWith("b", "0.2.0", api.Dependency{Name: "d", Package: "oci://reg/d", Version: "^1.0.0"})
+	c := pkgWith("c", "0.3.0", api.Dependency{Name: "d", Package: "oci://reg/d", Version: "^2.0.0"})
+	a := pkgWith("a", "0.1.0",
+		api.Dependency{Name: "b", Package: "oci://reg/b", Version: "*"},
+		api.Dependency{Name: "c", Package: "oci://reg/c", Version: "*"},
+	)
+	src.publish("reg/b", "0.2.0", b)
+	src.publish("reg/c", "0.3.0", c)
+	src.publish("reg/d", "1.0.0", d10)
+	src.publish("reg/d", "2.0.0", d20)
+
+	_, err := Resolve(ctx, a, src, Options{})
+	if err == nil {
+		t.Fatalf("expected conflict error")
+	}
+	if !strings.Contains(err.Error(), "incompatible constraints on reg/d") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveOptionalSkippedWithoutSelection(t *testing.T) {
+	ctx := context.Background()
+	src := newMockSource()
+	b := pkgWith("b", "0.2.0")
+	a := pkgWith("a", "0.1.0", api.Dependency{
+		Name:    "b",
+		Package: "oci://reg/b",
+		Version: "*",
+		Optional: true,
+		WhenComponent: "ingress",
+	})
+	src.publish("reg/b", "0.2.0", b)
+
+	got, err := Resolve(ctx, a, src, Options{})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(got.Lock.Spec.Resolved) != 0 {
+		t.Errorf("expected no resolved deps, got %d", len(got.Lock.Spec.Resolved))
+	}
+	if len(got.SkippedOptional) != 1 {
+		t.Errorf("expected 1 skipped, got %v", got.SkippedOptional)
+	}
+}
+
+func TestResolveOptionalFollowedWhenComponentSelected(t *testing.T) {
+	ctx := context.Background()
+	src := newMockSource()
+	b := pkgWith("b", "0.2.0")
+	a := pkgWith("a", "0.1.0", api.Dependency{
+		Name:    "b",
+		Package: "oci://reg/b",
+		Version: "*",
+		Optional: true,
+		WhenComponent: "ingress",
+	})
+	a.Spec.Components = []api.Component{{Name: "ingress", Path: "components/ingress"}}
+	src.publish("reg/b", "0.2.0", b)
+
+	sel := &api.Selection{Spec: api.SelectionSpec{Components: []string{"ingress"}}}
+	got, err := Resolve(ctx, a, src, Options{Selection: sel})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(got.Lock.Spec.Resolved) != 1 {
+		t.Errorf("expected 1 resolved, got %d", len(got.Lock.Spec.Resolved))
+	}
+}
+
+func TestResolvePicksHighestSatisfying(t *testing.T) {
+	ctx := context.Background()
+	src := newMockSource()
+	for _, v := range []string{"1.2.5", "1.3.0", "2.0.0", "1.2.7"} {
+		src.publish("reg/b", v, pkgWith("b", v))
+	}
+	a := pkgWith("a", "0.1.0", api.Dependency{Name: "b", Package: "oci://reg/b", Version: "^1.2.0"})
+	got, err := Resolve(ctx, a, src, Options{})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got.Lock.Spec.Resolved[0].Version != "1.3.0" {
+		t.Errorf("picked %s, want 1.3.0", got.Lock.Spec.Resolved[0].Version)
+	}
+}
+
+func TestResolveNoMatchingVersion(t *testing.T) {
+	ctx := context.Background()
+	src := newMockSource()
+	src.publish("reg/b", "0.5.0", pkgWith("b", "0.5.0"))
+	a := pkgWith("a", "0.1.0", api.Dependency{Name: "b", Package: "oci://reg/b", Version: "^1.0.0"})
+	_, err := Resolve(ctx, a, src, Options{})
+	if err == nil || !errors.Is(err, ErrNoVersionMatches) && !strings.Contains(err.Error(), "no version matches") {
+		t.Fatalf("expected no-version error, got %v", err)
+	}
+}
+
+func TestResolveIgnoresChannelTags(t *testing.T) {
+	ctx := context.Background()
+	src := newMockSource()
+	src.publish("reg/b", "stable", pkgWith("b", "stable"))
+	src.publish("reg/b", "1.0.0", pkgWith("b", "1.0.0"))
+	a := pkgWith("a", "0.1.0", api.Dependency{Name: "b", Package: "oci://reg/b", Version: "*"})
+	got, err := Resolve(ctx, a, src, Options{})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got.Lock.Spec.Resolved[0].Version != "1.0.0" {
+		t.Errorf("picked %s, want 1.0.0", got.Lock.Spec.Resolved[0].Version)
+	}
+}
+
+func TestResolveRootConflict(t *testing.T) {
+	ctx := context.Background()
+	src := newMockSource()
+	src.publish("reg/old", "1.0.0", pkgWith("old", "1.0.0"))
+	a := pkgWith("a", "0.1.0", api.Dependency{Name: "old", Package: "oci://reg/old", Version: "*"})
+	a.Spec.Conflicts = []api.ConflictRef{{Package: "oci://reg/old", Reason: "deprecated"}}
+	_, err := Resolve(ctx, a, src, Options{})
+	if err == nil || !strings.Contains(err.Error(), "conflicts with root") {
+		t.Fatalf("expected conflict error, got %v", err)
+	}
+}
+
+func TestRootDepsHashStable(t *testing.T) {
+	a := pkgWith("a", "0.1.0",
+		api.Dependency{Name: "b", Package: "oci://reg/b", Version: "^0.2"},
+		api.Dependency{Name: "c", Package: "oci://reg/c", Version: "^0.3"},
+	)
+	h1 := RootDepsHash(a)
+	// Reorder; hash should be the same.
+	a.Spec.Dependencies[0], a.Spec.Dependencies[1] = a.Spec.Dependencies[1], a.Spec.Dependencies[0]
+	h2 := RootDepsHash(a)
+	if h1 != h2 {
+		t.Fatalf("RootDepsHash should be stable across order: %s vs %s", h1, h2)
+	}
+	// Changing a constraint should change the hash.
+	a.Spec.Dependencies[0].Version = "^99"
+	h3 := RootDepsHash(a)
+	if h3 == h1 {
+		t.Fatalf("hash should change when constraint changes")
+	}
+}

--- a/internal/deps/resolver_test.go
+++ b/internal/deps/resolver_test.go
@@ -274,6 +274,20 @@ func TestResolveRootConflict(t *testing.T) {
 	}
 }
 
+func TestResolveRejectsDepWithCollector(t *testing.T) {
+	ctx := context.Background()
+	src := newMockSource()
+	withCollector := pkgWith("b", "0.2.0")
+	withCollector.Spec.Collector = &api.Collector{Command: "./collect.sh"}
+	src.publish("reg/b", "0.2.0", withCollector)
+	a := pkgWith("a", "0.1.0", api.Dependency{Name: "b", Package: "oci://reg/b", Version: "*"})
+
+	_, err := Resolve(ctx, a, src, Options{})
+	if err == nil || !strings.Contains(err.Error(), "spec.collector") {
+		t.Fatalf("expected collector-not-supported error, got %v", err)
+	}
+}
+
 func TestRootDepsHashStable(t *testing.T) {
 	a := pkgWith("a", "0.1.0",
 		api.Dependency{Name: "b", Package: "oci://reg/b", Version: "^0.2"},

--- a/internal/deps/semver.go
+++ b/internal/deps/semver.go
@@ -1,0 +1,61 @@
+package deps
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// parseConstraint parses a SemVer range expression. Empty input means "*"
+// (any version).
+func parseConstraint(expr string) (*semver.Constraints, error) {
+	if expr == "" {
+		expr = "*"
+	}
+	c, err := semver.NewConstraint(expr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid version constraint %q: %w", expr, err)
+	}
+	return c, nil
+}
+
+// parseVersion is the same as semver.NewVersion but with a clearer error
+// message. We strip a leading "v" because OCI tags conventionally use both
+// "1.2.3" and "v1.2.3"; SemVer treats them equivalently.
+func parseVersion(tag string) (*semver.Version, error) {
+	return semver.NewVersion(tag)
+}
+
+// pickBest returns the highest tag from candidates whose SemVer parse
+// satisfies constraint. Non-SemVer tags (channel aliases like "stable") are
+// silently skipped. Returns ErrNoVersionMatches if nothing matches.
+func pickBest(candidates []string, constraint *semver.Constraints) (string, *semver.Version, error) {
+	type candidate struct {
+		tag string
+		ver *semver.Version
+	}
+	var matches []candidate
+	for _, t := range candidates {
+		v, err := parseVersion(t)
+		if err != nil {
+			continue
+		}
+		if !constraint.Check(v) {
+			continue
+		}
+		matches = append(matches, candidate{tag: t, ver: v})
+	}
+	if len(matches) == 0 {
+		return "", nil, ErrNoVersionMatches
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].ver.LessThan(matches[j].ver)
+	})
+	best := matches[len(matches)-1]
+	return best.tag, best.ver, nil
+}
+
+// ErrNoVersionMatches is returned by pickBest when no candidate tag's
+// SemVer parse satisfies the constraint.
+var ErrNoVersionMatches = fmt.Errorf("no version matches constraint")

--- a/internal/deps/source.go
+++ b/internal/deps/source.go
@@ -1,0 +1,59 @@
+// Package deps walks a Package's Dependencies, picks a version per child
+// package satisfying every constraint, and writes a Lock pinning each pick
+// to a manifest digest.
+//
+// The resolver consumes a Source — a small interface over the OCI primitives
+// it needs (List tags, Inspect a ref). The default OCISource is backed by
+// internal/pkg; tests use an in-memory Source.
+package deps
+
+import (
+	"context"
+	"strings"
+
+	ipkg "github.com/confighubai/installer/internal/pkg"
+	"github.com/confighubai/installer/pkg/api"
+)
+
+// Source is the resolver's view of a package registry. It returns one
+// candidate version list per repo and the parsed manifest + config blob
+// for any specific ref.
+type Source interface {
+	// ListVersions returns the set of tags published at repo. The resolver
+	// filters to SemVer-shaped tags and picks the highest one satisfying
+	// the dependency's version constraint. Non-SemVer tags (e.g. channel
+	// aliases like "stable", "latest") are returned but ignored by the
+	// version-picker; they can still be used as an explicit pin if a
+	// downstream tool chooses to do so.
+	ListVersions(ctx context.Context, repo string) ([]string, error)
+
+	// Inspect fetches only the manifest + config blob at ref. The layer is
+	// not pulled. ref is the full OCI ref including tag (or @digest).
+	Inspect(ctx context.Context, ref string) (*ipkg.InspectResult, error)
+}
+
+// OCISource is the production Source: List + Inspect against a live registry
+// via internal/pkg.
+type OCISource struct{}
+
+func (OCISource) ListVersions(ctx context.Context, repo string) ([]string, error) {
+	return ipkg.List(ctx, repo)
+}
+
+func (OCISource) Inspect(ctx context.Context, ref string) (*ipkg.InspectResult, error) {
+	return ipkg.Inspect(ctx, ref)
+}
+
+// stripOCIPrefix strips the optional oci:// scheme from a package ref.
+func stripOCIPrefix(ref string) string {
+	return strings.TrimPrefix(ref, "oci://")
+}
+
+// joinRef rejoins a repo and tag into the canonical oci:// form used in
+// the lock file and surfaced to users.
+func joinRef(repo, tag string) string {
+	return "oci://" + stripOCIPrefix(repo) + ":" + tag
+}
+
+// _ ensures the api package import is retained.
+var _ = api.KindLock

--- a/internal/deps/source.go
+++ b/internal/deps/source.go
@@ -55,5 +55,11 @@ func joinRef(repo, tag string) string {
 	return "oci://" + stripOCIPrefix(repo) + ":" + tag
 }
 
+// pinDigestRef appends @<digest> to a tag-pinned oci ref. Used to give
+// cosign a fully-pinned reference for verification.
+func pinDigestRef(ref, digest string) string {
+	return ref + "@" + digest
+}
+
 // _ ensures the api package import is retained.
 var _ = api.KindLock

--- a/internal/pkg/auth.go
+++ b/internal/pkg/auth.go
@@ -1,0 +1,57 @@
+package pkg
+
+import (
+	"context"
+	"fmt"
+
+	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/credentials"
+	"oras.land/oras-go/v2/registry/remote/retry"
+)
+
+// authClient builds an oras auth.Client that reads credentials from the
+// docker-config-style store (~/.docker/config.json plus native helpers like
+// osxkeychain). Anonymous access works when no credentials are configured —
+// the store returns auth.EmptyCredential.
+func authClient() (*auth.Client, error) {
+	store, err := credentialStore()
+	if err != nil {
+		return nil, err
+	}
+	return &auth.Client{
+		Client:     retry.DefaultClient,
+		Cache:      auth.NewCache(),
+		Credential: credentials.Credential(store),
+	}, nil
+}
+
+// credentialStore returns the same docker-config-backed store used by
+// authClient. Exposed so login / logout can Put / Delete entries.
+func credentialStore() (credentials.Store, error) {
+	store, err := credentials.NewStoreFromDocker(credentials.StoreOptions{
+		AllowPlaintextPut: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("credential store: %w", err)
+	}
+	return store, nil
+}
+
+// Login stores a credential for registry. Credentials are written to the
+// docker-config store, so they are shared with docker, podman, and oras.
+func Login(ctx context.Context, registry, username, password string) error {
+	store, err := credentialStore()
+	if err != nil {
+		return err
+	}
+	return store.Put(ctx, registry, auth.Credential{Username: username, Password: password})
+}
+
+// Logout removes credentials for registry from the docker-config store.
+func Logout(ctx context.Context, registry string) error {
+	store, err := credentialStore()
+	if err != nil {
+		return err
+	}
+	return store.Delete(ctx, registry)
+}

--- a/internal/pkg/oci.go
+++ b/internal/pkg/oci.go
@@ -1,0 +1,424 @@
+package pkg
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content/memory"
+	"oras.land/oras-go/v2/registry/remote"
+
+	"github.com/confighubai/installer/internal/bundle"
+	"github.com/confighubai/installer/internal/version"
+	"github.com/confighubai/installer/pkg/api"
+)
+
+// PushResult is what Push returns about a completed push.
+type PushResult struct {
+	// Ref is the full reference (without the oci:// prefix) the artifact was
+	// pushed to, in <host>/<repo>:<tag> form.
+	Ref string
+	// ManifestDigest is the digest of the pushed manifest, in "sha256:<hex>".
+	ManifestDigest string
+	// LayerDigest is the digest of the package layer.
+	LayerDigest string
+	// LayerSize is the size of the layer in bytes.
+	LayerSize int64
+	// Files is the list of paths inside the layer, in tar order.
+	Files []string
+}
+
+// Push publishes a package to an OCI registry as a native installer artifact.
+//
+// src may be either a .tgz file produced by internal/bundle or a source
+// directory; directories are bundled to a temp file first. ref must be of the
+// form oci://host/repo:tag — pushing to a digest is not supported.
+func Push(ctx context.Context, src, ref string) (*PushResult, error) {
+	repoRef, tag, _, err := parseRef(ref, true /*requireTag*/)
+	if err != nil {
+		return nil, err
+	}
+	repo, err := newRepo(repoRef)
+	if err != nil {
+		return nil, err
+	}
+	res, err := stageAndCopy(ctx, src, tag, repo)
+	if err != nil {
+		return nil, err
+	}
+	res.Ref = repoRef + ":" + tag
+	return res, nil
+}
+
+// stageAndCopy builds the installer artifact (layer + config blob + manifest)
+// in an in-memory store, tags it as tag, and copies it to dst. dst may be a
+// *remote.Repository or any oras.Target (memory store in tests). Returns a
+// PushResult with Ref left blank for the caller to fill.
+func stageAndCopy(ctx context.Context, src, tag string, dst oras.Target) (*PushResult, error) {
+	tgz, loaded, cleanup, err := materializeForPush(src)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	layerData, err := os.ReadFile(tgz)
+	if err != nil {
+		return nil, err
+	}
+	layerDigest := digest.FromBytes(layerData)
+	// The layer is the source tree's tarball with paths relative to root
+	// (e.g. "installer.yaml", not "package/installer.yaml"). We extract it
+	// ourselves on pull, so we deliberately do NOT set
+	// file.AnnotationUnpack — the file-store would try to unpack into a
+	// "package/" subdir and reject paths that escape it.
+	layerDesc := ocispec.Descriptor{
+		MediaType: api.LayerMediaType,
+		Digest:    layerDigest,
+		Size:      int64(len(layerData)),
+		Annotations: map[string]string{
+			ocispec.AnnotationTitle: api.LayerTitle + ".tgz",
+		},
+	}
+
+	files, err := listTarFiles(layerData)
+	if err != nil {
+		return nil, err
+	}
+
+	cbBytes, err := buildConfigBlob(loaded.Package, layerDigest.String(), int64(len(layerData)), files)
+	if err != nil {
+		return nil, err
+	}
+	configDesc := ocispec.Descriptor{
+		MediaType: api.ConfigMediaType,
+		Digest:    digest.FromBytes(cbBytes),
+		Size:      int64(len(cbBytes)),
+	}
+
+	staging := memory.New()
+	if err := staging.Push(ctx, layerDesc, bytes.NewReader(layerData)); err != nil {
+		return nil, fmt.Errorf("stage layer: %w", err)
+	}
+	if err := staging.Push(ctx, configDesc, bytes.NewReader(cbBytes)); err != nil {
+		return nil, fmt.Errorf("stage config: %w", err)
+	}
+
+	manifestDesc, err := oras.PackManifest(ctx, staging, oras.PackManifestVersion1_1, api.ArtifactType, oras.PackManifestOptions{
+		Layers:           []ocispec.Descriptor{layerDesc},
+		ConfigDescriptor: &configDesc,
+		ManifestAnnotations: map[string]string{
+			// Fixed value → deterministic manifest digest.
+			ocispec.AnnotationCreated:      "1970-01-01T00:00:00Z",
+			ocispec.AnnotationTitle:        loaded.Package.Metadata.Name,
+			api.AnnotationName:             loaded.Package.Metadata.Name,
+			api.AnnotationVersion:          loaded.Package.Metadata.Version,
+			api.AnnotationInstallerVersion: version.Version,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("pack manifest: %w", err)
+	}
+	if err := staging.Tag(ctx, manifestDesc, tag); err != nil {
+		return nil, err
+	}
+	if _, err := oras.Copy(ctx, staging, tag, dst, tag, oras.DefaultCopyOptions); err != nil {
+		return nil, fmt.Errorf("oras copy: %w", err)
+	}
+
+	return &PushResult{
+		ManifestDigest: manifestDesc.Digest.String(),
+		LayerDigest:    layerDigest.String(),
+		LayerSize:      int64(len(layerData)),
+		Files:          files,
+	}, nil
+}
+
+// Inspect fetches only the manifest + config blob for a native installer
+// artifact. The layer is not pulled, making this cheap enough for the
+// resolver to call on every dependency candidate.
+func Inspect(ctx context.Context, ref string) (*api.ConfigBlob, error) {
+	repoRef, tag, want, err := parseRef(ref, false)
+	if err != nil {
+		return nil, err
+	}
+	repo, err := newRepo(repoRef)
+	if err != nil {
+		return nil, err
+	}
+	resolveRef := tag
+	if tag == "" {
+		resolveRef = want.String()
+	}
+	return inspectFromTarget(ctx, repo, resolveRef, want)
+}
+
+// inspectFromTarget reads the manifest at ref from any oras target and
+// decodes the config blob. Used by Inspect against a remote.Repository and by
+// tests against an in-memory store.
+func inspectFromTarget(ctx context.Context, target oras.Target, ref string, want digest.Digest) (*api.ConfigBlob, error) {
+	desc, err := target.Resolve(ctx, ref)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %s: %w", ref, err)
+	}
+	if want != "" && desc.Digest != want {
+		return nil, fmt.Errorf("digest mismatch: ref pinned %s but target returned %s", want, desc.Digest)
+	}
+	mrc, err := target.Fetch(ctx, desc)
+	if err != nil {
+		return nil, err
+	}
+	defer mrc.Close()
+	mbytes, err := io.ReadAll(mrc)
+	if err != nil {
+		return nil, err
+	}
+	var manifest ocispec.Manifest
+	if err := json.Unmarshal(mbytes, &manifest); err != nil {
+		return nil, fmt.Errorf("decode manifest: %w", err)
+	}
+	if manifest.ArtifactType != api.ArtifactType && manifest.Config.MediaType != api.ConfigMediaType {
+		return nil, fmt.Errorf("%s is not a native installer artifact (artifactType %q, config %q)",
+			ref, manifest.ArtifactType, manifest.Config.MediaType)
+	}
+	cbRC, err := target.Fetch(ctx, manifest.Config)
+	if err != nil {
+		return nil, fmt.Errorf("fetch config blob: %w", err)
+	}
+	defer cbRC.Close()
+	cbBytes, err := io.ReadAll(cbRC)
+	if err != nil {
+		return nil, err
+	}
+	var cb api.ConfigBlob
+	if err := json.Unmarshal(cbBytes, &cb); err != nil {
+		return nil, fmt.Errorf("decode config blob: %w", err)
+	}
+	return &cb, nil
+}
+
+// List returns the tags of repoRef. The endpoint is `/tags/list` per the OCI
+// distribution spec; the registry decides whether catalogs are public.
+func List(ctx context.Context, repoRef string) ([]string, error) {
+	parsed, err := parseRepoOnly(repoRef)
+	if err != nil {
+		return nil, err
+	}
+	repo, err := newRepo(parsed)
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	if err := repo.Tags(ctx, "", func(ts []string) error {
+		out = append(out, ts...)
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("list tags %s: %w", parsed, err)
+	}
+	return out, nil
+}
+
+// Tag points dstTag at the same manifest digest as srcRef. The original tag,
+// if any, is preserved. srcRef is a full ref (oci://host/repo:tag or
+// oci://host/repo@sha256:...); dstTag is a bare tag name.
+func Tag(ctx context.Context, srcRef, dstTag string) error {
+	if dstTag == "" {
+		return errors.New("destination tag required")
+	}
+	if strings.ContainsAny(dstTag, "/:@") {
+		return fmt.Errorf("destination tag %q must be a bare tag (no /, :, or @)", dstTag)
+	}
+	repoRef, srcTag, want, err := parseRef(srcRef, false)
+	if err != nil {
+		return err
+	}
+	repo, err := newRepo(repoRef)
+	if err != nil {
+		return err
+	}
+	resolveRef := srcTag
+	if srcTag == "" {
+		resolveRef = want.String()
+	}
+	desc, err := repo.Resolve(ctx, resolveRef)
+	if err != nil {
+		return fmt.Errorf("resolve %s: %w", srcRef, err)
+	}
+	if want != "" && desc.Digest != want {
+		return fmt.Errorf("digest mismatch on %s: pinned %s but registry returned %s", srcRef, want, desc.Digest)
+	}
+	if err := repo.Tag(ctx, desc, dstTag); err != nil {
+		return fmt.Errorf("tag %s as %s: %w", repoRef, dstTag, err)
+	}
+	return nil
+}
+
+// --- helpers ------------------------------------------------------------
+
+// parseRef accepts oci:// prefixed or bare references and splits them into
+// (repoRef, tag, digest). One of tag or digest is always populated unless
+// requireTag is set (in which case a tag is mandatory and digest is rejected).
+// repoRef has the form host/path[/...].
+func parseRef(ref string, requireTag bool) (repoRef, tag string, want digest.Digest, err error) {
+	ref = strings.TrimPrefix(ref, "oci://")
+	// Split off @sha256:... if present.
+	if at := strings.LastIndex(ref, "@"); at >= 0 {
+		want, err = digest.Parse(ref[at+1:])
+		if err != nil {
+			return "", "", "", fmt.Errorf("parse digest in %q: %w", ref, err)
+		}
+		ref = ref[:at]
+	}
+	if requireTag && want != "" {
+		return "", "", "", fmt.Errorf("push to %s: digest-only refs are not supported; use :tag", ref)
+	}
+	// Split off :tag.
+	if colon := strings.LastIndex(ref, ":"); colon >= 0 && !strings.Contains(ref[colon:], "/") {
+		tag = ref[colon+1:]
+		ref = ref[:colon]
+	}
+	if requireTag && tag == "" {
+		return "", "", "", fmt.Errorf("push requires :tag, got %q", ref)
+	}
+	if tag == "" && want == "" {
+		return "", "", "", fmt.Errorf("ref %q has neither :tag nor @digest", ref)
+	}
+	return ref, tag, want, nil
+}
+
+// parseRepoOnly strips the oci:// prefix and refuses any ref carrying a
+// :tag or @digest. Used by List, which targets the repo itself.
+func parseRepoOnly(ref string) (string, error) {
+	ref = strings.TrimPrefix(ref, "oci://")
+	if strings.Contains(ref, "@") {
+		return "", fmt.Errorf("list takes a repo ref without @digest, got %q", ref)
+	}
+	if colon := strings.LastIndex(ref, ":"); colon >= 0 && !strings.Contains(ref[colon:], "/") {
+		return "", fmt.Errorf("list takes a repo ref without :tag, got %q", ref)
+	}
+	return ref, nil
+}
+
+func newRepo(repoRef string) (*remote.Repository, error) {
+	repo, err := remote.NewRepository(repoRef)
+	if err != nil {
+		return nil, fmt.Errorf("repo %s: %w", repoRef, err)
+	}
+	client, err := authClient()
+	if err != nil {
+		return nil, err
+	}
+	repo.Client = client
+	// Allow http for plaintext registries (local zot, registry:2 in tests).
+	// oras-go defaults to https; the PlainHTTP toggle is controlled by env
+	// var ORAS_OCI_INSECURE for parity with the oras CLI.
+	if os.Getenv("ORAS_OCI_INSECURE") == "1" {
+		repo.PlainHTTP = true
+	}
+	if strings.HasPrefix(repoRef, "localhost") || strings.HasPrefix(repoRef, "127.0.0.1") {
+		repo.PlainHTTP = true
+	}
+	return repo, nil
+}
+
+// materializeForPush returns a path to a .tgz and the parsed Package. If src
+// is a directory, it is bundled to a temp file; the cleanup func removes the
+// temp dir.
+func materializeForPush(src string) (tgz string, loaded *Loaded, cleanup func(), err error) {
+	info, err := os.Stat(src)
+	if err != nil {
+		return "", nil, func() {}, err
+	}
+	if info.IsDir() {
+		tmp, err := os.MkdirTemp("", "installer-push-*")
+		if err != nil {
+			return "", nil, func() {}, err
+		}
+		cleanup = func() { _ = os.RemoveAll(tmp) }
+		tgzPath := filepath.Join(tmp, "package.tgz")
+		if _, err := bundle.Bundle(src, tgzPath); err != nil {
+			cleanup()
+			return "", nil, func() {}, err
+		}
+		loaded, err = Load(src)
+		if err != nil {
+			cleanup()
+			return "", nil, func() {}, err
+		}
+		return tgzPath, loaded, cleanup, nil
+	}
+	// src is a .tgz — extract to a temp dir just to read installer.yaml.
+	tmp, err := os.MkdirTemp("", "installer-push-*")
+	if err != nil {
+		return "", nil, func() {}, err
+	}
+	cleanup = func() { _ = os.RemoveAll(tmp) }
+	f, err := os.Open(src)
+	if err != nil {
+		cleanup()
+		return "", nil, func() {}, err
+	}
+	defer f.Close()
+	if err := extractTarGz(f, tmp); err != nil {
+		cleanup()
+		return "", nil, func() {}, err
+	}
+	loaded, err = Load(tmp)
+	if err != nil {
+		cleanup()
+		return "", nil, func() {}, fmt.Errorf("load %s: %w", src, err)
+	}
+	return src, loaded, cleanup, nil
+}
+
+func buildConfigBlob(pkg *api.Package, layerDigest string, layerSize int64, files []string) ([]byte, error) {
+	cb := api.ConfigBlob{
+		Bundle: api.BundleInfo{
+			InstallerVersion: version.Version,
+			LayerDigest:      layerDigest,
+			LayerSize:        layerSize,
+			Files:            files,
+		},
+		Manifest: pkg,
+	}
+	return json.Marshal(cb)
+}
+
+// listTarFiles reads a gzipped tar from data and returns its file paths in
+// the order they appear in the tar (the bundler emits them sorted).
+func listTarFiles(data []byte) ([]string, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("gzip: %w", err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	var out []string
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("tar read: %w", err)
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		out = append(out, hdr.Name)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+

--- a/internal/pkg/oci.go
+++ b/internal/pkg/oci.go
@@ -145,10 +145,17 @@ func stageAndCopy(ctx context.Context, src, tag string, dst oras.Target) (*PushR
 	}, nil
 }
 
+// InspectResult is what Inspect returns: the OCI manifest digest plus the
+// decoded config blob.
+type InspectResult struct {
+	ManifestDigest string
+	Config         *api.ConfigBlob
+}
+
 // Inspect fetches only the manifest + config blob for a native installer
 // artifact. The layer is not pulled, making this cheap enough for the
 // resolver to call on every dependency candidate.
-func Inspect(ctx context.Context, ref string) (*api.ConfigBlob, error) {
+func Inspect(ctx context.Context, ref string) (*InspectResult, error) {
 	repoRef, tag, want, err := parseRef(ref, false)
 	if err != nil {
 		return nil, err
@@ -167,7 +174,7 @@ func Inspect(ctx context.Context, ref string) (*api.ConfigBlob, error) {
 // inspectFromTarget reads the manifest at ref from any oras target and
 // decodes the config blob. Used by Inspect against a remote.Repository and by
 // tests against an in-memory store.
-func inspectFromTarget(ctx context.Context, target oras.Target, ref string, want digest.Digest) (*api.ConfigBlob, error) {
+func inspectFromTarget(ctx context.Context, target oras.Target, ref string, want digest.Digest) (*InspectResult, error) {
 	desc, err := target.Resolve(ctx, ref)
 	if err != nil {
 		return nil, fmt.Errorf("resolve %s: %w", ref, err)
@@ -205,7 +212,10 @@ func inspectFromTarget(ctx context.Context, target oras.Target, ref string, want
 	if err := json.Unmarshal(cbBytes, &cb); err != nil {
 		return nil, fmt.Errorf("decode config blob: %w", err)
 	}
-	return &cb, nil
+	return &InspectResult{
+		ManifestDigest: desc.Digest.String(),
+		Config:         &cb,
+	}, nil
 }
 
 // List returns the tags of repoRef. The endpoint is `/tags/list` per the OCI

--- a/internal/pkg/oci_test.go
+++ b/internal/pkg/oci_test.go
@@ -1,0 +1,227 @@
+package pkg
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	"oras.land/oras-go/v2/content/memory"
+
+	"github.com/confighubai/installer/internal/bundle"
+	"github.com/confighubai/installer/pkg/api"
+)
+
+const testInstallerYAML = `apiVersion: installer.confighub.com/v1alpha1
+kind: Package
+metadata:
+  name: ocitest
+  version: 1.2.3
+spec:
+  bases:
+    - {name: default, path: bases/default, default: true}
+`
+
+// testPackage creates a minimal but valid package source tree on disk and
+// returns its root.
+func testPackage(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	must := func(p, c string) {
+		full := filepath.Join(dir, p)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(c), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	must("installer.yaml", testInstallerYAML)
+	must("bases/default/kustomization.yaml", "resources:\n  - cm.yaml\n")
+	must("bases/default/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n")
+	return dir
+}
+
+// TestStageAndInspectRoundTrip pushes a package into an in-memory oras target,
+// inspects it through the same target, and verifies the round-trip preserves
+// the manifest, layer digest, and file list.
+func TestStageAndInspectRoundTrip(t *testing.T) {
+	src := testPackage(t)
+	ctx := context.Background()
+	mem := memory.New()
+
+	pushed, err := stageAndCopy(ctx, src, "v1", mem)
+	if err != nil {
+		t.Fatalf("stageAndCopy: %v", err)
+	}
+	if !strings.HasPrefix(pushed.LayerDigest, "sha256:") {
+		t.Fatalf("layer digest missing sha256 prefix: %s", pushed.LayerDigest)
+	}
+	if !strings.HasPrefix(pushed.ManifestDigest, "sha256:") {
+		t.Fatalf("manifest digest missing sha256 prefix: %s", pushed.ManifestDigest)
+	}
+	wantFiles := []string{
+		"bases/default/cm.yaml",
+		"bases/default/kustomization.yaml",
+		"installer.yaml",
+	}
+	if !equalStrings(pushed.Files, wantFiles) {
+		t.Fatalf("file list mismatch: got %v want %v", pushed.Files, wantFiles)
+	}
+
+	cb, err := inspectFromTarget(ctx, mem, "v1", "")
+	if err != nil {
+		t.Fatalf("inspectFromTarget: %v", err)
+	}
+	if cb.Manifest.Metadata.Name != "ocitest" || cb.Manifest.Metadata.Version != "1.2.3" {
+		t.Fatalf("manifest metadata wrong: %+v", cb.Manifest.Metadata)
+	}
+	if cb.Bundle.LayerDigest != pushed.LayerDigest {
+		t.Fatalf("layer digest in config blob (%s) differs from pushed (%s)",
+			cb.Bundle.LayerDigest, pushed.LayerDigest)
+	}
+	if cb.Bundle.LayerSize != pushed.LayerSize {
+		t.Fatalf("layer size mismatch: blob=%d pushed=%d", cb.Bundle.LayerSize, pushed.LayerSize)
+	}
+	if !equalStrings(cb.Bundle.Files, wantFiles) {
+		t.Fatalf("config blob file list mismatch: got %v want %v", cb.Bundle.Files, wantFiles)
+	}
+}
+
+// TestStageDeterministicManifest verifies that two pushes of the same source
+// tree produce the same manifest digest — required for digest pinning and
+// signing to be meaningful.
+func TestStageDeterministicManifest(t *testing.T) {
+	src := testPackage(t)
+	ctx := context.Background()
+
+	a, err := stageAndCopy(ctx, src, "v1", memory.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := stageAndCopy(ctx, src, "v1", memory.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.ManifestDigest != b.ManifestDigest {
+		t.Fatalf("manifest digest not deterministic: %s vs %s", a.ManifestDigest, b.ManifestDigest)
+	}
+	if a.LayerDigest != b.LayerDigest {
+		t.Fatalf("layer digest not deterministic: %s vs %s", a.LayerDigest, b.LayerDigest)
+	}
+}
+
+// TestInspectDigestPin enforces that a wrong @sha256:... pin fails inspect
+// even when the tag resolves successfully.
+func TestInspectDigestPin(t *testing.T) {
+	src := testPackage(t)
+	ctx := context.Background()
+	mem := memory.New()
+	pushed, err := stageAndCopy(ctx, src, "v1", mem)
+	if err != nil {
+		t.Fatal(err)
+	}
+	good, _ := digest.Parse(pushed.ManifestDigest)
+	if _, err := inspectFromTarget(ctx, mem, "v1", good); err != nil {
+		t.Fatalf("correct pin should succeed: %v", err)
+	}
+	bad := digest.Digest("sha256:" + strings.Repeat("0", 64))
+	_, err = inspectFromTarget(ctx, mem, "v1", bad)
+	if err == nil || !strings.Contains(err.Error(), "digest mismatch") {
+		t.Fatalf("wrong pin should fail with digest mismatch, got %v", err)
+	}
+}
+
+func TestStageRejectsNonPackage(t *testing.T) {
+	dir := t.TempDir()
+	// no installer.yaml
+	_, err := stageAndCopy(context.Background(), dir, "v1", memory.New())
+	if err == nil {
+		t.Fatalf("expected error for non-package dir")
+	}
+}
+
+func TestParseRef(t *testing.T) {
+	cases := []struct {
+		in         string
+		requireTag bool
+		wantRepo   string
+		wantTag    string
+		wantDigest digest.Digest
+		wantErr    bool
+	}{
+		{in: "oci://ghcr.io/o/r:v1", wantRepo: "ghcr.io/o/r", wantTag: "v1"},
+		{in: "ghcr.io/o/r:v1", wantRepo: "ghcr.io/o/r", wantTag: "v1"},
+		{in: "oci://ghcr.io/o/r:v1@sha256:" + strings.Repeat("a", 64), wantRepo: "ghcr.io/o/r", wantTag: "v1", wantDigest: digest.Digest("sha256:" + strings.Repeat("a", 64))},
+		{in: "ghcr.io/o/r@sha256:" + strings.Repeat("b", 64), wantRepo: "ghcr.io/o/r", wantDigest: digest.Digest("sha256:" + strings.Repeat("b", 64))},
+		{in: "ghcr.io/o/r", wantErr: true},
+		{in: "ghcr.io/o/r@sha256:" + strings.Repeat("c", 64), requireTag: true, wantErr: true},
+		{in: "ghcr.io/o/r:v1", requireTag: true, wantRepo: "ghcr.io/o/r", wantTag: "v1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			repo, tag, dgst, err := parseRef(tc.in, tc.requireTag)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if repo != tc.wantRepo {
+				t.Fatalf("repo: got %q want %q", repo, tc.wantRepo)
+			}
+			if tag != tc.wantTag {
+				t.Fatalf("tag: got %q want %q", tag, tc.wantTag)
+			}
+			if dgst != tc.wantDigest {
+				t.Fatalf("digest: got %q want %q", dgst, tc.wantDigest)
+			}
+		})
+	}
+}
+
+// TestListTarFilesSorted ensures the file list extracted from a layer matches
+// the bundler's deterministic order.
+func TestListTarFilesSorted(t *testing.T) {
+	src := testPackage(t)
+	dst := filepath.Join(t.TempDir(), "p.tgz")
+	if _, err := bundle.Bundle(src, dst); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files, err := listTarFiles(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"bases/default/cm.yaml",
+		"bases/default/kustomization.yaml",
+		"installer.yaml",
+	}
+	if !equalStrings(files, want) {
+		t.Fatalf("got %v want %v", files, want)
+	}
+}
+
+// ensure api types are referenced so import isn't pruned.
+var _ = api.ArtifactType
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/pkg/oci_test.go
+++ b/internal/pkg/oci_test.go
@@ -71,10 +71,14 @@ func TestStageAndInspectRoundTrip(t *testing.T) {
 		t.Fatalf("file list mismatch: got %v want %v", pushed.Files, wantFiles)
 	}
 
-	cb, err := inspectFromTarget(ctx, mem, "v1", "")
+	got, err := inspectFromTarget(ctx, mem, "v1", "")
 	if err != nil {
 		t.Fatalf("inspectFromTarget: %v", err)
 	}
+	if got.ManifestDigest != pushed.ManifestDigest {
+		t.Fatalf("manifest digest mismatch: inspect=%s pushed=%s", got.ManifestDigest, pushed.ManifestDigest)
+	}
+	cb := got.Config
 	if cb.Manifest.Metadata.Name != "ocitest" || cb.Manifest.Metadata.Version != "1.2.3" {
 		t.Fatalf("manifest metadata wrong: %+v", cb.Manifest.Metadata)
 	}

--- a/internal/pkg/pull.go
+++ b/internal/pkg/pull.go
@@ -16,6 +16,7 @@ import (
 	"oras.land/oras-go/v2/content/file"
 	"oras.land/oras-go/v2/registry/remote"
 
+	"github.com/confighubai/installer/internal/sign"
 	"github.com/confighubai/installer/pkg/api"
 )
 
@@ -102,6 +103,15 @@ func pullOCI(ctx context.Context, ref, dest string) (string, error) {
 		return "", fmt.Errorf("digest mismatch on %s: pinned %s but registry returned %s", ref, want, desc.Digest)
 	}
 
+	// Policy gate: if ~/.config/installer/policy.yaml enforces
+	// verification, refuse to extract an unverified artifact. We verify
+	// the resolved digest so a registry that returns a different artifact
+	// after our resolve can't slip past.
+	pinnedRef := joinRefForVerify(repoRef, desc.Digest.String())
+	if err := sign.EnforceVerification(ctx, pinnedRef); err != nil {
+		return "", fmt.Errorf("verify %s: %w", ref, err)
+	}
+
 	// Peek at the manifest to choose the extraction path. Native installer
 	// artifacts have artifactType set to api.ArtifactType; everything else
 	// (notably Helm-OCI charts) takes the file-store fallback.
@@ -167,6 +177,12 @@ func pullHelmShaped(ctx context.Context, repo *remote.Repository, byDigest strin
 		return extracted, nil
 	}
 	return resolveSingleSubdir(dest), nil
+}
+
+// joinRefForVerify combines a repo and digest into the canonical
+// oci://repo@sha256:... form passed to cosign.
+func joinRefForVerify(repoRef, digest string) string {
+	return "oci://" + repoRef + "@" + digest
 }
 
 // fetchManifest fetches and decodes an OCI image manifest by descriptor.

--- a/internal/pkg/pull.go
+++ b/internal/pkg/pull.go
@@ -4,17 +4,19 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/file"
 	"oras.land/oras-go/v2/registry/remote"
-	"oras.land/oras-go/v2/registry/remote/auth"
-	"oras.land/oras-go/v2/registry/remote/retry"
+
+	"github.com/confighubai/installer/pkg/api"
 )
 
 // Pull resolves a package reference to a local directory ready for Load.
@@ -79,21 +81,35 @@ func pullLocal(src, dest string) (string, error) {
 }
 
 func pullOCI(ctx context.Context, ref, dest string) (string, error) {
-	// ref is e.g. ghcr.io/owner/repo:tag
-	colon := strings.LastIndex(ref, ":")
-	if colon < 0 {
-		return "", fmt.Errorf("oci reference %q missing :tag", ref)
-	}
-	repoRef, tag := ref[:colon], ref[colon+1:]
-	repo, err := remote.NewRepository(repoRef)
+	repoRef, tag, want, err := parseRef(ref, false)
 	if err != nil {
-		return "", fmt.Errorf("oras: %w", err)
+		return "", err
 	}
-	repo.Client = &auth.Client{
-		Client:     retry.DefaultClient,
-		Cache:      auth.NewCache(),
-		Credential: auth.StaticCredential(repo.Reference.Registry, auth.EmptyCredential),
+	repo, err := newRepo(repoRef)
+	if err != nil {
+		return "", err
 	}
+
+	resolveRef := tag
+	if tag == "" {
+		resolveRef = want.String()
+	}
+	desc, err := repo.Resolve(ctx, resolveRef)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s: %w", ref, err)
+	}
+	if want != "" && desc.Digest != want {
+		return "", fmt.Errorf("digest mismatch on %s: pinned %s but registry returned %s", ref, want, desc.Digest)
+	}
+
+	// Peek at the manifest to choose the extraction path. Native installer
+	// artifacts have artifactType set to api.ArtifactType; everything else
+	// (notably Helm-OCI charts) takes the file-store fallback.
+	manifest, err := fetchManifest(ctx, repo, desc)
+	if err != nil {
+		return "", err
+	}
+
 	if dest == "" {
 		dest, err = os.MkdirTemp("", "installer-oci-*")
 		if err != nil {
@@ -102,26 +118,73 @@ func pullOCI(ctx context.Context, ref, dest string) (string, error) {
 	} else if err := os.MkdirAll(dest, 0o755); err != nil {
 		return "", err
 	}
+
+	if manifest.ArtifactType == api.ArtifactType {
+		return pullNative(ctx, repo, manifest, dest)
+	}
+	return pullHelmShaped(ctx, repo, desc.Digest.String(), dest)
+}
+
+// pullNative extracts the single tar.gz layer of a native installer artifact
+// into <dest>/package/, mirroring the single-subdir shape of Helm pulls.
+func pullNative(ctx context.Context, repo *remote.Repository, manifest *ocispec.Manifest, dest string) (string, error) {
+	if len(manifest.Layers) != 1 {
+		return "", fmt.Errorf("native installer artifact must have exactly 1 layer, got %d", len(manifest.Layers))
+	}
+	layer := manifest.Layers[0]
+	if layer.MediaType != api.LayerMediaType {
+		return "", fmt.Errorf("native installer artifact has unexpected layer mediaType %q", layer.MediaType)
+	}
+	pkgDir := filepath.Join(dest, api.LayerTitle)
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		return "", err
+	}
+	rc, err := repo.Fetch(ctx, layer)
+	if err != nil {
+		return "", fmt.Errorf("fetch layer: %w", err)
+	}
+	defer rc.Close()
+	if err := extractTarGz(rc, pkgDir); err != nil {
+		return "", err
+	}
+	return pkgDir, nil
+}
+
+// pullHelmShaped is the legacy file-store path: copy the layer to disk via
+// oras.Copy and post-extract any single .tgz file. Used for Helm-OCI charts.
+func pullHelmShaped(ctx context.Context, repo *remote.Repository, byDigest string, dest string) (string, error) {
 	store, err := file.New(dest)
 	if err != nil {
 		return "", err
 	}
 	defer store.Close()
-	// Allow Helm chart blobs (which are tar.gz layers) to be unpacked into the
-	// destination. The file store handles the unpacking based on layer media
-	// types and titles in the manifest.
-	if _, err := oras.Copy(ctx, repo, tag, store, tag, oras.DefaultCopyOptions); err != nil {
-		return "", fmt.Errorf("oras copy %s: %w", ref, err)
+	if _, err := oras.Copy(ctx, repo, byDigest, store, byDigest, oras.DefaultCopyOptions); err != nil {
+		return "", fmt.Errorf("oras copy %s: %w", byDigest, err)
 	}
-	// Helm OCI artifacts have a single .tgz layer named like <chart>-<ver>.tgz.
-	// oras-go's file store writes that as a regular file in dest. Detect and
-	// extract.
 	if extracted, ok, err := tryExtractHelmTGZ(dest); err != nil {
 		return "", err
 	} else if ok {
 		return extracted, nil
 	}
 	return resolveSingleSubdir(dest), nil
+}
+
+// fetchManifest fetches and decodes an OCI image manifest by descriptor.
+func fetchManifest(ctx context.Context, repo *remote.Repository, desc ocispec.Descriptor) (*ocispec.Manifest, error) {
+	rc, err := repo.Manifests().Fetch(ctx, desc)
+	if err != nil {
+		return nil, fmt.Errorf("fetch manifest: %w", err)
+	}
+	defer rc.Close()
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, err
+	}
+	var m ocispec.Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("decode manifest: %w", err)
+	}
+	return &m, nil
 }
 
 // tryExtractHelmTGZ looks for a single .tgz file at the top level of dest and,

--- a/internal/render/multipkg.go
+++ b/internal/render/multipkg.go
@@ -1,0 +1,189 @@
+package render
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	ipkg "github.com/confighubai/installer/internal/pkg"
+	"github.com/confighubai/installer/internal/selection"
+	"github.com/confighubai/installer/pkg/api"
+)
+
+// Fetcher resolves a locked dependency to a local directory the renderer
+// can load. Implementations are responsible for digest verification.
+//
+// destDir is the parent-chosen cache slot for this dependency. The function
+// returns the absolute path to the package root (containing installer.yaml).
+type Fetcher func(ctx context.Context, ref, digest, destDir string) (string, error)
+
+// DefaultFetcher pulls a locked dependency via ipkg.Pull. The ref is
+// digest-pinned (oci://...:tag@sha256:...) so the registry's response is
+// verified against the lock. If destDir already contains a package, the
+// fetch is skipped — the caller's cache hit.
+func DefaultFetcher(ctx context.Context, ref, digest, destDir string) (string, error) {
+	pkgRoot := filepath.Join(destDir, "package")
+	if _, err := os.Stat(filepath.Join(pkgRoot, "installer.yaml")); err == nil {
+		return pkgRoot, nil
+	}
+	pinned := ref + "@" + digest
+	return ipkg.Pull(ctx, pinned, destDir)
+}
+
+// DepsOptions configures RenderDependencies.
+type DepsOptions struct {
+	// Lock is the resolved dependency tree, typically read from
+	// <work-dir>/out/spec/lock.yaml.
+	Lock *api.Lock
+
+	// ParentInputs carries the parent's namespace. Used as the default
+	// namespace for dependencies whose lock entry does not provide one.
+	ParentInputs *api.Inputs
+
+	// WorkDir is the parent's working directory. Vendor cache lives at
+	// <WorkDir>/out/vendor/<name>@<version>/, dep render outputs go to
+	// <WorkDir>/out/<dep-name>/.
+	WorkDir string
+
+	// Fetcher resolves a locked dep's ref+digest to a local package root.
+	// If nil, DefaultFetcher is used.
+	Fetcher Fetcher
+}
+
+// DepResult records the outcome of one dependency render.
+type DepResult struct {
+	Name        string
+	OutDir      string
+	Manifests   []File
+	Secrets     []File
+	PackageRoot string // where the dep's source tree was materialized
+}
+
+// RenderDependencies renders each entry in opts.Lock into its own subtree
+// under <WorkDir>/out/<dep-name>/. The lock's Selection and Inputs are used
+// as wizard pre-answers; selection closure is run on top so the dep's own
+// Requires/Conflicts/ValidForBases rules are honored.
+//
+// Returns one DepResult per resolved dependency, in lock order.
+func RenderDependencies(ctx context.Context, opts DepsOptions) ([]DepResult, error) {
+	if opts.Lock == nil {
+		return nil, fmt.Errorf("RenderDependencies: Lock is required")
+	}
+	if opts.WorkDir == "" {
+		return nil, fmt.Errorf("RenderDependencies: WorkDir is required")
+	}
+	if opts.ParentInputs == nil {
+		return nil, fmt.Errorf("RenderDependencies: ParentInputs is required")
+	}
+	fetch := opts.Fetcher
+	if fetch == nil {
+		fetch = DefaultFetcher
+	}
+
+	vendorDir := filepath.Join(opts.WorkDir, "out", "vendor")
+	if err := os.MkdirAll(vendorDir, 0o755); err != nil {
+		return nil, err
+	}
+
+	var out []DepResult
+	for _, d := range opts.Lock.Spec.Resolved {
+		dest := filepath.Join(vendorDir, vendorSlug(d.Name, d.Version))
+		pkgRoot, err := fetch(ctx, d.Ref, d.Digest, dest)
+		if err != nil {
+			return nil, fmt.Errorf("fetch %s: %w", d.Ref, err)
+		}
+		loaded, err := ipkg.Load(pkgRoot)
+		if err != nil {
+			return nil, fmt.Errorf("load %s: %w", pkgRoot, err)
+		}
+
+		sel, inputs, err := buildDepWizardAnswers(loaded.Package, d, opts.ParentInputs)
+		if err != nil {
+			return nil, fmt.Errorf("dep %s: %w", d.Name, err)
+		}
+
+		depOut := filepath.Join(opts.WorkDir, "out", d.Name)
+		if err := os.MkdirAll(depOut, 0o755); err != nil {
+			return nil, err
+		}
+		res, err := Render(ctx, Options{Loaded: loaded, Selection: sel, Inputs: inputs}, depOut)
+		if err != nil {
+			return nil, fmt.Errorf("render dep %s: %w", d.Name, err)
+		}
+		out = append(out, DepResult{
+			Name:        d.Name,
+			OutDir:      depOut,
+			Manifests:   res.Manifests,
+			Secrets:     res.Secrets,
+			PackageRoot: pkgRoot,
+		})
+	}
+	return out, nil
+}
+
+// vendorSlug returns the dirname used for a cached dependency in
+// out/vendor/. Falls back to the dep name when no version is recorded.
+func vendorSlug(name, version string) string {
+	if version == "" {
+		return name
+	}
+	return name + "@" + version
+}
+
+// buildDepWizardAnswers turns a LockedDependency + the dep's installer.yaml
+// into the Selection + Inputs render needs. The lock's Selection drives the
+// closure-resolved selection; the lock's Inputs map is split between the
+// special "namespace" key (which becomes Inputs.Spec.Namespace) and the
+// declared input values.
+func buildDepWizardAnswers(pkg *api.Package, d api.LockedDependency, parent *api.Inputs) (*api.Selection, *api.Inputs, error) {
+	base := ""
+	components := []string{}
+	if d.Selection != nil {
+		base = d.Selection.Base
+		components = d.Selection.Components
+	}
+	sel, err := selection.Resolve(pkg, base, components)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve selection: %w", err)
+	}
+	// Carry the locked dep's identity onto Selection so re-render is keyed
+	// to the right package.
+	sel.Spec.Package = pkg.Metadata.Name
+	sel.Spec.PackageVersion = pkg.Metadata.Version
+
+	namespace := parent.Spec.Namespace
+	values := map[string]any{}
+	for k, v := range d.Inputs {
+		if k == "namespace" {
+			if s, ok := v.(string); ok && s != "" {
+				namespace = s
+			}
+			continue
+		}
+		values[k] = v
+	}
+	// Apply declared defaults for inputs not overridden by the lock.
+	for i := range pkg.Spec.Inputs {
+		in := &pkg.Spec.Inputs[i]
+		if _, present := values[in.Name]; present {
+			continue
+		}
+		if in.Default != nil {
+			values[in.Name] = in.Default
+		}
+	}
+
+	inputs := &api.Inputs{
+		APIVersion: api.APIVersion,
+		Kind:       api.KindInputs,
+		Metadata:   api.Metadata{Name: pkg.Metadata.Name + "-inputs"},
+		Spec: api.InputsSpec{
+			Package:        pkg.Metadata.Name,
+			PackageVersion: pkg.Metadata.Version,
+			Namespace:      namespace,
+			Values:         values,
+		},
+	}
+	return sel, inputs, nil
+}

--- a/internal/render/multipkg_test.go
+++ b/internal/render/multipkg_test.go
@@ -1,0 +1,298 @@
+package render_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confighubai/installer/internal/render"
+	"github.com/confighubai/installer/pkg/api"
+)
+
+const depPackageYAML = `apiVersion: installer.confighub.com/v1alpha1
+kind: Package
+metadata: {name: dep, version: 0.1.0}
+spec:
+  bases:
+    - {name: default, path: bases/default, default: true}
+  functionChainTemplate:
+    - toolchain: Kubernetes/YAML
+      whereResource: ""
+      invocations:
+        - {name: set-namespace, args: ["{{ .Namespace }}"]}
+`
+
+const depBaseKust = `resources:
+  - cm.yaml
+`
+
+const depCM = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dep-cm
+`
+
+const parentPackageYAML = `apiVersion: installer.confighub.com/v1alpha1
+kind: Package
+metadata: {name: parent, version: 0.1.0}
+spec:
+  bases:
+    - {name: default, path: bases/default, default: true}
+  dependencies:
+    - {name: dep-one, package: oci://test/dep, version: "^0.1.0"}
+  functionChainTemplate:
+    - toolchain: Kubernetes/YAML
+      whereResource: ""
+      invocations:
+        - {name: set-namespace, args: ["{{ .Namespace }}"]}
+`
+
+const parentBaseKust = `resources:
+  - cm.yaml
+`
+
+const parentCM = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: parent-cm
+`
+
+// writeFile creates parent directories as needed.
+func writeFile(t *testing.T, p, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeDepPackage writes a self-contained dep package under destDir/package/.
+// Mirrors the layout produced by ipkg.Pull for a native installer artifact.
+func writeDepPackage(t *testing.T, destDir string) string {
+	t.Helper()
+	root := filepath.Join(destDir, "package")
+	writeFile(t, filepath.Join(root, "installer.yaml"), depPackageYAML)
+	writeFile(t, filepath.Join(root, "bases/default/kustomization.yaml"), depBaseKust)
+	writeFile(t, filepath.Join(root, "bases/default/cm.yaml"), depCM)
+	return root
+}
+
+func TestRenderDependencies(t *testing.T) {
+	if _, err := exec.LookPath("kustomize"); err != nil {
+		t.Skip("kustomize not on PATH")
+	}
+	ctx := context.Background()
+	work := t.TempDir()
+
+	// Parent source.
+	pkgDir := filepath.Join(work, "package")
+	writeFile(t, filepath.Join(pkgDir, "installer.yaml"), parentPackageYAML)
+	writeFile(t, filepath.Join(pkgDir, "bases/default/kustomization.yaml"), parentBaseKust)
+	writeFile(t, filepath.Join(pkgDir, "bases/default/cm.yaml"), parentCM)
+
+	parentInputs := &api.Inputs{
+		APIVersion: api.APIVersion,
+		Kind:       api.KindInputs,
+		Spec:       api.InputsSpec{Package: "parent", Namespace: "demo"},
+	}
+
+	lock := &api.Lock{
+		APIVersion: api.APIVersion,
+		Kind:       api.KindLock,
+		Metadata:   api.Metadata{Name: "parent"},
+		Spec: api.LockSpec{
+			Package: api.LockedPackage{Name: "parent", Version: "0.1.0"},
+			Resolved: []api.LockedDependency{{
+				Name:        "dep-one",
+				Ref:         "oci://test/dep:0.1.0",
+				Digest:      "sha256:" + strings.Repeat("a", 64),
+				Version:     "0.1.0",
+				RequestedBy: []string{"root"},
+				Inputs:      map[string]any{"namespace": "dep-ns"},
+			}},
+		},
+	}
+
+	fakeFetcher := func(_ context.Context, _, _, destDir string) (string, error) {
+		// Mimic the cache-hit semantics: only write once.
+		root := filepath.Join(destDir, "package")
+		if _, err := os.Stat(filepath.Join(root, "installer.yaml")); err == nil {
+			return root, nil
+		}
+		return writeDepPackage(t, destDir), nil
+	}
+
+	results, err := render.RenderDependencies(ctx, render.DepsOptions{
+		Lock:         lock,
+		ParentInputs: parentInputs,
+		WorkDir:      work,
+		Fetcher:      fakeFetcher,
+	})
+	if err != nil {
+		t.Fatalf("RenderDependencies: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d dep results, want 1", len(results))
+	}
+	r := results[0]
+	if r.Name != "dep-one" {
+		t.Errorf("name = %q", r.Name)
+	}
+	wantOut := filepath.Join(work, "out", "dep-one")
+	if r.OutDir != wantOut {
+		t.Errorf("outDir = %q want %q", r.OutDir, wantOut)
+	}
+	if len(r.Manifests) != 1 {
+		t.Fatalf("manifests = %d, want 1", len(r.Manifests))
+	}
+
+	// The dep's namespace from its lock entry (dep-ns) drove its
+	// set-namespace function. Verify the rendered ConfigMap landed there.
+	cmPath := filepath.Join(wantOut, "manifests", "configmap-dep-ns-dep-cm.yaml")
+	body, err := os.ReadFile(cmPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", cmPath, err)
+	}
+	if !strings.Contains(string(body), "namespace: dep-ns") {
+		t.Errorf("dep namespace not applied:\n%s", body)
+	}
+
+	// The dep's spec dir should carry its own selection/inputs/function-chain.
+	for _, name := range []string{"selection.yaml", "inputs.yaml", "function-chain.yaml", "manifest-index.yaml"} {
+		if _, err := os.Stat(filepath.Join(wantOut, "spec", name)); err != nil {
+			t.Errorf("missing dep spec doc %s: %v", name, err)
+		}
+	}
+}
+
+func TestRenderDependenciesNamespaceFallbackToParent(t *testing.T) {
+	if _, err := exec.LookPath("kustomize"); err != nil {
+		t.Skip("kustomize not on PATH")
+	}
+	ctx := context.Background()
+	work := t.TempDir()
+
+	parentInputs := &api.Inputs{
+		APIVersion: api.APIVersion,
+		Kind:       api.KindInputs,
+		Spec:       api.InputsSpec{Package: "parent", Namespace: "parent-ns"},
+	}
+
+	lock := &api.Lock{
+		Spec: api.LockSpec{
+			Package: api.LockedPackage{Name: "parent"},
+			Resolved: []api.LockedDependency{{
+				Name:    "dep-one",
+				Ref:     "oci://test/dep:0.1.0",
+				Digest:  "sha256:" + strings.Repeat("b", 64),
+				Version: "0.1.0",
+				// No inputs.namespace — should fall back to parent's.
+			}},
+		},
+	}
+
+	results, err := render.RenderDependencies(ctx, render.DepsOptions{
+		Lock:         lock,
+		ParentInputs: parentInputs,
+		WorkDir:      work,
+		Fetcher: func(_ context.Context, _, _, destDir string) (string, error) {
+			return writeDepPackage(t, destDir), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("RenderDependencies: %v", err)
+	}
+	cmPath := filepath.Join(results[0].OutDir, "manifests", "configmap-parent-ns-dep-cm.yaml")
+	body, err := os.ReadFile(cmPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", cmPath, err)
+	}
+	if !strings.Contains(string(body), "namespace: parent-ns") {
+		t.Errorf("parent namespace not used as fallback:\n%s", body)
+	}
+}
+
+// TestRenderDependenciesDeterministic re-renders the same lock and verifies
+// every output file is byte-identical across runs — the acceptance criterion
+// for Phase 5.
+func TestRenderDependenciesDeterministic(t *testing.T) {
+	if _, err := exec.LookPath("kustomize"); err != nil {
+		t.Skip("kustomize not on PATH")
+	}
+	ctx := context.Background()
+	parentInputs := &api.Inputs{
+		APIVersion: api.APIVersion,
+		Kind:       api.KindInputs,
+		Spec:       api.InputsSpec{Package: "parent", Namespace: "demo"},
+	}
+	lock := &api.Lock{
+		Spec: api.LockSpec{
+			Package: api.LockedPackage{Name: "parent"},
+			Resolved: []api.LockedDependency{{
+				Name:    "dep-one",
+				Ref:     "oci://test/dep:0.1.0",
+				Digest:  "sha256:" + strings.Repeat("c", 64),
+				Version: "0.1.0",
+			}},
+		},
+	}
+	run := func() map[string]string {
+		work := t.TempDir()
+		_, err := render.RenderDependencies(ctx, render.DepsOptions{
+			Lock:         lock,
+			ParentInputs: parentInputs,
+			WorkDir:      work,
+			Fetcher: func(_ context.Context, _, _, destDir string) (string, error) {
+				return writeDepPackage(t, destDir), nil
+			},
+		})
+		if err != nil {
+			t.Fatalf("RenderDependencies: %v", err)
+		}
+		return collectHashes(t, filepath.Join(work, "out", "dep-one"))
+	}
+	a, b := run(), run()
+	if len(a) != len(b) {
+		t.Fatalf("file count differs: %d vs %d", len(a), len(b))
+	}
+	for name, ha := range a {
+		hb, ok := b[name]
+		if !ok {
+			t.Errorf("file %s present in run a, missing in run b", name)
+			continue
+		}
+		if ha != hb {
+			t.Errorf("digest mismatch for %s: %s vs %s", name, ha, hb)
+		}
+	}
+}
+
+// collectHashes returns rel-path → sha256 for every file under dir.
+func collectHashes(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(dir, path)
+		sum := sha256.Sum256(data)
+		out[rel] = hex.EncodeToString(sum[:])
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}

--- a/internal/sign/cosign_integration_test.go
+++ b/internal/sign/cosign_integration_test.go
@@ -1,0 +1,195 @@
+package sign_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	ipkg "github.com/confighubai/installer/internal/pkg"
+	"github.com/confighubai/installer/internal/sign"
+	"github.com/confighubai/installer/pkg/api"
+)
+
+// TestCosignSignAndVerify exercises the real cosign binary against a local
+// registry started by the test. Gated on:
+//
+//   - cosign binary on PATH
+//   - docker daemon on PATH and reachable
+//
+// Strategy:
+//   1. Spin up registry:2 on a free-ish port (5556 — distinct from the
+//      manual end-to-end registry on 5555).
+//   2. Push a minimal installer artifact via ipkg.Push.
+//   3. Generate a cosign key pair with empty password.
+//   4. Sign the artifact (keyed).
+//   5. Verify with the matching key — must succeed.
+//   6. Verify with a different key — must fail.
+//   7. EnforceVerification with a policy that lists the matching key —
+//      must succeed.
+//   8. EnforceVerification with a policy that lists only a different key —
+//      must fail.
+func TestCosignSignAndVerify(t *testing.T) {
+	if _, err := exec.LookPath("cosign"); err != nil {
+		t.Skip("cosign not on PATH")
+	}
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not on PATH")
+	}
+	if err := exec.Command("docker", "info").Run(); err != nil {
+		t.Skip("docker daemon not reachable")
+	}
+
+	const (
+		registryName     = "installer-cosign-test-registry"
+		registryAddr     = "localhost:5556"
+		artifactRepoPath = "test/sample"
+		artifactTag      = "0.1.0"
+	)
+	startRegistry(t, registryName, "5556")
+	t.Cleanup(func() { _ = exec.Command("docker", "rm", "-f", registryName).Run() })
+
+	// 2. Push a minimal package.
+	pkgRoot := writeMinimalPackage(t)
+	ctx := context.Background()
+	ref := "oci://" + registryAddr + "/" + artifactRepoPath + ":" + artifactTag
+	if _, err := ipkg.Push(ctx, pkgRoot, ref); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+
+	// 3. Generate a key pair (cosign).
+	keyDir := t.TempDir()
+	t.Setenv("COSIGN_PASSWORD", "")
+	runCosign(t, keyDir, "generate-key-pair")
+	priv := filepath.Join(keyDir, "cosign.key")
+	pub := filepath.Join(keyDir, "cosign.pub")
+	otherDir := t.TempDir()
+	runCosignDir(t, otherDir, []string{"generate-key-pair"})
+	otherPub := filepath.Join(otherDir, "cosign.pub")
+
+	// 4. Sign with the local registry's plain-HTTP option.
+	t.Setenv("COSIGN_ALLOW_INSECURE_REGISTRY", "true")
+	if err := sign.Sign(ctx, ref, sign.SignOptions{Key: priv, Yes: true}); err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	// 5. Verify with the matching public key — must succeed.
+	if err := sign.Verify(ctx, ref, sign.VerifyOptions{
+		TrustedKey: &api.TrustedKey{PublicKey: pub},
+	}); err != nil {
+		t.Fatalf("Verify with matching key should succeed: %v", err)
+	}
+
+	// 6. Verify with the other key — must fail.
+	if err := sign.Verify(ctx, ref, sign.VerifyOptions{
+		TrustedKey: &api.TrustedKey{PublicKey: otherPub},
+	}); err == nil {
+		t.Fatalf("Verify with wrong key should fail")
+	}
+
+	// 7. EnforceVerification with a policy that lists the matching key —
+	// must succeed.
+	policyDir := t.TempDir()
+	policyOK := filepath.Join(policyDir, "ok.yaml")
+	mustWrite(t, policyOK, fmt.Sprintf(`apiVersion: installer.confighub.com/v1alpha1
+kind: SigningPolicy
+spec:
+  enforce: true
+  trustedKeys:
+    - publicKey: %s
+`, pub))
+	t.Setenv(sign.EnvPolicyPath, policyOK)
+	if err := sign.EnforceVerification(ctx, ref); err != nil {
+		t.Fatalf("EnforceVerification(match) failed: %v", err)
+	}
+
+	// 8. EnforceVerification with a policy that lists only the wrong key
+	// — must fail.
+	policyBad := filepath.Join(policyDir, "bad.yaml")
+	mustWrite(t, policyBad, fmt.Sprintf(`apiVersion: installer.confighub.com/v1alpha1
+kind: SigningPolicy
+spec:
+  enforce: true
+  trustedKeys:
+    - publicKey: %s
+`, otherPub))
+	t.Setenv(sign.EnvPolicyPath, policyBad)
+	err := sign.EnforceVerification(ctx, ref)
+	if err == nil || !strings.Contains(err.Error(), "no trust entry verified") {
+		t.Fatalf("EnforceVerification(wrong-key) should fail, got %v", err)
+	}
+}
+
+// --- helpers --------------------------------------------------------------
+
+func startRegistry(t *testing.T, name, hostPort string) {
+	t.Helper()
+	_ = exec.Command("docker", "rm", "-f", name).Run()
+	if err := exec.Command("docker", "run", "-d", "--name", name, "-p", hostPort+":5000", "registry:2").Run(); err != nil {
+		t.Skipf("cannot start registry container: %v", err)
+	}
+	// Wait for the registry to be ready.
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get("http://localhost:" + hostPort + "/v2/")
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == 200 {
+				return
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("registry did not come up on :%s", hostPort)
+}
+
+func runCosign(t *testing.T, workDir string, args ...string) {
+	runCosignDir(t, workDir, args)
+}
+
+func runCosignDir(t *testing.T, workDir string, args []string) {
+	t.Helper()
+	cmd := exec.Command("cosign", args...)
+	cmd.Dir = workDir
+	cmd.Env = append(os.Environ(), "COSIGN_PASSWORD=")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("cosign %v: %v\n%s", args, err, out)
+	}
+}
+
+func writeMinimalPackage(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	must := func(p, c string) {
+		full := filepath.Join(dir, p)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(c), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	must("installer.yaml", `apiVersion: installer.confighub.com/v1alpha1
+kind: Package
+metadata: {name: signtest, version: 0.1.0}
+spec:
+  bases:
+    - {name: default, path: bases/default, default: true}
+`)
+	must("bases/default/kustomization.yaml", "resources:\n  - cm.yaml\n")
+	must("bases/default/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n")
+	return dir
+}
+
+func mustWrite(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/sign/sign.go
+++ b/internal/sign/sign.go
@@ -1,0 +1,245 @@
+// Package sign shells out to the cosign binary to sign and verify installer
+// OCI artifacts. Cosign's Go SDK is large and pulls a lot of sigstore
+// dependencies; for v1 we keep the installer binary small by invoking
+// cosign as an external process.
+//
+// Policy is loaded from ~/.config/installer/policy.yaml. When the file is
+// absent or Enforce is false, EnforceVerification is a no-op.
+package sign
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/confighubai/installer/pkg/api"
+)
+
+// Defaults
+const (
+	// DefaultPolicyPath is where LoadPolicy looks if no override is set.
+	DefaultPolicyPath = "~/.config/installer/policy.yaml"
+	// EnvPolicyPath overrides DefaultPolicyPath at runtime.
+	EnvPolicyPath = "INSTALLER_SIGNING_POLICY"
+	// EnvCosignBinary names the cosign binary; default "cosign".
+	EnvCosignBinary = "INSTALLER_COSIGN_BIN"
+)
+
+// SignOptions control Sign.
+type SignOptions struct {
+	// Key is the cosign key reference for keyed mode. Empty ⇒ keyless.
+	Key string
+	// Recursive signs every layer/manifest. Off by default for installer
+	// artifacts (single manifest is enough).
+	Recursive bool
+	// Yes suppresses the keyless TTY confirmation prompt. Matches
+	// `cosign sign --yes`.
+	Yes bool
+}
+
+// Sign attaches a cosign signature to ref. ref must be a digest-pinned or
+// tag-pinned reference; cosign resolves it. The cosign binary inherits the
+// caller's environment, so SIGSTORE_*, COSIGN_*, and OIDC tokens are
+// honored.
+func Sign(ctx context.Context, ref string, opts SignOptions) error {
+	bin := cosignBin()
+	if _, err := exec.LookPath(bin); err != nil {
+		return fmt.Errorf("cosign binary %q not found on PATH: %w", bin, err)
+	}
+	args := []string{"sign"}
+	if opts.Yes {
+		args = append(args, "--yes")
+	}
+	if opts.Recursive {
+		args = append(args, "--recursive")
+	}
+	if opts.Key != "" {
+		args = append(args, "--key", opts.Key)
+	}
+	args = append(args, refForCosign(ref))
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("cosign sign %s: %w", ref, err)
+	}
+	return nil
+}
+
+// VerifyOptions tune one Verify call. Caller usually loads a Policy and
+// passes the matching entries; for ad-hoc `installer verify`, a single
+// TrustedKey or TrustedKeyless is constructed from CLI flags.
+type VerifyOptions struct {
+	// TrustedKey forces a keyed verification against this public key.
+	TrustedKey *api.TrustedKey
+	// TrustedKeyless forces a keyless verification.
+	TrustedKeyless *api.TrustedKeyless
+}
+
+// Verify runs cosign verify with the given trust entry. Exactly one of
+// opts.TrustedKey or opts.TrustedKeyless must be set.
+func Verify(ctx context.Context, ref string, opts VerifyOptions) error {
+	if (opts.TrustedKey == nil) == (opts.TrustedKeyless == nil) {
+		return errors.New("Verify: exactly one of TrustedKey or TrustedKeyless must be set")
+	}
+	bin := cosignBin()
+	if _, err := exec.LookPath(bin); err != nil {
+		return fmt.Errorf("cosign binary %q not found on PATH: %w", bin, err)
+	}
+	args := []string{"verify"}
+	switch {
+	case opts.TrustedKey != nil:
+		args = append(args, "--key", opts.TrustedKey.PublicKey)
+	case opts.TrustedKeyless != nil:
+		args = append(args,
+			"--certificate-identity", opts.TrustedKeyless.Identity,
+			"--certificate-oidc-issuer", opts.TrustedKeyless.Issuer,
+		)
+	}
+	args = append(args, refForCosign(ref))
+	cmd := exec.CommandContext(ctx, bin, args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	// Discard stdout: cosign prints the verified-payload JSON which is
+	// noisy for our use case. We surface stderr on failure.
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("cosign verify: %w\n%s", err, stderr.String())
+	}
+	return nil
+}
+
+// EnforceVerification consults the loaded policy and verifies ref. If the
+// policy is absent, or Enforce is false, returns nil. Otherwise tries every
+// matching trust entry; succeeds on first match.
+func EnforceVerification(ctx context.Context, ref string) error {
+	p, err := LoadPolicy()
+	if err != nil {
+		return err
+	}
+	if p == nil || !p.Spec.Enforce {
+		return nil
+	}
+	keys, kls := matchEntries(p, ref)
+	if len(keys) == 0 && len(kls) == 0 {
+		return fmt.Errorf("signing policy enforces verification but no trust entry matches %s; add a TrustedKey/TrustedKeyless with this repo's prefix", ref)
+	}
+	var attempts []string
+	for _, k := range keys {
+		if err := Verify(ctx, ref, VerifyOptions{TrustedKey: &k}); err == nil {
+			return nil
+		} else {
+			attempts = append(attempts, fmt.Sprintf("trustedKey %s: %v", describeKey(k), err))
+		}
+	}
+	for _, k := range kls {
+		if err := Verify(ctx, ref, VerifyOptions{TrustedKeyless: &k}); err == nil {
+			return nil
+		} else {
+			attempts = append(attempts, fmt.Sprintf("trustedKeyless %s@%s: %v", k.Identity, k.Issuer, err))
+		}
+	}
+	return fmt.Errorf("no trust entry verified %s:\n  %s", ref, strings.Join(attempts, "\n  "))
+}
+
+// LoadPolicy reads the policy file. Returns (nil, nil) if the file is
+// absent. The path is taken from EnvPolicyPath if set, else
+// DefaultPolicyPath (tilde-expanded).
+func LoadPolicy() (*api.SigningPolicy, error) {
+	path := os.Getenv(EnvPolicyPath)
+	if path == "" {
+		expanded, err := expandTilde(DefaultPolicyPath)
+		if err != nil {
+			return nil, err
+		}
+		path = expanded
+	}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	return api.ParseSigningPolicy(data)
+}
+
+// matchEntries returns the subset of trust entries whose Repos prefix-list
+// matches ref (or is empty). ref's oci:// prefix is stripped before
+// matching.
+func matchEntries(p *api.SigningPolicy, ref string) ([]api.TrustedKey, []api.TrustedKeyless) {
+	bare := strings.TrimPrefix(ref, "oci://")
+	bare = stripTagAndDigest(bare)
+	var keys []api.TrustedKey
+	for _, k := range p.Spec.TrustedKeys {
+		if repoMatches(k.Repos, bare) {
+			keys = append(keys, k)
+		}
+	}
+	var kls []api.TrustedKeyless
+	for _, k := range p.Spec.TrustedKeyless {
+		if repoMatches(k.Repos, bare) {
+			kls = append(kls, k)
+		}
+	}
+	return keys, kls
+}
+
+func repoMatches(repos []string, bareRef string) bool {
+	if len(repos) == 0 {
+		return true
+	}
+	for _, r := range repos {
+		r = strings.TrimPrefix(r, "oci://")
+		if strings.HasPrefix(bareRef, r) {
+			return true
+		}
+	}
+	return false
+}
+
+// stripTagAndDigest removes both :tag and @digest suffixes from a bare
+// (oci://-less) ref so prefix matching operates on the repo only.
+func stripTagAndDigest(ref string) string {
+	if at := strings.LastIndex(ref, "@"); at >= 0 {
+		ref = ref[:at]
+	}
+	if colon := strings.LastIndex(ref, ":"); colon >= 0 && !strings.Contains(ref[colon:], "/") {
+		ref = ref[:colon]
+	}
+	return ref
+}
+
+func refForCosign(ref string) string {
+	return strings.TrimPrefix(ref, "oci://")
+}
+
+func cosignBin() string {
+	if b := os.Getenv(EnvCosignBinary); b != "" {
+		return b
+	}
+	return "cosign"
+}
+
+func describeKey(k api.TrustedKey) string {
+	if k.Description != "" {
+		return k.Description
+	}
+	return k.PublicKey
+}
+
+func expandTilde(p string) (string, error) {
+	if !strings.HasPrefix(p, "~/") {
+		return p, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, p[2:]), nil
+}

--- a/internal/sign/sign_test.go
+++ b/internal/sign/sign_test.go
@@ -1,0 +1,199 @@
+package sign
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confighubai/installer/pkg/api"
+)
+
+const policyYAML = `apiVersion: installer.confighub.com/v1alpha1
+kind: SigningPolicy
+spec:
+  enforce: true
+  trustedKeys:
+    - publicKey: /etc/keys/all.pub
+    - publicKey: /etc/keys/ghcr.pub
+      repos: [ghcr.io/confighubai]
+  trustedKeyless:
+    - identity: ops@confighub.com
+      issuer: https://accounts.google.com
+      repos: [oci://ghcr.io/confighubai]
+`
+
+const policyYAMLNoEnforce = `apiVersion: installer.confighub.com/v1alpha1
+kind: SigningPolicy
+spec:
+  enforce: false
+`
+
+const policyYAMLBadEnforceNoEntries = `apiVersion: installer.confighub.com/v1alpha1
+kind: SigningPolicy
+spec:
+  enforce: true
+`
+
+func TestLoadPolicy_Absent(t *testing.T) {
+	t.Setenv(EnvPolicyPath, filepath.Join(t.TempDir(), "missing.yaml"))
+	got, err := LoadPolicy()
+	if err != nil {
+		t.Fatalf("LoadPolicy: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil for absent policy file")
+	}
+}
+
+func TestLoadPolicy_Parsed(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "policy.yaml")
+	if err := os.WriteFile(p, []byte(policyYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(EnvPolicyPath, p)
+	got, err := LoadPolicy()
+	if err != nil {
+		t.Fatalf("LoadPolicy: %v", err)
+	}
+	if !got.Spec.Enforce {
+		t.Errorf("Enforce should be true")
+	}
+	if len(got.Spec.TrustedKeys) != 2 {
+		t.Errorf("got %d trusted keys", len(got.Spec.TrustedKeys))
+	}
+	if len(got.Spec.TrustedKeyless) != 1 {
+		t.Errorf("got %d keyless entries", len(got.Spec.TrustedKeyless))
+	}
+}
+
+func TestLoadPolicy_NoEnforce(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "policy.yaml")
+	if err := os.WriteFile(p, []byte(policyYAMLNoEnforce), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(EnvPolicyPath, p)
+	got, err := LoadPolicy()
+	if err != nil {
+		t.Fatalf("LoadPolicy: %v", err)
+	}
+	if got.Spec.Enforce {
+		t.Errorf("Enforce should be false")
+	}
+}
+
+func TestLoadPolicy_RejectsEnforceWithoutEntries(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "policy.yaml")
+	if err := os.WriteFile(p, []byte(policyYAMLBadEnforceNoEntries), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(EnvPolicyPath, p)
+	_, err := LoadPolicy()
+	if err == nil || !strings.Contains(err.Error(), "no trustedKeys") {
+		t.Fatalf("expected enforce-without-entries error, got %v", err)
+	}
+}
+
+func TestMatchEntries(t *testing.T) {
+	p := &api.SigningPolicy{
+		Spec: api.SigningPolicySpec{
+			Enforce: true,
+			TrustedKeys: []api.TrustedKey{
+				{PublicKey: "all.pub"},                                            // matches all
+				{PublicKey: "ghcr.pub", Repos: []string{"ghcr.io/confighubai"}},   // scoped
+				{PublicKey: "other.pub", Repos: []string{"docker.io/other"}},      // doesn't match
+			},
+			TrustedKeyless: []api.TrustedKeyless{
+				{Identity: "ops@ch", Issuer: "x", Repos: []string{"oci://ghcr.io/confighubai"}},
+			},
+		},
+	}
+	keys, kls := matchEntries(p, "oci://ghcr.io/confighubai/foo:v1@sha256:abc")
+	if len(keys) != 2 {
+		t.Errorf("expected 2 keys matched, got %d (%+v)", len(keys), keys)
+	}
+	if len(kls) != 1 {
+		t.Errorf("expected 1 keyless matched, got %d", len(kls))
+	}
+
+	// A different repo only matches the unrestricted key.
+	keys, kls = matchEntries(p, "oci://example.com/foo:v1")
+	if len(keys) != 1 || keys[0].PublicKey != "all.pub" {
+		t.Errorf("expected only all.pub, got %+v", keys)
+	}
+	if len(kls) != 0 {
+		t.Errorf("expected no keyless match, got %+v", kls)
+	}
+}
+
+func TestEnforceVerification_NoPolicy(t *testing.T) {
+	t.Setenv(EnvPolicyPath, filepath.Join(t.TempDir(), "absent.yaml"))
+	if err := EnforceVerification(t.Context(), "oci://anything:v1"); err != nil {
+		t.Fatalf("absent policy should be a no-op: %v", err)
+	}
+}
+
+func TestEnforceVerification_DisabledPolicy(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "policy.yaml")
+	if err := os.WriteFile(p, []byte(policyYAMLNoEnforce), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(EnvPolicyPath, p)
+	if err := EnforceVerification(t.Context(), "oci://anything:v1"); err != nil {
+		t.Fatalf("disabled policy should be a no-op: %v", err)
+	}
+}
+
+func TestEnforceVerification_NoMatchingEntry(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "policy.yaml")
+	if err := os.WriteFile(p, []byte(`apiVersion: installer.confighub.com/v1alpha1
+kind: SigningPolicy
+spec:
+  enforce: true
+  trustedKeys:
+    - publicKey: /x.pub
+      repos: [ghcr.io/confighubai]
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(EnvPolicyPath, p)
+	err := EnforceVerification(t.Context(), "oci://other.io/foo:v1")
+	if err == nil || !strings.Contains(err.Error(), "no trust entry matches") {
+		t.Fatalf("expected no-match error, got %v", err)
+	}
+}
+
+func TestStripTagAndDigest(t *testing.T) {
+	cases := map[string]string{
+		"ghcr.io/o/r:v1":                                                                          "ghcr.io/o/r",
+		"ghcr.io/o/r@sha256:abc":                                                                  "ghcr.io/o/r",
+		"ghcr.io/o/r:v1@sha256:abc":                                                               "ghcr.io/o/r",
+		"localhost:5555/o/r:v1":                                                                   "localhost:5555/o/r",
+		"localhost:5555/o/r":                                                                      "localhost:5555/o/r",
+	}
+	for in, want := range cases {
+		if got := stripTagAndDigest(in); got != want {
+			t.Errorf("stripTagAndDigest(%q) = %q want %q", in, got, want)
+		}
+	}
+}
+
+func TestExpandTilde(t *testing.T) {
+	got, err := expandTilde("~/foo/bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	home, _ := os.UserHomeDir()
+	if got != filepath.Join(home, "foo/bar") {
+		t.Errorf("expandTilde = %q", got)
+	}
+	// No tilde — returned as-is.
+	if got, _ := expandTilde("/abs/path"); got != "/abs/path" {
+		t.Errorf("non-tilde unchanged: %q", got)
+	}
+}

--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -1,0 +1,266 @@
+// Package upload turns a rendered work-dir into the inputs the cub CLI
+// needs to materialize ConfigHub Spaces, Units, and Links — without itself
+// shelling out. The CLI layer in internal/cli/upload.go orchestrates the
+// cub calls.
+//
+// Phase 6 wires this up:
+//   - One Space per package (parent + each locked dep).
+//   - One untargeted installer-record Unit per Space, holding installer.yaml
+//     + every file in that package's out/<pkg>/spec/ (plus the lock for the
+//     parent).
+//   - Cross-Space NeedsProvides links from the parent's record Unit to each
+//     dep's record Unit, derived from the lock.
+package upload
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/confighubai/installer/pkg/api"
+)
+
+// Package is one unit-of-upload — the parent or a locked dep.
+type Package struct {
+	// Name is metadata.name from installer.yaml.
+	Name string
+	// Version is metadata.version from installer.yaml.
+	Version string
+	// LocalHandle is the name the parent used for this dep in its
+	// installer.yaml + lock. Empty for the parent itself. Used to derive
+	// link slugs and to match dep packages back to lock entries.
+	LocalHandle string
+	// PackageDir is the directory containing installer.yaml.
+	PackageDir string
+	// ManifestsDir is where rendered per-resource YAML lives.
+	ManifestsDir string
+	// SpecDir is where this package's spec docs live (selection.yaml etc.).
+	SpecDir string
+	// SecretsDir is where rendered Secret YAML lives (never uploaded).
+	SecretsDir string
+	// SpaceSlug is the ConfigHub Space this package's Units land in.
+	SpaceSlug string
+	// IsParent is true for the root package; false for every dep.
+	IsParent bool
+}
+
+// Vars is the template-execution context for --space-pattern.
+type Vars struct {
+	PackageName    string
+	PackageVersion string
+	// Variant is reserved for the variant work (Phase 9+). Empty in v1.
+	Variant string
+}
+
+// RenderSpaceSlug expands pattern using vars. Templates have access to
+// PackageName, PackageVersion, and Variant. Returns the expanded slug,
+// stripped of whitespace.
+func RenderSpaceSlug(pattern string, vars Vars) (string, error) {
+	if pattern == "" {
+		return "", fmt.Errorf("empty --space-pattern")
+	}
+	tmpl, err := template.New("space").Option("missingkey=error").Parse(pattern)
+	if err != nil {
+		return "", fmt.Errorf("parse --space-pattern %q: %w", pattern, err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, vars); err != nil {
+		return "", fmt.Errorf("execute --space-pattern %q: %w", pattern, err)
+	}
+	slug := strings.TrimSpace(buf.String())
+	if slug == "" {
+		return "", fmt.Errorf("--space-pattern %q rendered to an empty slug for package %+v", pattern, vars)
+	}
+	return slug, nil
+}
+
+// DiscoverInput is what Discover needs to do its job. Caller supplies the
+// parent's already-loaded Package and Lock, plus the workDir and pattern.
+type DiscoverInput struct {
+	WorkDir       string
+	SpacePattern  string
+	ParentPackage *api.Package
+	Lock          *api.Lock // nil when the parent declares no Dependencies
+}
+
+// Discover walks the work-dir layout produced by Render and returns one
+// Package per source — the parent first, then each locked dep in lock
+// order. Each dep's installer.yaml is read from the vendor cache the
+// renderer populated at out/vendor/<name>@<version>/package/.
+func Discover(in DiscoverInput) ([]Package, error) {
+	if in.WorkDir == "" {
+		return nil, fmt.Errorf("WorkDir is required")
+	}
+	if in.ParentPackage == nil {
+		return nil, fmt.Errorf("ParentPackage is required")
+	}
+	pattern := in.SpacePattern
+	if pattern == "" {
+		pattern = "{{.PackageName}}"
+	}
+
+	out := []Package{}
+
+	parentSlug, err := RenderSpaceSlug(pattern, Vars{
+		PackageName:    in.ParentPackage.Metadata.Name,
+		PackageVersion: in.ParentPackage.Metadata.Version,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("parent space slug: %w", err)
+	}
+	out = append(out, Package{
+		Name:         in.ParentPackage.Metadata.Name,
+		Version:      in.ParentPackage.Metadata.Version,
+		PackageDir:   filepath.Join(in.WorkDir, "package"),
+		ManifestsDir: filepath.Join(in.WorkDir, "out", "manifests"),
+		SpecDir:      filepath.Join(in.WorkDir, "out", "spec"),
+		SecretsDir:   filepath.Join(in.WorkDir, "out", "secrets"),
+		SpaceSlug:    parentSlug,
+		IsParent:     true,
+	})
+
+	if in.Lock == nil {
+		return out, nil
+	}
+	for _, d := range in.Lock.Spec.Resolved {
+		vendor := filepath.Join(in.WorkDir, "out", "vendor", vendorSlug(d.Name, d.Version), "package")
+		if _, err := os.Stat(filepath.Join(vendor, "installer.yaml")); err != nil {
+			return nil, fmt.Errorf("dep %s vendor missing — run `installer render %s` first: %w", d.Name, in.WorkDir, err)
+		}
+		// Read just enough metadata. We pulled this dep ourselves, so the
+		// lock's Name/Version are authoritative; we still re-read
+		// installer.yaml so a future per-dep override (e.g., a renamed
+		// upstream package) is honored.
+		data, err := os.ReadFile(filepath.Join(vendor, "installer.yaml"))
+		if err != nil {
+			return nil, err
+		}
+		depPkg, err := api.ParsePackage(data)
+		if err != nil {
+			return nil, fmt.Errorf("parse dep %s installer.yaml: %w", d.Name, err)
+		}
+		slug, err := RenderSpaceSlug(pattern, Vars{
+			PackageName:    depPkg.Metadata.Name,
+			PackageVersion: depPkg.Metadata.Version,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("dep %s space slug: %w", d.Name, err)
+		}
+		out = append(out, Package{
+			Name:         depPkg.Metadata.Name,
+			Version:      depPkg.Metadata.Version,
+			LocalHandle:  d.Name,
+			PackageDir:   vendor,
+			ManifestsDir: filepath.Join(in.WorkDir, "out", d.Name, "manifests"),
+			SpecDir:      filepath.Join(in.WorkDir, "out", d.Name, "spec"),
+			SecretsDir:   filepath.Join(in.WorkDir, "out", d.Name, "secrets"),
+			SpaceSlug:    slug,
+			IsParent:     false,
+		})
+	}
+	return out, nil
+}
+
+// vendorSlug mirrors render.vendorSlug — duplicated to avoid an import
+// cycle. Keep in sync.
+func vendorSlug(name, version string) string {
+	if version == "" {
+		return name
+	}
+	return name + "@" + version
+}
+
+// InstallerRecordSlug is the conventional name for the per-Space Unit that
+// carries installer.yaml + spec docs (no Target). One per Space.
+const InstallerRecordSlug = "installer-record"
+
+// BuildInstallerRecord builds the multi-doc YAML body for the per-Space
+// installer-record Unit. The result is `installer.yaml` followed by every
+// YAML doc in pkg.SpecDir (in lexicographic order), separated by `---`.
+// Files outside spec/ are not included.
+func BuildInstallerRecord(pkg Package) ([]byte, error) {
+	paths := []string{filepath.Join(pkg.PackageDir, "installer.yaml")}
+	entries, err := os.ReadDir(pkg.SpecDir)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", pkg.SpecDir, err)
+	}
+	var specFiles []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		n := e.Name()
+		if !strings.HasSuffix(n, ".yaml") && !strings.HasSuffix(n, ".yml") {
+			continue
+		}
+		specFiles = append(specFiles, filepath.Join(pkg.SpecDir, n))
+	}
+	sort.Strings(specFiles)
+	paths = append(paths, specFiles...)
+
+	var buf bytes.Buffer
+	for i, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", p, err)
+		}
+		// Strip the BOM-style "---\n" header some YAML emitters leave at
+		// the front so the boundary marker we insert is the only one.
+		trimmed := bytes.TrimSpace(data)
+		trimmed = bytes.TrimPrefix(trimmed, []byte("---\n"))
+		trimmed = bytes.TrimSpace(trimmed)
+		if i > 0 {
+			buf.WriteString("---\n")
+		}
+		buf.Write(trimmed)
+		buf.WriteByte('\n')
+	}
+	return buf.Bytes(), nil
+}
+
+// CrossSpaceLink describes one parent-to-dep edge to materialize as a
+// ConfigHub Link spanning two Spaces. Both ends point at each Space's
+// installer-record Unit.
+type CrossSpaceLink struct {
+	// Slug is the link's deterministic slug, derived from the dep name.
+	Slug string
+	// FromSpace is the parent's Space; FromUnit is the parent's
+	// installer-record Unit slug.
+	FromSpace string
+	FromUnit  string
+	// ToSpace is the dep's Space; ToUnit is the dep's installer-record
+	// Unit slug.
+	ToSpace string
+	ToUnit  string
+	// Reason is the human-readable why (the dep's Name from the lock).
+	Reason string
+}
+
+// PlanCrossSpaceLinks builds the list of links to create from a discovered
+// package set. Packages must include the parent first; deps are matched by
+// LocalHandle.
+func PlanCrossSpaceLinks(packages []Package) []CrossSpaceLink {
+	if len(packages) < 2 {
+		return nil
+	}
+	if !packages[0].IsParent {
+		return nil
+	}
+	parent := packages[0]
+	var out []CrossSpaceLink
+	for _, dep := range packages[1:] {
+		out = append(out, CrossSpaceLink{
+			Slug:      "dep-" + dep.LocalHandle,
+			FromSpace: parent.SpaceSlug,
+			FromUnit:  InstallerRecordSlug,
+			ToSpace:   dep.SpaceSlug,
+			ToUnit:    InstallerRecordSlug,
+			Reason:    "depends on " + dep.LocalHandle,
+		})
+	}
+	return out
+}

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -1,0 +1,244 @@
+package upload
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confighubai/installer/pkg/api"
+)
+
+func TestRenderSpaceSlug(t *testing.T) {
+	cases := []struct {
+		pattern string
+		vars    Vars
+		want    string
+		wantErr bool
+	}{
+		{"{{.PackageName}}", Vars{PackageName: "foo"}, "foo", false},
+		{"{{.PackageName}}-{{.PackageVersion}}", Vars{PackageName: "foo", PackageVersion: "0.3.0"}, "foo-0.3.0", false},
+		{"prod-{{.PackageName}}", Vars{PackageName: "x"}, "prod-x", false},
+		{"", Vars{PackageName: "x"}, "", true},
+		{"{{.Bogus}}", Vars{PackageName: "x"}, "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.pattern, func(t *testing.T) {
+			got, err := RenderSpaceSlug(tc.pattern, tc.vars)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDiscoverParentOnly(t *testing.T) {
+	work := t.TempDir()
+	writeFile(t, filepath.Join(work, "package", "installer.yaml"), minimalParentYAML)
+	writeFile(t, filepath.Join(work, "package", "bases/default/kustomization.yaml"), "resources: []")
+	writeFile(t, filepath.Join(work, "out", "manifests", "x.yaml"), "kind: ConfigMap")
+	writeFile(t, filepath.Join(work, "out", "spec", "selection.yaml"), "kind: Selection")
+
+	parent, err := api.ParsePackage([]byte(minimalParentYAML))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	pkgs, err := Discover(DiscoverInput{
+		WorkDir:       work,
+		SpacePattern:  "{{.PackageName}}",
+		ParentPackage: parent,
+		Lock:          nil,
+	})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(pkgs) != 1 {
+		t.Fatalf("got %d packages, want 1", len(pkgs))
+	}
+	if !pkgs[0].IsParent || pkgs[0].SpaceSlug != "parent" {
+		t.Fatalf("parent mismatch: %+v", pkgs[0])
+	}
+}
+
+func TestDiscoverWithLock(t *testing.T) {
+	work := t.TempDir()
+	writeFile(t, filepath.Join(work, "package", "installer.yaml"), parentWithDepYAML)
+	writeFile(t, filepath.Join(work, "package", "bases/default/kustomization.yaml"), "resources: []")
+	// Vendor cache is keyed by the lock's local handle (matches what
+	// render.RenderDependencies writes), not by the dep's package name.
+	writeFile(t, filepath.Join(work, "out", "vendor", "dep-a@0.2.0", "package", "installer.yaml"), depPackageYAML)
+	writeFile(t, filepath.Join(work, "out", "vendor", "dep-a@0.2.0", "package", "bases/default/kustomization.yaml"), "resources: []")
+
+	parent, err := api.ParsePackage([]byte(parentWithDepYAML))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	lock := &api.Lock{
+		Spec: api.LockSpec{
+			Package: api.LockedPackage{Name: "parent", Version: "0.1.0"},
+			Resolved: []api.LockedDependency{{
+				Name:    "dep-a",
+				Ref:     "oci://reg/dep-pkg:0.2.0",
+				Version: "0.2.0",
+			}},
+		},
+	}
+	pkgs, err := Discover(DiscoverInput{
+		WorkDir:       work,
+		SpacePattern:  "{{.PackageName}}-{{.PackageVersion}}",
+		ParentPackage: parent,
+		Lock:          lock,
+	})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(pkgs) != 2 {
+		t.Fatalf("got %d packages, want 2", len(pkgs))
+	}
+	if pkgs[0].SpaceSlug != "parent-0.1.0" || !pkgs[0].IsParent {
+		t.Fatalf("parent mismatch: %+v", pkgs[0])
+	}
+	dep := pkgs[1]
+	if dep.SpaceSlug != "dep-pkg-0.2.0" || dep.IsParent {
+		t.Fatalf("dep mismatch: %+v", dep)
+	}
+	if dep.LocalHandle != "dep-a" {
+		t.Fatalf("LocalHandle = %q want dep-a", dep.LocalHandle)
+	}
+	wantManifests := filepath.Join(work, "out", "dep-a", "manifests")
+	if dep.ManifestsDir != wantManifests {
+		t.Fatalf("ManifestsDir = %q want %q", dep.ManifestsDir, wantManifests)
+	}
+}
+
+func TestDiscoverErrorOnMissingVendor(t *testing.T) {
+	work := t.TempDir()
+	writeFile(t, filepath.Join(work, "package", "installer.yaml"), parentWithDepYAML)
+	writeFile(t, filepath.Join(work, "package", "bases/default/kustomization.yaml"), "resources: []")
+	parent, _ := api.ParsePackage([]byte(parentWithDepYAML))
+	lock := &api.Lock{
+		Spec: api.LockSpec{
+			Package: api.LockedPackage{Name: "parent"},
+			Resolved: []api.LockedDependency{{Name: "dep-a", Ref: "oci://reg/dep-pkg:0.2.0", Version: "0.2.0"}},
+		},
+	}
+	_, err := Discover(DiscoverInput{WorkDir: work, ParentPackage: parent, Lock: lock})
+	if err == nil || !strings.Contains(err.Error(), "vendor missing") {
+		t.Fatalf("expected vendor-missing error, got %v", err)
+	}
+}
+
+func TestBuildInstallerRecord(t *testing.T) {
+	work := t.TempDir()
+	pkgDir := filepath.Join(work, "package")
+	specDir := filepath.Join(work, "out", "spec")
+	writeFile(t, filepath.Join(pkgDir, "installer.yaml"), minimalParentYAML)
+	writeFile(t, filepath.Join(specDir, "selection.yaml"), "kind: Selection\nmetadata: {name: x}\n")
+	writeFile(t, filepath.Join(specDir, "inputs.yaml"), "kind: Inputs\nmetadata: {name: y}\n")
+	writeFile(t, filepath.Join(specDir, "notes.txt"), "ignored")
+
+	body, err := BuildInstallerRecord(Package{
+		PackageDir: pkgDir,
+		SpecDir:    specDir,
+	})
+	if err != nil {
+		t.Fatalf("BuildInstallerRecord: %v", err)
+	}
+	docs := strings.Split(string(body), "\n---\n")
+	if len(docs) != 3 {
+		t.Fatalf("got %d docs, want 3 (installer.yaml + 2 spec files): \n%s", len(docs), body)
+	}
+	if !strings.Contains(docs[0], "kind: Package") {
+		t.Errorf("first doc should be Package: %s", docs[0])
+	}
+	// Sorted by filename within spec/: inputs.yaml before selection.yaml.
+	if !strings.Contains(docs[1], "kind: Inputs") {
+		t.Errorf("second doc should be Inputs (sorted): %s", docs[1])
+	}
+	if !strings.Contains(docs[2], "kind: Selection") {
+		t.Errorf("third doc should be Selection: %s", docs[2])
+	}
+	// Non-YAML files are ignored.
+	if strings.Contains(string(body), "ignored") {
+		t.Errorf("notes.txt should have been filtered out")
+	}
+}
+
+func TestPlanCrossSpaceLinks(t *testing.T) {
+	packages := []Package{
+		{Name: "parent", SpaceSlug: "parent-space", IsParent: true},
+		{Name: "dep-pkg-a", LocalHandle: "dep-a", SpaceSlug: "dep-pkg-a-space"},
+		{Name: "dep-pkg-b", LocalHandle: "dep-b", SpaceSlug: "dep-pkg-b-space"},
+	}
+	links := PlanCrossSpaceLinks(packages)
+	if len(links) != 2 {
+		t.Fatalf("got %d links, want 2", len(links))
+	}
+	if links[0].Slug != "dep-dep-a" {
+		t.Errorf("link[0].Slug = %q", links[0].Slug)
+	}
+	if links[0].FromSpace != "parent-space" || links[0].ToSpace != "dep-pkg-a-space" {
+		t.Errorf("link[0] spaces wrong: %+v", links[0])
+	}
+	if links[0].FromUnit != InstallerRecordSlug || links[0].ToUnit != InstallerRecordSlug {
+		t.Errorf("link[0] units should be the record slug: %+v", links[0])
+	}
+}
+
+func TestPlanCrossSpaceLinksEmpty(t *testing.T) {
+	if got := PlanCrossSpaceLinks([]Package{{Name: "p", IsParent: true}}); got != nil {
+		t.Fatalf("parent-only should produce no links, got %v", got)
+	}
+	if got := PlanCrossSpaceLinks(nil); got != nil {
+		t.Fatalf("nil should produce no links")
+	}
+}
+
+// --- fixtures + helpers --------------------------------------------------
+
+const minimalParentYAML = `apiVersion: installer.confighub.com/v1alpha1
+kind: Package
+metadata: {name: parent, version: 0.1.0}
+spec:
+  bases:
+    - {name: default, path: bases/default, default: true}
+`
+
+const parentWithDepYAML = `apiVersion: installer.confighub.com/v1alpha1
+kind: Package
+metadata: {name: parent, version: 0.1.0}
+spec:
+  bases:
+    - {name: default, path: bases/default, default: true}
+  dependencies:
+    - name: dep-a
+      package: oci://reg/dep-pkg
+      version: "^0.2.0"
+`
+
+const depPackageYAML = `apiVersion: installer.confighub.com/v1alpha1
+kind: Package
+metadata: {name: dep-pkg, version: 0.2.0}
+spec:
+  bases:
+    - {name: default, path: bases/default, default: true}
+`
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,9 @@
+// Package version exposes the installer build version. The default is "dev";
+// release builds set it via -ldflags:
+//
+//	go build -ldflags "-X github.com/confighubai/installer/internal/version.Version=0.4.0" ./cmd/installer
+package version
+
+// Version is overridden at build time. Recorded in ConfigBlob.BundleInfo so
+// each artifact carries the installer that produced it.
+var Version = "dev"

--- a/pkg/api/configblob.go
+++ b/pkg/api/configblob.go
@@ -1,0 +1,30 @@
+package api
+
+// ConfigBlob is the JSON-encoded config blob attached to a native installer
+// OCI artifact. It holds enough metadata for the resolver and `installer
+// inspect` to operate without pulling the layer.
+//
+// Field naming uses JSON tags only — the blob is always serialized as JSON
+// (mediaType ConfigMediaType).
+type ConfigBlob struct {
+	Bundle   BundleInfo `json:"bundle"`
+	Manifest *Package   `json:"manifest"`
+}
+
+// BundleInfo is the computed-at-bundle-time header.
+type BundleInfo struct {
+	// InstallerVersion is the version of the installer CLI that produced
+	// this artifact (from internal/version.Version).
+	InstallerVersion string `json:"installerVersion,omitempty"`
+
+	// LayerDigest is the sha256 digest of the package .tgz, in the
+	// "sha256:<hex>" form. Matches the layer descriptor's Digest.
+	LayerDigest string `json:"layerDigest"`
+
+	// LayerSize is the size in bytes of the package .tgz.
+	LayerSize int64 `json:"layerSize"`
+
+	// Files is the list of paths in the .tgz, in tar order (sorted). Useful
+	// for `installer inspect` and for resolver sanity checks.
+	Files []string `json:"files"`
+}

--- a/pkg/api/dependency.go
+++ b/pkg/api/dependency.go
@@ -1,0 +1,74 @@
+package api
+
+// Dependency declares another installer package this package composes with.
+// Multiple parents may request the same dependency; the resolver picks one
+// version satisfying every constraint, with conflicts/replaces honored.
+//
+// Phase 3 is parse-only — these fields are validated structurally but not
+// acted upon. The Phase 4 resolver consumes them.
+type Dependency struct {
+	// Name is the local handle for this dependency within the parent
+	// package. Used in lock files and error messages. Must be unique within
+	// a package's Dependencies list.
+	Name string `yaml:"name" json:"name"`
+
+	// Package is the OCI ref (oci://host/repo) without a tag — the
+	// resolver picks the tag matching Version.
+	Package string `yaml:"package" json:"package"`
+
+	// Version is a SemVer range expression (e.g. "^1.2.0", ">= 0.3, < 0.5",
+	// "*"). Empty means "any version".
+	Version string `yaml:"version,omitempty" json:"version,omitempty"`
+
+	// Selection pre-answers the dep's wizard. If nil, the dep's defaults
+	// apply.
+	Selection *DependencySelection `yaml:"selection,omitempty" json:"selection,omitempty"`
+
+	// Inputs pre-answers the dep's wizard prompts (input name → value).
+	Inputs map[string]any `yaml:"inputs,omitempty" json:"inputs,omitempty"`
+
+	// Optional, when true, makes this dependency conditional on
+	// WhenComponent being selected in the parent's Selection. Optional
+	// without WhenComponent means the dep is followed if no parent
+	// component disables it (today: always followed; reserved for future
+	// nuance).
+	Optional bool `yaml:"optional,omitempty" json:"optional,omitempty"`
+
+	// WhenComponent names a parent Component whose selection turns this
+	// dependency on. Mirrors Helm subchart conditions and Debian Recommends.
+	WhenComponent string `yaml:"whenComponent,omitempty" json:"whenComponent,omitempty"`
+
+	// Satisfies lists ExternalRequire entries from the parent's package
+	// that this dependency provides. Lets the resolver mark
+	// externalRequires as covered without a separate cluster probe.
+	Satisfies []ExternalRequire `yaml:"satisfies,omitempty" json:"satisfies,omitempty"`
+}
+
+// DependencySelection is the parent-visible part of a child package's
+// Selection — base and components only. The full Selection adds metadata
+// the resolver fills in (package name, version), so DependencySelection
+// keeps the authored surface small.
+type DependencySelection struct {
+	Base       string   `yaml:"base,omitempty" json:"base,omitempty"`
+	Components []string `yaml:"components,omitempty" json:"components,omitempty"`
+}
+
+// ConflictRef hard-excludes a package from the resolution set. The
+// resolver fails if any dependency (direct or transitive) names a package
+// matching one of these entries.
+type ConflictRef struct {
+	// Package is the OCI ref (oci://host/repo) of the excluded package.
+	Package string `yaml:"package" json:"package"`
+	// Version is a SemVer range; empty or "*" matches any version.
+	Version string `yaml:"version,omitempty" json:"version,omitempty"`
+	// Reason is shown in resolver error messages.
+	Reason string `yaml:"reason,omitempty" json:"reason,omitempty"`
+}
+
+// ReplaceRef declares that this package supersedes another. The resolver
+// treats a dependency on the named package matching the version range as
+// satisfied by the package declaring the replacement.
+type ReplaceRef struct {
+	Package string `yaml:"package" json:"package"`
+	Version string `yaml:"version,omitempty" json:"version,omitempty"`
+}

--- a/pkg/api/doc.go
+++ b/pkg/api/doc.go
@@ -19,14 +19,22 @@ const (
 	KindSelection     = "Selection"
 	KindFunctionChain = "FunctionChain"
 	KindFacts         = "Facts"
+	KindLock          = "Lock"
 )
 
 // Metadata is the common metadata block on every installer doc.
+//
+// KubeVersion and InstallerVersion are only meaningful on a Package, but
+// live here so the same block round-trips through MarshalYAML for every
+// kind. Both are SemVer range strings (e.g. ">= 1.28"); empty means
+// unconstrained.
 type Metadata struct {
-	Name        string            `yaml:"name" json:"name"`
-	Version     string            `yaml:"version,omitempty" json:"version,omitempty"`
-	Labels      map[string]string `yaml:"labels,omitempty" json:"labels,omitempty"`
-	Annotations map[string]string `yaml:"annotations,omitempty" json:"annotations,omitempty"`
+	Name             string            `yaml:"name" json:"name"`
+	Version          string            `yaml:"version,omitempty" json:"version,omitempty"`
+	KubeVersion      string            `yaml:"kubeVersion,omitempty" json:"kubeVersion,omitempty"`
+	InstallerVersion string            `yaml:"installerVersion,omitempty" json:"installerVersion,omitempty"`
+	Labels           map[string]string `yaml:"labels,omitempty" json:"labels,omitempty"`
+	Annotations      map[string]string `yaml:"annotations,omitempty" json:"annotations,omitempty"`
 }
 
 // Header pairs APIVersion + Kind for sniffing.

--- a/pkg/api/lock.go
+++ b/pkg/api/lock.go
@@ -1,0 +1,62 @@
+package api
+
+// Lock pins every dependency of a package to a specific OCI digest. The
+// resolver (Phase 4) writes one Lock as <work-dir>/out/spec/lock.yaml; the
+// renderer (Phase 5) reads it and refuses to proceed if stale.
+//
+// The lock is also embedded in the parent's installer-record Unit on upload
+// (Phase 6), so each rendered package's ConfigHub Space carries enough
+// metadata to reproduce its own render — without keeping a separate file
+// under version control.
+type Lock struct {
+	APIVersion string   `yaml:"apiVersion" json:"apiVersion"`
+	Kind       string   `yaml:"kind" json:"kind"`
+	Metadata   Metadata `yaml:"metadata" json:"metadata"`
+	Spec       LockSpec `yaml:"spec" json:"spec"`
+}
+
+type LockSpec struct {
+	// Package identifies the root package this lock was generated for.
+	Package LockedPackage `yaml:"package" json:"package"`
+
+	// Resolved is the dependency DAG in topological order: parents before
+	// children. Each entry records the OCI ref + digest the resolver chose.
+	Resolved []LockedDependency `yaml:"resolved,omitempty" json:"resolved,omitempty"`
+}
+
+// LockedPackage describes the root package the lock was computed against.
+type LockedPackage struct {
+	Name    string `yaml:"name" json:"name"`
+	Version string `yaml:"version,omitempty" json:"version,omitempty"`
+	// Digest is the OCI manifest digest of the root package, if it was
+	// pulled from a registry. Empty for in-tree (un-published) root
+	// packages, which is the common case during authoring.
+	Digest string `yaml:"digest,omitempty" json:"digest,omitempty"`
+}
+
+// LockedDependency pins one resolved dependency.
+type LockedDependency struct {
+	// Name matches the Dependency.Name from the parent's installer.yaml.
+	Name string `yaml:"name" json:"name"`
+
+	// Ref is the full pinned OCI ref the resolver chose, including tag.
+	// Example: oci://ghcr.io/confighubai/gateway-api:1.4.2
+	Ref string `yaml:"ref" json:"ref"`
+
+	// Digest is the sha256:<hex> of the manifest at Ref. The renderer
+	// re-verifies the digest at fetch time so retagging upstream cannot
+	// silently change the resolved content.
+	Digest string `yaml:"digest" json:"digest"`
+
+	// Version is the resolved SemVer string (without any range operator).
+	Version string `yaml:"version,omitempty" json:"version,omitempty"`
+
+	// RequestedBy lists the names of parents that requested this
+	// dependency (transitively). The root is named "root".
+	RequestedBy []string `yaml:"requestedBy,omitempty" json:"requestedBy,omitempty"`
+
+	// Selection and Inputs are the pre-answers the resolver passed down
+	// (merged across multiple parents requesting the same dep).
+	Selection *DependencySelection `yaml:"selection,omitempty" json:"selection,omitempty"`
+	Inputs    map[string]any       `yaml:"inputs,omitempty" json:"inputs,omitempty"`
+}

--- a/pkg/api/oci.go
+++ b/pkg/api/oci.go
@@ -1,0 +1,38 @@
+package api
+
+// OCI media types and annotation keys for native installer artifacts.
+//
+// An installer artifact is a single-layer OCI image manifest where:
+//   - ArtifactType discriminates the artifact from Helm OCI charts and other
+//     unrelated artifacts in the same registry,
+//   - the config blob (ConfigMediaType) carries enough metadata for the
+//     resolver and `installer inspect` to operate without pulling the layer,
+//   - the single layer (LayerMediaType) is the deterministic .tgz produced by
+//     internal/bundle.
+const (
+	// ArtifactType is the OCI artifactType set on the image manifest for
+	// native installer packages.
+	ArtifactType = "application/vnd.confighub.installer.package.v1+json"
+
+	// ConfigMediaType is the media type of the config blob (a JSON-encoded
+	// ConfigBlob document).
+	ConfigMediaType = "application/vnd.confighub.installer.package.config.v1+json"
+
+	// LayerMediaType is the media type of the single .tgz layer.
+	LayerMediaType = "application/vnd.confighub.installer.package.tar+gzip"
+)
+
+// OCI manifest annotation keys for installer-specific metadata. These mirror
+// fields in ConfigBlob so registry-listing UIs can show name/version without
+// fetching the config blob.
+const (
+	AnnotationName             = "installer.confighub.com/name"
+	AnnotationVersion          = "installer.confighub.com/version"
+	AnnotationKubeVersion      = "installer.confighub.com/kube-version"
+	AnnotationInstallerVersion = "installer.confighub.com/installer-version"
+)
+
+// LayerTitle is the file/directory name set on the layer descriptor's
+// org.opencontainers.image.title annotation. Combined with the file store's
+// unpack annotation, this becomes the subdirectory name when pulling.
+const LayerTitle = "package"

--- a/pkg/api/package.go
+++ b/pkg/api/package.go
@@ -71,6 +71,27 @@ type PackageSpec struct {
 	// group is executed by funcimpl.NewStandardExecutor with its own toolchain
 	// and whereResource filter, output of each group feeding the next.
 	FunctionChainTemplate []FunctionGroup `yaml:"functionChainTemplate,omitempty" json:"functionChainTemplate,omitempty"`
+
+	// Dependencies declares other installer packages this package composes
+	// with. Each entry pins an OCI ref + SemVer constraint; the resolver
+	// (Phase 4) walks the DAG and writes out/spec/lock.yaml. Parse-only in
+	// Phase 3 — wizard, render, and upload ignore this field.
+	Dependencies []Dependency `yaml:"dependencies,omitempty" json:"dependencies,omitempty"`
+
+	// Conflicts hard-excludes other packages from the resolution set.
+	// Mirrors Debian's Conflicts:.
+	Conflicts []ConflictRef `yaml:"conflicts,omitempty" json:"conflicts,omitempty"`
+
+	// Replaces declares packages this one supersedes (typically across a
+	// rename). The resolver treats a request for a Replaces[i].Package
+	// matching the version range as satisfied by this package. Mirrors
+	// Debian's Replaces:.
+	Replaces []ReplaceRef `yaml:"replaces,omitempty" json:"replaces,omitempty"`
+
+	// BundleExamples controls whether the examples/ subtree is included by
+	// `installer package`. Default behavior (when nil) is true — examples
+	// are bundled. Set to false to exclude them from published artifacts.
+	BundleExamples *bool `yaml:"bundleExamples,omitempty" json:"bundleExamples,omitempty"`
 }
 
 type Base struct {

--- a/pkg/api/parse.go
+++ b/pkg/api/parse.go
@@ -117,6 +117,34 @@ func ParseLock(data []byte) (*Lock, error) {
 	return &l, nil
 }
 
+// ParseSigningPolicy parses ~/.config/installer/policy.yaml.
+func ParseSigningPolicy(data []byte) (*SigningPolicy, error) {
+	var p SigningPolicy
+	if err := yaml.Unmarshal(data, &p); err != nil {
+		return nil, fmt.Errorf("parse SigningPolicy: %w", err)
+	}
+	if p.Kind != "" && p.Kind != KindSigningPolicy {
+		return nil, fmt.Errorf("unexpected kind %q (want %q)", p.Kind, KindSigningPolicy)
+	}
+	if p.Spec.Enforce && len(p.Spec.TrustedKeys) == 0 && len(p.Spec.TrustedKeyless) == 0 {
+		return nil, fmt.Errorf("SigningPolicy enforces verification but has no trustedKeys or trustedKeyless entries")
+	}
+	for i, k := range p.Spec.TrustedKeys {
+		if k.PublicKey == "" {
+			return nil, fmt.Errorf("spec.trustedKeys[%d]: publicKey is required", i)
+		}
+	}
+	for i, k := range p.Spec.TrustedKeyless {
+		if k.Identity == "" {
+			return nil, fmt.Errorf("spec.trustedKeyless[%d]: identity is required", i)
+		}
+		if k.Issuer == "" {
+			return nil, fmt.Errorf("spec.trustedKeyless[%d]: issuer is required", i)
+		}
+	}
+	return &p, nil
+}
+
 // ParseSelection parses selection.yaml bytes into a Selection.
 func ParseSelection(data []byte) (*Selection, error) {
 	var s Selection

--- a/pkg/api/parse.go
+++ b/pkg/api/parse.go
@@ -49,7 +49,72 @@ func ParsePackage(data []byte) (*Package, error) {
 	if defaults > 1 {
 		return nil, fmt.Errorf("only one base may set default: true")
 	}
+	if err := validateDependencies(&p); err != nil {
+		return nil, err
+	}
+	if err := validateConflictReplaces(&p); err != nil {
+		return nil, err
+	}
 	return &p, nil
+}
+
+// validateDependencies enforces structural rules on spec.dependencies:
+// names are required and unique, package is required, WhenComponent (if
+// set) must reference a declared Component.
+func validateDependencies(p *Package) error {
+	if len(p.Spec.Dependencies) == 0 {
+		return nil
+	}
+	componentNames := make(map[string]struct{}, len(p.Spec.Components))
+	for _, c := range p.Spec.Components {
+		componentNames[c.Name] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(p.Spec.Dependencies))
+	for i, d := range p.Spec.Dependencies {
+		where := fmt.Sprintf("spec.dependencies[%d]", i)
+		if d.Name == "" {
+			return fmt.Errorf("%s: name is required", where)
+		}
+		if d.Package == "" {
+			return fmt.Errorf("%s (%s): package is required", where, d.Name)
+		}
+		if _, dup := seen[d.Name]; dup {
+			return fmt.Errorf("%s: duplicate dependency name %q", where, d.Name)
+		}
+		seen[d.Name] = struct{}{}
+		if d.WhenComponent != "" {
+			if _, ok := componentNames[d.WhenComponent]; !ok {
+				return fmt.Errorf("%s (%s): whenComponent %q does not match any declared component", where, d.Name, d.WhenComponent)
+			}
+		}
+	}
+	return nil
+}
+
+func validateConflictReplaces(p *Package) error {
+	for i, c := range p.Spec.Conflicts {
+		if c.Package == "" {
+			return fmt.Errorf("spec.conflicts[%d]: package is required", i)
+		}
+	}
+	for i, r := range p.Spec.Replaces {
+		if r.Package == "" {
+			return fmt.Errorf("spec.replaces[%d]: package is required", i)
+		}
+	}
+	return nil
+}
+
+// ParseLock parses lock.yaml bytes into a Lock.
+func ParseLock(data []byte) (*Lock, error) {
+	var l Lock
+	if err := yaml.Unmarshal(data, &l); err != nil {
+		return nil, fmt.Errorf("parse Lock: %w", err)
+	}
+	if l.Kind != "" && l.Kind != KindLock {
+		return nil, fmt.Errorf("unexpected kind %q (want %q)", l.Kind, KindLock)
+	}
+	return &l, nil
 }
 
 // ParseSelection parses selection.yaml bytes into a Selection.

--- a/pkg/api/parse_test.go
+++ b/pkg/api/parse_test.go
@@ -105,6 +105,154 @@ metadata:
 	}
 }
 
+const validPackageWithDeps = `apiVersion: installer.confighub.com/v1alpha1
+kind: Package
+metadata:
+  name: stack
+  version: 0.3.0
+  kubeVersion: ">= 1.28"
+  installerVersion: ">= 0.2.0"
+spec:
+  bases:
+    - {name: default, path: bases/default, default: true}
+  components:
+    - {name: ingress, path: components/ingress}
+  dependencies:
+    - name: gateway-api
+      package: oci://ghcr.io/confighubai/gateway-api
+      version: "^1.2.0"
+      selection:
+        base: default
+        components: [crds, kgateway]
+      inputs:
+        namespace: gateway-system
+      whenComponent: ingress
+      satisfies:
+        - {kind: CRD, name: gateway.networking.k8s.io}
+        - {kind: GatewayClass, capability: ext-proc}
+    - name: cert-manager
+      package: oci://ghcr.io/confighubai/cert-manager
+      version: ">= 1.15.0"
+      optional: true
+  conflicts:
+    - {package: oci://ghcr.io/foo/old-gateway, version: "*"}
+  replaces:
+    - {package: oci://ghcr.io/foo/old-name, version: "< 2.0.0"}
+  bundleExamples: false
+  functionChainTemplate:
+    - toolchain: Kubernetes/YAML
+      whereResource: ""
+      invocations:
+        - name: set-namespace
+          args: ["test"]
+`
+
+func TestParsePackageWithDeps(t *testing.T) {
+	p, err := api.ParsePackage([]byte(validPackageWithDeps))
+	if err != nil {
+		t.Fatalf("ParsePackage: %v", err)
+	}
+	if p.Metadata.KubeVersion != ">= 1.28" {
+		t.Errorf("kubeVersion = %q", p.Metadata.KubeVersion)
+	}
+	if p.Metadata.InstallerVersion != ">= 0.2.0" {
+		t.Errorf("installerVersion = %q", p.Metadata.InstallerVersion)
+	}
+	if len(p.Spec.Dependencies) != 2 {
+		t.Fatalf("dependencies = %d, want 2", len(p.Spec.Dependencies))
+	}
+	d := p.Spec.Dependencies[0]
+	if d.Name != "gateway-api" || d.Version != "^1.2.0" {
+		t.Errorf("dep[0] mismatch: %+v", d)
+	}
+	if d.Selection == nil || d.Selection.Base != "default" || len(d.Selection.Components) != 2 {
+		t.Errorf("dep[0].selection mismatch: %+v", d.Selection)
+	}
+	if d.Inputs["namespace"] != "gateway-system" {
+		t.Errorf("dep[0].inputs mismatch: %+v", d.Inputs)
+	}
+	if d.WhenComponent != "ingress" {
+		t.Errorf("dep[0].whenComponent = %q", d.WhenComponent)
+	}
+	if len(d.Satisfies) != 2 {
+		t.Errorf("dep[0].satisfies count = %d", len(d.Satisfies))
+	}
+	if !p.Spec.Dependencies[1].Optional {
+		t.Errorf("dep[1].optional should be true")
+	}
+	if len(p.Spec.Conflicts) != 1 || p.Spec.Conflicts[0].Package == "" {
+		t.Errorf("conflicts mismatch: %+v", p.Spec.Conflicts)
+	}
+	if len(p.Spec.Replaces) != 1 || p.Spec.Replaces[0].Version != "< 2.0.0" {
+		t.Errorf("replaces mismatch: %+v", p.Spec.Replaces)
+	}
+	if p.Spec.BundleExamples == nil || *p.Spec.BundleExamples != false {
+		t.Errorf("bundleExamples should be false")
+	}
+}
+
+func TestParsePackageRejectsDuplicateDepName(t *testing.T) {
+	bad := strings.Replace(validPackageWithDeps, "    - name: cert-manager", "    - name: gateway-api", 1)
+	_, err := api.ParsePackage([]byte(bad))
+	if err == nil || !strings.Contains(err.Error(), "duplicate dependency name") {
+		t.Fatalf("expected duplicate-name error, got %v", err)
+	}
+}
+
+func TestParsePackageRejectsDepMissingFields(t *testing.T) {
+	missingPackage := `apiVersion: installer.confighub.com/v1alpha1
+kind: Package
+metadata: {name: t}
+spec:
+  bases: [{name: default, path: bases/default, default: true}]
+  dependencies:
+    - name: foo
+`
+	_, err := api.ParsePackage([]byte(missingPackage))
+	if err == nil || !strings.Contains(err.Error(), "package is required") {
+		t.Fatalf("expected package-required error, got %v", err)
+	}
+}
+
+func TestParsePackageRejectsBadWhenComponent(t *testing.T) {
+	bad := strings.Replace(validPackageWithDeps, "whenComponent: ingress", "whenComponent: nope", 1)
+	_, err := api.ParsePackage([]byte(bad))
+	if err == nil || !strings.Contains(err.Error(), "whenComponent") {
+		t.Fatalf("expected whenComponent error, got %v", err)
+	}
+}
+
+func TestParseLock(t *testing.T) {
+	lockYAML := `apiVersion: installer.confighub.com/v1alpha1
+kind: Lock
+metadata:
+  name: stack
+spec:
+  package:
+    name: stack
+    version: 0.3.0
+  resolved:
+    - name: gateway-api
+      ref: oci://ghcr.io/confighubai/gateway-api:1.4.2
+      digest: sha256:bbbbbbbb
+      version: 1.4.2
+      requestedBy: [root]
+      selection:
+        base: default
+        components: [crds]
+`
+	l, err := api.ParseLock([]byte(lockYAML))
+	if err != nil {
+		t.Fatalf("ParseLock: %v", err)
+	}
+	if l.Spec.Package.Name != "stack" {
+		t.Errorf("package.name = %q", l.Spec.Package.Name)
+	}
+	if len(l.Spec.Resolved) != 1 || l.Spec.Resolved[0].Digest != "sha256:bbbbbbbb" {
+		t.Errorf("resolved mismatch: %+v", l.Spec.Resolved)
+	}
+}
+
 func TestMarshalRoundTrip(t *testing.T) {
 	sel := &api.Selection{
 		APIVersion: api.APIVersion,

--- a/pkg/api/policy.go
+++ b/pkg/api/policy.go
@@ -1,0 +1,57 @@
+package api
+
+// SigningPolicy declares which signatures the installer trusts when
+// verifying OCI artifacts on pull / deps update. The file lives at
+// ~/.config/installer/policy.yaml. Absent file ⇒ no verification.
+//
+// When Enforce is true and a ref's signature does not satisfy at least one
+// entry in TrustedKeys or TrustedKeyless, the operation fails.
+type SigningPolicy struct {
+	APIVersion string            `yaml:"apiVersion" json:"apiVersion"`
+	Kind       string            `yaml:"kind" json:"kind"`
+	Metadata   Metadata          `yaml:"metadata,omitempty" json:"metadata,omitempty"`
+	Spec       SigningPolicySpec `yaml:"spec" json:"spec"`
+}
+
+const KindSigningPolicy = "SigningPolicy"
+
+type SigningPolicySpec struct {
+	// Enforce, when true, makes pull/deps update fail on unverified
+	// artifacts. When false, the policy is treated as advisory:
+	// `installer verify` still works, but pull and deps update do not
+	// gate on it.
+	Enforce bool `yaml:"enforce" json:"enforce"`
+
+	// TrustedKeys lists cosign public-key entries.
+	TrustedKeys []TrustedKey `yaml:"trustedKeys,omitempty" json:"trustedKeys,omitempty"`
+
+	// TrustedKeyless lists Sigstore-keyless identity entries (Fulcio
+	// certificate identity + OIDC issuer).
+	TrustedKeyless []TrustedKeyless `yaml:"trustedKeyless,omitempty" json:"trustedKeyless,omitempty"`
+}
+
+// TrustedKey points at a cosign-compatible public key.
+type TrustedKey struct {
+	// PublicKey is the path on disk OR a cosign key reference
+	// (k8s://, awskms://, etc.) passed verbatim to `cosign verify --key`.
+	PublicKey string `yaml:"publicKey" json:"publicKey"`
+	// Repos optionally scopes this key to specific OCI repos. Each entry
+	// is matched as a prefix (no globs in v1). Empty = matches all repos.
+	Repos []string `yaml:"repos,omitempty" json:"repos,omitempty"`
+	// Description is shown in error messages when no key matches.
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+}
+
+// TrustedKeyless is a Sigstore identity claim.
+type TrustedKeyless struct {
+	// Identity is the cosign --certificate-identity value (the email or
+	// URI in the Fulcio cert). Required.
+	Identity string `yaml:"identity" json:"identity"`
+	// Issuer is the OIDC issuer URL (--certificate-oidc-issuer).
+	// Required.
+	Issuer string `yaml:"issuer" json:"issuer"`
+	// Repos scopes this identity to specific OCI repos (prefix match).
+	Repos []string `yaml:"repos,omitempty" json:"repos,omitempty"`
+	// Description is shown in error messages when no identity matches.
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+}

--- a/test/e2e/package-and-deps.sh
+++ b/test/e2e/package-and-deps.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# package-and-deps.sh — end-to-end smoke for the package + dependency
+# pipeline. Drives the installer binary through:
+#
+#   build → start registry → push example-base → wizard → deps update →
+#   render → assertions → (optional) upload to ConfigHub.
+#
+# Requirements:
+#   - go and a working build environment
+#   - docker (registry:2 is pulled on demand)
+#   - kustomize on PATH (render shells out to it)
+#
+# Optional:
+#   - cub on PATH and authenticated (INSTALLER_E2E_CONFIGHUB=1 runs upload
+#     against the live server). Upload uses Spaces prefixed
+#     installer-e2e-* and tears them down on exit.
+#
+# Exit codes:
+#   0  pipeline succeeded
+#   1  pipeline failed; failure point printed on stderr
+#
+# All temp state lives in $(mktemp -d) and is removed on exit unless
+# INSTALLER_E2E_KEEP=1.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+WORK_TMP=
+REGISTRY_NAME=installer-e2e-registry
+REGISTRY_PORT=5555
+DO_UPLOAD=${INSTALLER_E2E_CONFIGHUB:-0}
+KEEP=${INSTALLER_E2E_KEEP:-0}
+
+# Spaces created by the upload step. Names track the --space-pattern
+# below; cleaned up on exit.
+UPLOAD_SPACES=(installer-e2e-example-stack installer-e2e-example-base)
+
+log() { printf '\n=== %s ===\n' "$*"; }
+fail() { printf '\nFAIL: %s\n' "$*" >&2; exit 1; }
+
+cleanup() {
+  set +e
+  if [[ "$DO_UPLOAD" = "1" ]]; then
+    for s in "${UPLOAD_SPACES[@]}"; do
+      cub space delete --recursive --quiet "$s" >/dev/null 2>&1
+    done
+  fi
+  docker rm -f "$REGISTRY_NAME" >/dev/null 2>&1
+  if [[ "$KEEP" != "1" && -n "$WORK_TMP" ]]; then
+    rm -rf "$WORK_TMP"
+  else
+    echo "preserved: $WORK_TMP"
+  fi
+}
+trap cleanup EXIT
+
+# 1. Build.
+log "build installer"
+( cd "$REPO_ROOT" && go build -o bin/installer ./cmd/installer )
+BIN="$REPO_ROOT/bin/installer"
+
+# 2. Registry.
+log "start registry:2 on :$REGISTRY_PORT"
+docker rm -f "$REGISTRY_NAME" >/dev/null 2>&1
+docker run -d --name "$REGISTRY_NAME" -p "$REGISTRY_PORT:5000" registry:2 >/dev/null
+for i in {1..30}; do
+  if curl -s -o /dev/null -w "%{http_code}" "http://localhost:$REGISTRY_PORT/v2/" | grep -q 200; then break; fi
+  sleep 0.2
+done
+
+# 3. Push example-base.
+log "push example-base"
+"$BIN" push "$REPO_ROOT/examples/example-base" \
+  "oci://localhost:$REGISTRY_PORT/installer-e2e/example-base:0.1.0" >/dev/null
+
+# 4. Wizard + deps update + render.
+WORK_TMP=$(mktemp -d -t installer-e2e.XXXXXX)
+log "wizard"
+"$BIN" wizard "$REPO_ROOT/examples/example-stack" \
+  --work-dir "$WORK_TMP" \
+  --non-interactive \
+  --namespace e2e-ns >/dev/null
+
+log "deps update"
+"$BIN" deps update "$WORK_TMP"
+
+log "render"
+"$BIN" render "$WORK_TMP"
+
+# 5. Assertions.
+log "assertions"
+parent_manifests="$WORK_TMP/out/manifests"
+dep_manifests="$WORK_TMP/out/base/manifests"
+lock="$WORK_TMP/out/spec/lock.yaml"
+
+[[ -d "$parent_manifests" ]] || fail "parent manifests dir missing: $parent_manifests"
+[[ -d "$dep_manifests"    ]] || fail "dep manifests dir missing: $dep_manifests"
+[[ -f "$lock"             ]] || fail "lock file missing: $lock"
+
+# Parent should render exactly the Deployment.
+parent_count=$(find "$parent_manifests" -type f -name '*.yaml' | wc -l | tr -d ' ')
+[[ "$parent_count" = "1" ]] || fail "parent has $parent_count manifests, want 1"
+grep -q 'kind: Deployment' "$parent_manifests"/*.yaml || fail "parent manifest is not a Deployment"
+grep -q '^  namespace: e2e-ns' "$parent_manifests"/*.yaml || fail "parent Deployment missing namespace: e2e-ns"
+
+# Dep should render exactly Namespace + ConfigMap, both in e2e-ns.
+dep_count=$(find "$dep_manifests" -type f -name '*.yaml' | wc -l | tr -d ' ')
+[[ "$dep_count" = "2" ]] || fail "dep has $dep_count manifests, want 2"
+ns_file="$dep_manifests/namespace-e2e-ns.yaml"
+cm_file="$dep_manifests/configmap-e2e-ns-example-base-defaults.yaml"
+[[ -f "$ns_file" ]] || fail "missing $ns_file"
+[[ -f "$cm_file" ]] || fail "missing $cm_file"
+grep -q '^  name: e2e-ns$' "$ns_file" || fail "Namespace not renamed to e2e-ns"
+
+# Lock should pin the dep digest.
+grep -q 'name: base' "$lock" || fail "lock missing dep entry"
+grep -q '^      digest: sha256:' "$lock" || fail "lock missing pinned digest"
+
+echo "render assertions passed: parent=1 manifest, dep=2 manifests, lock has pinned digest"
+
+# 6. Determinism: re-render and confirm every output file's sha256 matches.
+log "determinism"
+WORK_TMP2=$(mktemp -d -t installer-e2e-2.XXXXXX)
+"$BIN" wizard "$REPO_ROOT/examples/example-stack" \
+  --work-dir "$WORK_TMP2" --non-interactive --namespace e2e-ns >/dev/null
+"$BIN" deps update "$WORK_TMP2" >/dev/null
+"$BIN" render "$WORK_TMP2" >/dev/null
+diff -q -r \
+  <(find "$WORK_TMP/out" -type f -not -path '*/vendor/*' -exec shasum -a 256 {} \; | awk '{print $1, $2}' | sed "s|$WORK_TMP/||" | sort) \
+  <(find "$WORK_TMP2/out" -type f -not -path '*/vendor/*' -exec shasum -a 256 {} \; | awk '{print $1, $2}' | sed "s|$WORK_TMP2/||" | sort) \
+  >/dev/null || fail "rendered output differs across two runs"
+echo "determinism: out/ trees byte-identical across two renders"
+rm -rf "$WORK_TMP2"
+
+# 7. Optional upload to ConfigHub.
+if [[ "$DO_UPLOAD" = "1" ]]; then
+  log "upload to ConfigHub (--space-pattern installer-e2e-{{.PackageName}})"
+  if ! command -v cub >/dev/null 2>&1; then
+    fail "INSTALLER_E2E_CONFIGHUB=1 but cub not on PATH"
+  fi
+  if ! cub space list >/dev/null 2>&1; then
+    fail "cub auth not configured (run \`cub auth login\`)"
+  fi
+  # Prefix all Spaces so cleanup picks them up.
+  "$BIN" upload "$WORK_TMP" --space-pattern 'installer-e2e-{{.PackageName}}'
+
+  for s in "${UPLOAD_SPACES[@]}"; do
+    if ! cub space list 2>/dev/null | awk '{print $1}' | grep -qx "$s"; then
+      fail "expected Space $s not found after upload"
+    fi
+  done
+  echo "Spaces created:"
+  for s in "${UPLOAD_SPACES[@]}"; do
+    echo "  $s"
+    cub unit list --space "$s" 2>&1 | awk 'NR>1 {print "    "$1}'
+  done
+fi
+
+log "OK"


### PR DESCRIPTION
## Summary

Builds out the installer's package + dependency management pipeline from
scratch, following the staged plan in
[`docs/package-management-plan.md`](docs/package-management-plan.md).

End state — `installer --help` now has:
- `package` — deterministic `.tgz` of a package source tree
- `push` / `pull` / `inspect` / `list` / `tag` / `login` / `logout` — native OCI artifacts (`application/vnd.confighub.installer.package.v1+json`)
- `deps update` / `deps tree` — SemVer resolver with single-version-per-repo, lock-file persistence, stale detection
- `render` — multi-package: parent + each locked dep render into their own subtree
- `upload` — one Space per package, one untargeted `installer-record` Unit per Space, cross-Space `dep-<handle>` links
- `sign` / `verify` — cosign keyed or keyless; `~/.config/installer/policy.yaml` gates `pull` and `deps update`

The two design docs:
- [`docs/package-management.md`](docs/package-management.md) — spec
- [`docs/package-management-plan.md`](docs/package-management-plan.md) — phased build plan

A two-package fixture (`examples/example-stack` → `examples/example-base`)
and `test/e2e/package-and-deps.sh` exercise the full pipeline.

## Commits

- `4c0f8bc` Phases 0-2: CLI scaffolding, deterministic bundler, OCI push/pull/inspect/list/tag
- `b5fef70` Phases 3-4: dependency schema, SemVer resolver, `installer deps update`, lock file with stale detection
- `8940447` Phases 5-6: multi-package render (per-dep namespace + Selection from lock), per-dep Spaces, installer-record Unit, cross-Space links
- `d94c512` Phases 7-8: cosign signing + policy enforcement on pull/deps update, multi-package example, e2e script, README cleanup

## Test plan

- [x] `go test ./...` — clean, includes unit tests in `internal/{bundle,deps,pkg,render,sign,upload}` and `pkg/api`.
- [x] `go vet ./...` — clean.
- [x] `installer package` produces byte-identical `.tgz` across runs (sha256 verified for `examples/hello-app`).
- [x] OCI round-trip against a local `registry:2`: `push` → `inspect` → `list` → `tag` → `pull` with `@sha256:` pin enforcement.
- [x] Resolver against a live registry: two versions of `dep-a` published, `^1.2.0` picks the highest; two consecutive `deps update` runs produce byte-identical `lock.yaml`; stale-lock detection warns after `installer.yaml` is edited.
- [x] Multi-package render: parent + 2 deps render into `out/{manifests,dep-a/manifests,dep-b/manifests}/`; dep namespace honors lock's `inputs.namespace` and falls back to parent's; `RenderDependencies` determinism test asserts byte-identical files across re-renders.
- [x] Multi-package upload against live ConfigHub: 3 Spaces, 2 Units each (rendered + untargeted `installer-record`), intra-Space link inference per Space, cross-Space `dep-<handle>` links from parent record → each dep record. `installer-record` is a 6-doc YAML carrying Package, FunctionChain, Inputs, Lock (with pinned manifest digests), ManifestIndex, Selection.
- [x] Cosign signing + verify (integration test against cosign 3.0.6): sign with key A → verify with A succeeds, verify with key B fails; policy with key A → pull succeeds, policy with key B → pull fails with full error chain (`verify <ref>: no trust entry verified <pinned>: trustedKey ...`).
- [x] e2e script: `test/e2e/package-and-deps.sh` exits 0 with `=== OK ===` in both default mode and `INSTALLER_E2E_CONFIGHUB=1` mode; trap cleanup leaves no leftover Spaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)