### PR TITLE
User documentation: author guide, tutorial, consumer guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,28 @@ installed, the same commands work via `cub install ...`.
 └── cub-plugin.yaml             # cub plugin manifest
 ```
 
+## User docs
+
+For people using the installer (writing packages, installing them, or
+managing day-2 changes). These are how-to and reference; the design
+docs below explain _why_ the installer works the way it does.
+
+- [Author guide](docs/author-guide.md) — for package authors. Schema
+  reference for `installer.yaml`, file organization, how the install
+  pipeline consumes your declarations, authoring best practices,
+  publishing, signing, and version-to-version evolution.
+- [Author tutorial](docs/author-tutorial.md) — hands-on walkthrough
+  of building a small package from an empty directory to a signed OCI
+  artifact. ~30 minutes. Read this before the author guide if you
+  prefer learning by example.
+- [Consumer guide](docs/consumer-guide.md) — for operators consuming
+  packages. Find a package, install it, make day-2 changes, upgrade,
+  revert. Plus a troubleshooting section for the common errors.
+
 ## Design docs
+
+For contributors to the installer itself. If you're using or
+authoring packages, the user docs above are what you want.
 
 - [Design principles](docs/principles.md) — the seven principles the
   installer is anchored to (package files are read-only; spec is the
@@ -278,7 +299,6 @@ upgrade --set-image preflight rejection`. Spaces created with the
 
 ## Roadmap
 
-- Documentation for package authors and for package consumers.
 - Secrets (currently we use a hack during fact collection).
 - `installer preflight` — evaluate `externalRequires` against a live cluster.
 - Automatic apply ordering (CRDs before custom resources, Namespace before

--- a/docs/author-guide.md
+++ b/docs/author-guide.md
@@ -1,0 +1,774 @@
+# Package Author Guide
+
+Reference for authoring an installer package — file layout, the
+`installer.yaml` schema, what each declaration becomes at install time,
+publishing, signing, and version-to-version evolution.
+
+If you're new to the installer, read [the consumer
+guide](./consumer-guide.md) first to understand what an operator does
+with your package, then come back here. For a hands-on walkthrough of
+authoring a small package from scratch, see [the author
+tutorial](./author-tutorial.md).
+
+> **Note.** This guide describes _what_ to put in a package and _why_.
+> The doctrine the installer is anchored to lives in
+> [docs/principles.md](./principles.md). When in doubt, that's the
+> tiebreaker.
+
+## Mental model
+
+A package is a kustomize tree wrapped with an `installer.yaml`
+manifest. The manifest declares:
+
+- **Bases** — alternative top-level kustomize trees the operator
+  picks one of.
+- **Components** — opt-in kustomize Components the operator may
+  layer on.
+- **Inputs** — wizard prompts the operator answers.
+- **Function chain template** — the resolved-at-install-time chain of
+  ConfigHub functions that mutate the kustomize output before it's
+  written.
+- **Dependencies** — other installer packages this package composes
+  with.
+- **External requirements** — cluster preconditions the operator
+  must satisfy independently (CRDs, GatewayClass, etc.).
+
+The installer pulls your package into the operator's work-dir, the
+wizard collects answers, render produces literal Kubernetes YAML,
+upload writes the YAML to ConfigHub as Units, and day-2 commands
+(plan / update / upgrade) drive the install over time. None of those
+steps re-templates your package: the rendered YAML is the source of
+truth from upload onward.
+
+## File organization
+
+Minimum:
+
+```
+my-package/
+├── installer.yaml
+└── bases/
+    └── default/
+        ├── kustomization.yaml
+        └── ...resources...
+```
+
+A typical package with optional components, validation, and a
+collector:
+
+```
+my-package/
+├── installer.yaml                 # the manifest (this guide)
+├── bases/
+│   ├── default/                   # primary base
+│   │   ├── kustomization.yaml
+│   │   ├── deployment.yaml
+│   │   └── service.yaml
+│   └── alt/                       # an alternative shape
+│       └── kustomization.yaml
+├── components/
+│   ├── monitoring/                # opt-in: add ServiceMonitor
+│   │   ├── kustomization.yaml     # kind: Component
+│   │   └── servicemonitor.yaml
+│   └── ingress/
+│       ├── kustomization.yaml
+│       └── ingress.yaml
+├── validation/                    # optional: bundled docs about
+│   ├── env.schema.json            # configurable env vars / flags /
+│   ├── command.yaml               # runtime expectations. Surfaced
+│   └── runtime.yaml               # by `installer doc`.
+└── collector/                     # optional: install-time fact
+    └── collect.sh                 # discovery script (see Collector)
+```
+
+Paths in `installer.yaml`'s `bases[].path` and `components[].path` are
+relative to the package root and must point at directories containing
+a `kustomization.yaml`. Components' `kustomization.yaml` must use
+`kind: Component` (kustomize Components, not Kustomizations).
+
+## installer.yaml — the manifest
+
+Every package declares one document of:
+
+```yaml
+apiVersion: installer.confighub.com/v1alpha1
+kind: Package
+metadata:
+  name: my-package
+  version: 0.1.0          # SemVer
+  kubeVersion: ">= 1.28"  # SemVer range; empty means unconstrained
+  installerVersion: ">= 0.2.0"
+spec:
+  ...
+```
+
+`metadata.name` and `metadata.version` are required. The two
+`*Version` fields constrain what cluster Kubernetes / installer
+versions the package supports; mismatches are an error at resolve
+and render time.
+
+The rest of this section walks `spec.*` field by field.
+
+### `spec.bases` (required)
+
+Alternative top-level kustomize trees. Exactly one is selected at
+install time (the wizard's `--base` flag, or the `default: true` base
+when the operator doesn't pick).
+
+```yaml
+spec:
+  bases:
+    - name: default
+      path: bases/default
+      default: true
+      description: A minimal app — Namespace, Deployment, Service.
+    - name: alt
+      path: bases/alt
+      description: An alternative deployment shape.
+      externalRequires:
+        - kind: GatewayClass
+          capability: ext-proc
+```
+
+Use multiple bases when your package supports orthogonal deployment
+shapes that cannot be expressed as opt-in Components — e.g., KServe
+Knative vs Raw, llm-d colocated vs P/D-disaggregated.
+
+Only one base may set `default: true`. Each base may declare its own
+`externalRequires` in addition to the package-level requires.
+
+### `spec.components`
+
+Opt-in kustomize Components (the kustomize `kind: Component`) layered
+on top of the chosen base. The wizard's preset prompt
+(`minimal` / `default` / `all` / `selected`) is the most common way
+operators pick components.
+
+```yaml
+spec:
+  components:
+    - name: monitoring
+      path: components/monitoring
+      description: Adds a ServiceMonitor for Prometheus scraping.
+      default: true                  # picked by the `default` preset
+      externalRequires:
+        - kind: CRD
+          name: servicemonitors.monitoring.coreos.com
+          suggestedSource: oci://ghcr.io/.../kube-prometheus-stack
+    - name: ingress
+      path: components/ingress
+    - name: ingress-tls
+      path: components/ingress-tls
+      requires: [ingress]            # auto-pulled in if ingress is selected
+      conflicts: [no-tls]            # cannot coexist
+      validForBases: [default]       # only valid against this base
+```
+
+- `default: true` makes a component part of the `default` preset.
+  Components without `default` are only installed under the `all`
+  preset or via explicit `--select <name>`.
+- `requires:` is closure-resolved by the wizard's solver. Selecting
+  `ingress-tls` automatically pulls in `ingress`.
+- `conflicts:` is a hard error at solve time.
+- `validForBases:` constrains which base the component can layer on.
+  Empty means valid for all bases.
+- `externalRequires:` declares this component's preconditions, in
+  addition to package-level + base-level requires.
+
+### `spec.inputs`
+
+Wizard prompts. Referenced in the function-chain template as
+`{{ .Inputs.<name> }}`.
+
+```yaml
+spec:
+  inputs:
+    - name: replicas
+      type: int
+      default: 2
+      prompt: "How many replicas?"
+      description: "Number of pod replicas the Deployment will run."
+    - name: license
+      type: string
+      required: true
+      prompt: "License key"
+    - name: tier
+      type: enum
+      options: [basic, pro, enterprise]
+      default: basic
+    - name: hostnames
+      type: list
+      default: []
+    - name: enable_tls
+      type: bool
+      default: false
+    - name: cert_issuer
+      type: string
+      whenExternalRequire: WebhookCertProvider
+      default: letsencrypt-prod
+```
+
+Field reference:
+
+- `name` — variable name in chain templates. Must be a valid
+  identifier.
+- `type` — `string` (default), `int`, `bool`, `enum`, `list`.
+- `default` — used when the operator doesn't supply a value. Must
+  match `type`.
+- `required` — fails if missing and no default.
+- `prompt` — the human-readable question shown by the interactive
+  wizard.
+- `description` — longer help text.
+- `options` — required when `type: enum`.
+- `whenExternalRequire` — only prompt when the package declares an
+  ExternalRequire of this kind. Useful for inputs that only make
+  sense when a particular requirement applies (e.g., `cert_issuer`
+  only matters if your package needs a `WebhookCertProvider`).
+
+**Best practice**: declare a `default:` whenever you can name a
+reasonable one. Required inputs without defaults should be rare —
+[Principle 4](./principles.md#4-optimize-for-the-zero-override-case)
+is "optimize for the zero-override case." If you have ten required
+inputs, your package needs a sensible default profile, not ten more
+prompts.
+
+### `spec.functionChainTemplate`
+
+A list of function-invocation groups. At render time the template is
+resolved against the operator's answers (via Go `text/template`,
+with `.Inputs`, `.Selection`, `.Package`, `.Namespace`, `.Facts` in
+scope), then each group is executed by the ConfigHub function
+executor SDK. The output of each invocation feeds the next
+invocation; the output of each group feeds the next group.
+
+```yaml
+spec:
+  functionChainTemplate:
+    - toolchain: Kubernetes/YAML        # required per group
+      whereResource: ""                 # optional; empty = all resources
+      description: Set the namespace on every namespaced resource.
+      invocations:
+        - name: set-namespace
+          args: ["{{ .Namespace }}"]
+        - name: set-replicas
+          args: ["{{ .Inputs.replicas }}"]
+        - name: set-container-image
+          args: ["app", "{{ .Inputs.image }}"]
+```
+
+- `toolchain` — `Kubernetes/YAML`, `AppConfig/Properties`, etc.
+  Each group declares its own toolchain so a single chain can mutate
+  raw Kubernetes YAML and AppConfig units in the same render.
+- `whereResource` — a function-executor filter expression scoping
+  this group to a subset of resources. Empty = all.
+- `invocations` — ordered. Each invocation names a function and its
+  string args (templated).
+
+Common functions: `set-namespace`, `set-name`, `set-replicas`,
+`set-container-image`, `set-container-image-reference`,
+`set-container-resources`, `set-env`, `set-hostname`, `yq-i`,
+`set-string-path`, `delete-path`. The full list is in `cub function
+list` against a running ConfigHub.
+
+**When to use the function chain vs kustomize itself**: kustomize
+handles structural composition (resources, components, overlays,
+patches). The function chain handles install-time mutations driven by
+operator answers. Image overrides for occasional patch-level bumps
+are a special case — see "Image overrides" below.
+
+### `spec.externalRequires`
+
+Cluster preconditions your package needs but does not provide. The
+wizard surfaces them; `installer preflight` (when shipped) probes them
+against a live cluster.
+
+```yaml
+spec:
+  externalRequires:
+    - kind: CRD
+      name: servicemonitors.monitoring.coreos.com
+      version: ">= v1"
+      suggestedSource: oci://ghcr.io/.../kube-prometheus-stack
+    - kind: GatewayClass
+      capability: ext-proc
+      suggestedProviders: [istio, envoy-gateway, kgateway]
+    - kind: WebhookCertProvider
+      name: cert-manager
+      issuerKind: ClusterIssuer
+```
+
+Recognized `kind` values: `CRD`, `ClusterFeature`,
+`WebhookCertProvider`, `GatewayClass`, `Operator`, `StorageClass`,
+`RuntimeClass`. Use `suggestedSource` (a single OCI ref) or
+`suggestedProviders` (a list of well-known providers) so operators
+have a path forward when the requirement is missing.
+
+### `spec.provides`
+
+What your package itself supplies. Used by the dependency resolver to
+mark the corresponding `externalRequires` from other packages as
+satisfied.
+
+```yaml
+spec:
+  provides:
+    - kind: CRD
+      name: gateway.networking.k8s.io
+    - kind: GatewayClass
+      name: istio
+```
+
+### `spec.clusterSingleton`
+
+Leader-election leases your package claims at cluster scope. Two
+packages claiming the same lease cannot coexist; the resolver fails
+on conflict.
+
+```yaml
+spec:
+  clusterSingleton:
+    - lease: my-app-leader
+      namespace: kube-system
+```
+
+### `spec.externalManifests`
+
+Remote manifest files (typically release-tarball CRDs) that get
+fetched at render time and merged into the rendered output as
+additional Units. Used by projects that distribute CRDs outside any
+chart.
+
+```yaml
+spec:
+  externalManifests:
+    - name: gaie-crds
+      url: https://github.com/.../v0.4.0/manifests.yaml
+      digest: sha256:abcd1234...
+      splitByResource: true            # default true; one Unit per resource
+      phase: crds                      # routes into spec.phases (if used)
+```
+
+The `digest` is mandatory and must pin the file you tested against —
+fetch is verified against it before render uses the bytes.
+
+### `spec.collector`
+
+An executable bundled in the package that the wizard runs to discover
+install-time facts (server URL, image tag, worker IDs, etc.) and to
+materialize sensitive material as `.env.secret` files consumed by
+kustomize secretGenerator.
+
+```yaml
+spec:
+  collector:
+    command: collector/collect.sh
+    args: []
+    description: Discover the active cub server URL + bootstrap a worker secret.
+```
+
+The wizard runs the command with the package root as the working
+directory and the following env vars set (parent env is also
+inherited so `cub` works inside the script):
+
+- `INSTALLER_PACKAGE_DIR` — absolute path to the package working copy
+- `INSTALLER_WORK_DIR` — absolute path to the parent working
+  directory
+- `INSTALLER_OUT_DIR` — absolute path to `<work-dir>/out`
+- `INSTALLER_NAMESPACE` — value of `--namespace`
+- `INSTALLER_BASE` — chosen base name
+- `INSTALLER_SELECTED` — comma-separated selected component names
+- `INSTALLER_INPUT_<NAME>` — one variable per declared input
+  (uppercased)
+
+The collector's stdout is parsed as a YAML map and persisted to
+`out/spec/facts.yaml`. The map's keys become available in chain
+templates as `{{ .Facts.<key> }}`. The collector may also write
+`.env.secret` files inside the package working copy at paths its
+kustomize secretGenerator references; the installer never reads or
+uploads those files. Rendered Secret resources are routed to
+`out/secrets/` and never uploaded as Units.
+
+**Re-run on upgrade**. `installer upgrade` re-runs the collector
+against the new package; facts are not assumed to survive a version
+bump.
+
+### `spec.validation`
+
+Points at machine-readable component documentation bundled in the
+package (typically generated by `docker run <image> docgen
+{command,env,runtime}` and committed under `./validation/`). Surfaced
+by `installer doc` so an AI agent or human can read what env vars
+your workload accepts and what runtime expectations it has without
+re-pulling the image.
+
+```yaml
+spec:
+  validation:
+    commandHelp: validation/command.yaml
+    envSchema: validation/env.schema.json
+    runtimeSpec: validation/runtime.yaml
+    howToRegenerate: |
+      docker run --rm myorg/myapp:0.1.0 docgen command > validation/command.yaml
+      docker run --rm myorg/myapp:0.1.0 docgen env > validation/env.schema.json
+      docker run --rm myorg/myapp:0.1.0 docgen runtime > validation/runtime.yaml
+```
+
+Optional. The installer doesn't consume these files at render time.
+
+### `spec.dependencies`
+
+Other installer packages this one composes with.
+
+```yaml
+spec:
+  dependencies:
+    - name: gateway-api                     # local handle (must be unique)
+      package: oci://ghcr.io/myorg/gateway-api  # OCI ref without tag
+      version: "^1.2.0"                     # SemVer range
+      selection:                            # pre-answers the dep's wizard
+        base: default
+        components: [crds, kgateway]
+      inputs:                               # pre-answers the dep's inputs
+        namespace: gateway-system
+      whenComponent: ingress                # only follow when parent
+                                            # selects "ingress"
+      satisfies:                            # marks parent's externalRequires
+        - kind: CRD
+          name: gateway.networking.k8s.io
+        - kind: GatewayClass
+          capability: ext-proc
+    - name: cert-manager
+      package: oci://ghcr.io/myorg/cert-manager
+      version: ">= 1.15.0"
+      optional: true
+```
+
+The resolver walks the DAG, picks one version per package satisfying
+every constraint, honors `conflicts:` and `replaces:`, and writes
+`out/spec/lock.yaml` pinning each dependency to a manifest digest.
+
+### `spec.conflicts` and `spec.replaces`
+
+```yaml
+spec:
+  conflicts:
+    - package: oci://ghcr.io/foo/old-gateway
+      version: "*"
+      reason: "Replaced by gateway-api dependency."
+  replaces:
+    - package: oci://ghcr.io/foo/old-name
+      version: "< 2.0.0"
+```
+
+`conflicts` hard-excludes other packages from the resolution set.
+`replaces` declares this package supersedes another (typically across
+a rename) — a request for the named package matching the version
+range is treated as satisfied by this package.
+
+### `spec.bundleExamples`
+
+Controls whether the `examples/` subtree is bundled by `installer
+package`. Default `true`. Set to `false` to exclude examples from
+published artifacts.
+
+## How the install pipeline consumes your package
+
+Knowing the pipeline helps you reason about what's load-bearing and
+what isn't.
+
+1. **`installer pull <ref> <work-dir>/package`** — fetches the
+   bundled tgz from OCI, verifies signature if a policy is configured,
+   extracts into `<work-dir>/package/`. Your `installer.yaml`,
+   `bases/`, `components/`, etc. land here verbatim.
+
+2. **`installer wizard <ref>`** — loads `installer.yaml`, runs the
+   selection solver (closure of `requires:`, conflict / `validForBases`
+   checks), runs your collector if present, writes
+   `out/spec/{selection,inputs,facts}.yaml`.
+
+3. **`installer deps update <work-dir>`** (only if you declare
+   dependencies) — resolves the DAG and writes `out/spec/lock.yaml`.
+
+4. **`installer render <work-dir>`** — composes a synthetic top-level
+   kustomization that references your chosen base + components, runs
+   `kustomize build`, then runs your function-chain template
+   (resolved with `.Inputs` / `.Selection` / `.Package` / `.Namespace`
+   / `.Facts`). For multi-package installs, each dep is rendered into
+   its own subtree under `out/<dep-name>/`. Output lands as one
+   resource per file in `out/manifests/`.
+
+5. **`installer upload <work-dir>`** — creates one Space per package
+   (parent + each locked dep) and one Unit per rendered file, plus
+   one untargeted `installer-record` Unit per Space carrying your
+   `installer.yaml` + the spec docs (so a freshly cloned work-dir is
+   recoverable from cub alone). Cross-Space Links wire the parent's
+   record to each dep's record.
+
+6. **`installer plan` / `update` / `upgrade` / `upgrade-apply`** —
+   day-2 operations. The operator's job, but several things you author
+   shape how they behave: your `images:` block enables `--set-image`;
+   your `default: true` components are adopted by `default`-preset
+   re-renders; your input schema diff (across versions) drives what an
+   upgrade prompts for vs carries forward silently.
+
+## Authoring best practices
+
+These are the prescriptive ones. The full doctrine is
+[principles.md](./principles.md); read it.
+
+### Defaults everywhere
+
+Inputs without defaults force prompts. Components without `default:
+true` are invisible to the `default` preset. Operators of a
+well-authored package can install with `installer wizard <ref>
+--namespace foo` and walk away. Aim for that.
+
+### Declare an `images:` block
+
+Put a kustomize `images:` block in your chosen base's
+`kustomization.yaml`, with `newName` / `newTag` matching what's
+hard-coded in your manifests. This enables `installer
+wizard --set-image name=ref` and `installer upgrade --set-image` for
+operators. Without it, `--set-image` fails fast with a message
+pointing at this guide. Cost: three lines of YAML; benefit: image
+mirroring + patch-version bumps without your operator hand-editing
+your package tree.
+
+```yaml
+# bases/default/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+images:
+  - name: myorg/myapp
+    newName: myorg/myapp
+    newTag: v1.2.3
+```
+
+If image changes are expected to be frequent (per-component image
+registries, multi-arch by tag, image-by-URI rewrites), declare image
+inputs and a `set-container-image` group in
+`functionChainTemplate` instead. Reach for that only if the
+`images:` block is genuinely insufficient.
+
+### Components, not flags
+
+When something is binary ("with monitoring" / "without monitoring"),
+prefer a component over a `bool` input. Components compose better
+with kustomize, are visible to the wizard's preset prompt, and let
+operators see what's installed at a glance.
+
+### Don't smuggle templates into rendered YAML
+
+Your package's rendered output ends up as literal Kubernetes YAML in
+ConfigHub Units. Don't ship Go-template syntax, Helm placeholders, or
+`{{ }}`-style variables in resources after kustomize build — they
+won't be re-templated. If a value needs to vary at install time,
+either declare an input + function-chain mutation, or expose it as a
+kustomize image / replicas / patch transformer.
+
+### Design for re-render
+
+Every install state (selection, inputs, facts, dependency lock) is
+captured in `out/spec/`. Your render must be deterministic from
+those files plus your package source — same package + same spec +
+same facts = byte-identical Unit bodies. If you have a non-determinism
+(timestamps, random IDs), push it into the collector's facts so it's
+captured once and replayed thereafter.
+
+### Don't add inputs an operator could change post-install
+
+Container images, replica counts, env vars — anything ConfigHub has a
+function for (`set-container-image`, `set-replicas`, `set-env`) — is
+post-install ConfigHub mutation territory. Don't add an input and
+function-chain step for these unless the value is install-time-only
+(captured at install and never tuned afterward). The wizard should
+ask the small number of things that genuinely need to be answered
+once, up front.
+
+## Publishing
+
+The publish flow is `installer package` → `installer push`:
+
+```bash
+# Build a deterministic .tgz of the source tree.
+installer package ./my-package -o my-package-0.1.0.tgz
+# Output names the digest:
+#   sha256:bc4e...
+
+# Push to an OCI registry as an installer artifact.
+installer push my-package-0.1.0.tgz oci://ghcr.io/myorg/my-package:0.1.0
+
+# Inspect what's in a registry without pulling the layer.
+installer inspect oci://ghcr.io/myorg/my-package:0.1.0
+installer list oci://ghcr.io/myorg/my-package
+```
+
+`installer package` is byte-deterministic: sorted entries, zeroed
+mtimes / uids / gids, canonicalized modes, gzip without filename or
+mtime metadata. The same source tree on two machines produces an
+identical tarball.
+
+What's bundled:
+
+- `installer.yaml`
+- Every directory referenced by `bases[].path`,
+  `components[].path`, `validation.*`, and `collector.command` (if
+  relative).
+- `examples/` (when `spec.bundleExamples` is unset or `true`).
+
+What's refused:
+
+- `*.env.secret` anywhere.
+- Anything under `out/`.
+- Anything matched by `.installerignore` (gitignore syntax).
+
+## Signing
+
+`installer push` accepts `--sign` to attach a cosign signature
+(keyed or keyless). Operators verify with `installer verify` or by
+configuring `~/.config/installer/policy.yaml` to require signatures
+matching trusted keys / identities — when that policy exists,
+`installer pull` and `installer deps update` enforce verification on
+every fetch.
+
+```bash
+# Keyed signing.
+installer push my-package-0.1.0.tgz oci://ghcr.io/myorg/my-package:0.1.0 \
+    --sign --key cosign.key
+
+# Keyless (Sigstore Fulcio, OIDC).
+installer push my-package-0.1.0.tgz oci://ghcr.io/myorg/my-package:0.1.0 \
+    --sign --keyless
+```
+
+If your package will be consumed by people you don't know, sign every
+release. The cost is small; the trust story for your operators is
+substantial.
+
+## Versioning + upgrade considerations
+
+Operators upgrade with `installer upgrade <work-dir> <new-ref>`. The
+upgrade machinery does a schema-diff between the prior install's
+package and yours, and behaves accordingly. As an author, this gives
+you a few rules of the road:
+
+### Adding inputs
+
+- **New input with a default**: silently adopted on upgrade. Safe.
+- **New required input without a default**: surfaces as an
+  interactive prompt; in non-interactive mode, the upgrade fails fast
+  naming the new input. Avoid this when you can — provide a sensible
+  default and let the operator change it later if needed.
+
+### Removing inputs
+
+Silently dropped from the new `inputs.yaml` on upgrade. Operators do
+not need to do anything.
+
+### Changing input types
+
+Errors out the upgrade. The operator must re-run `installer wizard`
+to re-answer. Avoid type changes; if you need one, ship a new input
+under a different name and remove the old in a later release.
+
+### Adding components
+
+- **New component with `default: true`**: adopted on upgrade _only_
+  if the operator's prior selection matched the old package's
+  default preset exactly. Otherwise the component is available but
+  not enabled by default — operators discover it via `installer doc`
+  or the wizard.
+- **New component without `default: true`**: invisible until the
+  operator picks it.
+
+### Removing components
+
+Silently dropped from selection if previously selected. Operators do
+not need to do anything; their next render simply omits the
+removed component.
+
+### Changing the function chain
+
+Any change in `functionChainTemplate` re-runs against the new render
+on upgrade. Render is deterministic; the next plan shows the
+resulting diff, and operators can review before applying.
+
+### Image transforms
+
+If your package declares an `images:` block, operators may have
+applied `--set-image` overrides that are now stored in their
+`Inputs.Spec.ImageOverrides`. Those carry forward on upgrade
+automatically — your new release does not need to do anything special
+for them.
+
+### Bumping `metadata.version`
+
+Use SemVer. The version is what shows up in the `installer-upgrade-…`
+ChangeSet name and in operator-facing diagnostics; honest
+versioning makes operator audit trails readable.
+
+### Bumping `kubeVersion` / `installerVersion`
+
+Tighten these as you start using newer features. The installer
+refuses to render against incompatible cluster + installer versions.
+
+## Common author tasks
+
+### Add an opt-in component
+
+1. `mkdir components/<name>`, drop a kustomize Component
+   (`kind: Component`) `kustomization.yaml` + the resources that
+   layer in.
+2. Add an entry under `spec.components`. Set `default: true` if the
+   component should be part of the recommended install.
+3. Declare any preconditions in `externalRequires`.
+4. If the component depends on another component in your package,
+   list it under `requires:`.
+
+### Add an input
+
+1. Add an entry under `spec.inputs` with `name`, `type`, and a
+   `default:` whenever you can name one.
+2. Reference the value from `functionChainTemplate` invocations as
+   `{{ .Inputs.<name> }}`, or rely on a kustomize transformer
+   reading it (e.g., via a generator).
+
+### Depend on another installer package
+
+1. Add an entry under `spec.dependencies` with `name`, `package`
+   (OCI ref without tag), `version` (SemVer range).
+2. Optionally pre-answer the dep's wizard via `selection:` and
+   `inputs:`.
+3. If the dep covers an `externalRequires` of yours, list it under
+   `satisfies:` so the resolver marks the requirement satisfied.
+
+### Cut a release
+
+1. Bump `metadata.version` per SemVer.
+2. `installer package ./my-package -o my-package-X.Y.Z.tgz` — record
+   the printed sha256.
+3. `installer push my-package-X.Y.Z.tgz oci://.../my-package:X.Y.Z
+   --sign` (or `--key` / `--keyless`).
+4. Optionally `installer tag oci://.../my-package:X.Y.Z latest` if
+   you publish a moving `latest` tag (most don't — a SemVer tag is
+   reproducible).
+
+### Help operators audit your package
+
+Ship `validation/` with `command.yaml` / `env.schema.json` /
+`runtime.yaml` — generated from the workload itself, committed in
+the package. `installer doc <ref>` surfaces them. AI agents and
+humans both benefit.
+
+## Next steps
+
+- The [tutorial](./author-tutorial.md) walks through building a small
+  package end to end.
+- [Consumer guide](./consumer-guide.md) — what your operators see.
+- [Principles](./principles.md) — the doctrine the installer is
+  anchored to.
+- The full design lives in [package-management.md](./package-management.md)
+  and [lifecycle.md](./lifecycle.md), if you want to know _why_ a
+  thing works the way it does.

--- a/docs/author-tutorial.md
+++ b/docs/author-tutorial.md
@@ -1,0 +1,580 @@
+# Author Tutorial: Build a Package From Scratch
+
+Walks you through authoring a small installer package — a status
+page service called `statusboard` — from an empty directory to a
+signed OCI artifact. Takes ~30 minutes. Mirrors the shape of
+`examples/hello-app` but is built fresh so you see every decision.
+
+By the end you'll have:
+
+- A working package with a base, two opt-in components, an input,
+  and a function-chain template.
+- An `images:` block so operators can override container tags
+  without editing your source.
+- A bundled `.tgz` ready to push to an OCI registry.
+
+For the complete schema reference, see [author-guide.md](./author-guide.md).
+For the doctrine the installer is anchored to, see
+[principles.md](./principles.md).
+
+## Prerequisites
+
+- `installer` binary on PATH (or invoke `bin/installer` from a clone).
+- `kustomize` on PATH.
+- A scratch directory: `mkdir -p ~/scratch/statusboard && cd
+  ~/scratch/statusboard`.
+
+## Step 1: the minimum viable package
+
+A package must have:
+
+- `installer.yaml` (the manifest).
+- One base directory containing a `kustomization.yaml`.
+
+Create the manifest:
+
+```bash
+cat > installer.yaml <<'YAML'
+apiVersion: installer.confighub.com/v1alpha1
+kind: Package
+metadata:
+  name: statusboard
+  version: 0.1.0
+spec:
+  bases:
+    - name: default
+      path: bases/default
+      default: true
+      description: A minimal status page service.
+YAML
+```
+
+Create the base. We'll start with a single Namespace + Deployment +
+Service:
+
+```bash
+mkdir -p bases/default
+cat > bases/default/namespace.yaml <<'YAML'
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: confighubplaceholder
+YAML
+
+cat > bases/default/deployment.yaml <<'YAML'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: statusboard
+  namespace: confighubplaceholder
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: statusboard }
+  template:
+    metadata:
+      labels: { app: statusboard }
+    spec:
+      containers:
+        - name: app
+          image: nginxdemos/hello:plain-text
+          ports:
+            - containerPort: 80
+YAML
+
+cat > bases/default/service.yaml <<'YAML'
+apiVersion: v1
+kind: Service
+metadata:
+  name: statusboard
+  namespace: confighubplaceholder
+spec:
+  selector: { app: statusboard }
+  ports:
+    - port: 80
+      targetPort: 80
+YAML
+
+cat > bases/default/kustomization.yaml <<'YAML'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+YAML
+```
+
+Two notes:
+
+- The Namespace name is `confighubplaceholder` — a sentinel. The
+  function-chain template (which we'll add in step 3) rewrites it
+  to whatever the operator passes via `--namespace`.
+- The image is hard-coded to `nginxdemos/hello:plain-text`. We'll
+  enable operator overrides via a kustomize `images:` block in
+  step 4.
+
+Verify the package parses:
+
+```bash
+installer doc .
+```
+
+You should see `statusboard 0.1.0` with the `default` base and no
+components. Now let's exercise the install path locally without a
+ConfigHub server:
+
+```bash
+installer wizard ./. \
+  --work-dir /tmp/statusboard \
+  --non-interactive \
+  --namespace demo
+
+installer render /tmp/statusboard
+ls /tmp/statusboard/out/manifests/
+# deployment-confighubplaceholder-statusboard.yaml
+# namespace-confighubplaceholder.yaml
+# service-confighubplaceholder-statusboard.yaml
+```
+
+Notice the manifests still say `confighubplaceholder`. We haven't
+added the namespace-rewriting function yet.
+
+## Step 2: a function chain that rewrites the namespace
+
+The wizard accepts `--namespace`; we want the rendered manifests to
+use that value instead of `confighubplaceholder`.
+
+Add `spec.functionChainTemplate` to `installer.yaml`:
+
+```yaml
+# append to installer.yaml
+  functionChainTemplate:
+    - toolchain: Kubernetes/YAML
+      whereResource: ""
+      description: Set the namespace on every namespaced resource.
+      invocations:
+        - name: set-namespace
+          args: ["{{ .Namespace }}"]
+```
+
+Re-render:
+
+```bash
+rm -rf /tmp/statusboard
+installer wizard ./. --work-dir /tmp/statusboard --non-interactive --namespace demo
+installer render /tmp/statusboard
+ls /tmp/statusboard/out/manifests/
+# deployment-demo-statusboard.yaml
+# namespace-demo.yaml
+# service-demo-statusboard.yaml
+```
+
+The filenames now reflect the chosen namespace, and the manifest
+contents do too:
+
+```bash
+grep namespace /tmp/statusboard/out/manifests/deployment-demo-statusboard.yaml
+#  namespace: demo
+```
+
+The chain template is Go `text/template` — `.Namespace` is the
+value passed to `--namespace`, `.Inputs.<name>` are answers to your
+declared inputs, `.Selection` is the resolved base + components, and
+`.Facts` is the collector's output map (we don't have one yet).
+
+## Step 3: a wizard input
+
+Add a `replicas` input so operators can size the deployment without
+editing the package:
+
+```yaml
+# append to installer.yaml under spec:
+  inputs:
+    - name: replicas
+      type: int
+      default: 1
+      prompt: "Number of replicas"
+      description: "How many statusboard pods to run."
+```
+
+Wire it into the function chain:
+
+```yaml
+# extend the existing functionChainTemplate group
+  functionChainTemplate:
+    - toolchain: Kubernetes/YAML
+      whereResource: ""
+      description: Set the namespace + replicas.
+      invocations:
+        - name: set-namespace
+          args: ["{{ .Namespace }}"]
+        - name: set-replicas
+          args: ["{{ .Inputs.replicas }}"]
+```
+
+Re-render with a non-default value:
+
+```bash
+rm -rf /tmp/statusboard
+installer wizard ./. --work-dir /tmp/statusboard --non-interactive --namespace demo --input replicas=3
+installer render /tmp/statusboard
+grep replicas /tmp/statusboard/out/manifests/deployment-demo-statusboard.yaml
+#  replicas: 3
+```
+
+And confirm the default takes when `--input replicas=…` is absent:
+
+```bash
+rm -rf /tmp/statusboard
+installer wizard ./. --work-dir /tmp/statusboard --non-interactive --namespace demo
+installer render /tmp/statusboard
+grep replicas /tmp/statusboard/out/manifests/deployment-demo-statusboard.yaml
+#  replicas: 1
+```
+
+> **Why a `default:`?** Because operators of a well-authored package
+> shouldn't have to answer prompts that have a sensible answer.
+> [Principle 4](./principles.md#4-optimize-for-the-zero-override-case)
+> — _optimize for the zero-override case._
+
+## Step 4: declare an `images:` block for operator overrides
+
+Operators frequently want to pin a specific image tag, mirror to an
+internal registry, or bump a patch version — without hand-editing
+your source. Declare a kustomize `images:` block in your base, and
+they get `installer wizard --set-image` and `installer upgrade
+--set-image` for free.
+
+Edit `bases/default/kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+# images: declares the names overridable by --set-image. The default
+# values match what's hard-coded in deployment.yaml.
+images:
+  - name: nginxdemos/hello
+    newName: nginxdemos/hello
+    newTag: plain-text
+```
+
+Test with an override:
+
+```bash
+rm -rf /tmp/statusboard
+installer wizard ./. \
+  --work-dir /tmp/statusboard \
+  --non-interactive --namespace demo \
+  --set-image nginxdemos/hello=nginxdemos/hello:plain-text-v2
+installer render /tmp/statusboard
+grep image /tmp/statusboard/out/manifests/deployment-demo-statusboard.yaml
+#  - image: nginxdemos/hello:plain-text-v2
+```
+
+The override is recorded in `out/spec/inputs.yaml` under
+`spec.imageOverrides`, so it round-trips across upgrades:
+
+```bash
+grep -A 1 imageOverrides /tmp/statusboard/out/spec/inputs.yaml
+# imageOverrides:
+#   nginxdemos/hello: nginxdemos/hello:plain-text-v2
+```
+
+If you don't declare an `images:` block and an operator passes
+`--set-image`, render fails fast with a useful message — `kustomize
+edit set image` against an undeclared image would silently inject a
+new block, which contradicts your contract as the package author.
+
+## Step 5: an opt-in component
+
+Components are kustomize Components (`kind: Component`) layered on
+top of the base. We'll add a `monitoring` component that adds a
+`ServiceMonitor`.
+
+```bash
+mkdir -p components/monitoring
+cat > components/monitoring/servicemonitor.yaml <<'YAML'
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: statusboard
+  namespace: confighubplaceholder
+spec:
+  selector:
+    matchLabels: { app: statusboard }
+  endpoints:
+    - port: web
+YAML
+
+cat > components/monitoring/kustomization.yaml <<'YAML'
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - servicemonitor.yaml
+YAML
+```
+
+Add it to `installer.yaml`:
+
+```yaml
+# add under spec:
+  components:
+    - name: monitoring
+      path: components/monitoring
+      description: Adds a ServiceMonitor for Prometheus scraping.
+      default: true
+      externalRequires:
+        - kind: CRD
+          name: servicemonitors.monitoring.coreos.com
+          suggestedSource: oci://ghcr.io/.../kube-prometheus-stack
+```
+
+Two things to notice:
+
+- `default: true` makes monitoring part of the wizard's `default`
+  preset. Operators who say "I trust your defaults" get monitoring
+  automatically.
+- `externalRequires` declares that the cluster needs the
+  ServiceMonitor CRD before this component can apply. The wizard
+  surfaces this; `installer preflight` (when shipped) will probe
+  the cluster.
+
+Test:
+
+```bash
+rm -rf /tmp/statusboard
+installer wizard ./. --work-dir /tmp/statusboard --non-interactive \
+  --namespace demo --select monitoring
+installer render /tmp/statusboard
+ls /tmp/statusboard/out/manifests/
+# adds: servicemonitor-demo-statusboard.yaml
+```
+
+Or via the `default` preset:
+
+```bash
+rm -rf /tmp/statusboard
+installer wizard ./. --work-dir /tmp/statusboard --non-interactive \
+  --namespace demo --components default
+installer render /tmp/statusboard
+ls /tmp/statusboard/out/manifests/
+# also adds servicemonitor-demo-statusboard.yaml
+```
+
+## Step 6: a second component with a `requires:`
+
+We'll add an `ingress` component, then an `ingress-tls` component
+that depends on it.
+
+```bash
+mkdir -p components/ingress
+cat > components/ingress/ingress.yaml <<'YAML'
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: statusboard
+  namespace: confighubplaceholder
+spec:
+  rules:
+    - host: statusboard.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: statusboard
+                port: { number: 80 }
+YAML
+
+cat > components/ingress/kustomization.yaml <<'YAML'
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ingress.yaml
+YAML
+
+mkdir -p components/ingress-tls
+cat > components/ingress-tls/patch.yaml <<'YAML'
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: statusboard
+  namespace: confighubplaceholder
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  tls:
+    - hosts: [statusboard.example.com]
+      secretName: statusboard-tls
+YAML
+
+cat > components/ingress-tls/kustomization.yaml <<'YAML'
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: patch.yaml
+YAML
+```
+
+Update `installer.yaml`:
+
+```yaml
+  components:
+    - name: monitoring
+      path: components/monitoring
+      ...
+    - name: ingress
+      path: components/ingress
+      description: Expose the service via an Ingress.
+    - name: ingress-tls
+      path: components/ingress-tls
+      description: Annotate the Ingress to request a cert from cert-manager.
+      requires: [ingress]
+      externalRequires:
+        - kind: WebhookCertProvider
+          name: cert-manager
+          issuerKind: ClusterIssuer
+```
+
+`requires: [ingress]` means selecting `ingress-tls` automatically
+pulls in `ingress`. The wizard's solver does this closure and
+errors on conflicts. Test:
+
+```bash
+rm -rf /tmp/statusboard
+installer wizard ./. --work-dir /tmp/statusboard --non-interactive \
+  --namespace demo --select ingress-tls
+cat /tmp/statusboard/out/spec/selection.yaml
+#   components: [ingress, ingress-tls]   # both selected
+installer render /tmp/statusboard
+```
+
+## Step 7: try the interactive wizard
+
+Everything we've done so far has been non-interactive (scripted via
+flags). Try it interactively to see what an operator sees:
+
+```bash
+rm -rf /tmp/statusboard
+installer wizard ./.
+# Prompts:
+#   Components: [minimal/default/all/selected]
+#   Kubernetes namespace: <text>
+#   Tweak any other inputs? [y/N]
+```
+
+The interactive wizard skips inputs that have a default and aren't
+required, unless the operator answers yes to "Tweak any other
+inputs?". This is Principle 4 in action — well-defaulted packages
+ask one or two questions and ship.
+
+## Step 8: package and publish
+
+Build a deterministic tarball:
+
+```bash
+installer package ./. -o statusboard-0.1.0.tgz
+# Wrote statusboard-0.1.0.tgz (sha256:bc4e...)
+```
+
+Two builds on two machines from the same source produce the same
+sha256. Publish to a registry:
+
+```bash
+installer push statusboard-0.1.0.tgz oci://ghcr.io/myorg/statusboard:0.1.0
+```
+
+Operators can now:
+
+```bash
+installer inspect oci://ghcr.io/myorg/statusboard:0.1.0
+installer pull oci://ghcr.io/myorg/statusboard:0.1.0 ./statusboard-pulled
+```
+
+For production releases, sign with cosign — keyed:
+
+```bash
+cosign generate-key-pair
+installer push statusboard-0.1.0.tgz oci://ghcr.io/myorg/statusboard:0.1.0 \
+    --sign --key cosign.key
+```
+
+Or keyless (Sigstore Fulcio + OIDC):
+
+```bash
+installer push statusboard-0.1.0.tgz oci://ghcr.io/myorg/statusboard:0.1.0 \
+    --sign --keyless
+```
+
+Operators can configure `~/.config/installer/policy.yaml` to require
+signatures on every pull.
+
+## Step 9: release a 0.2.0
+
+When you change the package, bump `metadata.version` to 0.2.0,
+re-package, re-push. Operators upgrade with:
+
+```bash
+installer upgrade <work-dir> oci://ghcr.io/myorg/statusboard:0.2.0
+installer upgrade-apply <work-dir>
+```
+
+The upgrade machinery diffs your old vs new schema:
+
+- New input with default → silently adopted.
+- New required input without default → operator prompted (or
+  fail-fast in non-interactive mode).
+- Removed input → silently dropped.
+- Changed input type → upgrade fails, operator must re-run wizard.
+- New `default: true` component → adopted only if operator's prior
+  selection matched the old default preset.
+
+See [author-guide.md → Versioning + upgrade
+considerations](./author-guide.md#versioning--upgrade-considerations)
+for the complete rules.
+
+## What you have
+
+```
+~/scratch/statusboard/
+├── installer.yaml                # the manifest
+├── bases/
+│   └── default/
+│       ├── deployment.yaml
+│       ├── kustomization.yaml    # with images: block
+│       ├── namespace.yaml
+│       └── service.yaml
+└── components/
+    ├── ingress/
+    │   ├── ingress.yaml
+    │   └── kustomization.yaml
+    ├── ingress-tls/
+    │   ├── kustomization.yaml
+    │   └── patch.yaml
+    └── monitoring/
+        ├── kustomization.yaml
+        └── servicemonitor.yaml
+```
+
+A ~150-line `installer.yaml` + a small kustomize tree. Operators
+can install with one command, override images without editing your
+source, choose components by name or by preset, and upgrade to your
+next release with the schema-diff machinery handling the carry-
+forward.
+
+## Where to go next
+
+- [author-guide.md](./author-guide.md) — schema reference for every
+  field you didn't touch in this tutorial: `dependencies`,
+  `provides`, `clusterSingleton`, `externalManifests`, `collector`,
+  `validation`, `conflicts`, `replaces`, `bundleExamples`.
+- [consumer-guide.md](./consumer-guide.md) — what operators do with
+  what you ship. Read it once before you publish your first release.
+- [principles.md](./principles.md) — the doctrine the installer is
+  anchored to. Worth re-reading after you've shipped a few packages.

--- a/docs/consumer-guide.md
+++ b/docs/consumer-guide.md
@@ -1,0 +1,555 @@
+# Package Consumer Guide
+
+For operators who pull packages someone else has authored, install
+them, and manage day-2 changes — image bumps, configuration tweaks,
+package upgrades, reverts.
+
+If you author packages, see [author-guide.md](./author-guide.md) +
+[author-tutorial.md](./author-tutorial.md). The doctrine the
+installer is anchored to lives in [principles.md](./principles.md).
+
+## What the installer does
+
+```
+                             pull        wizard         render
+  oci://registry/pkg:1.2 ──→ package/ ──→ spec/   ───→ manifests/
+                                                            │
+                                                            │ upload
+                                                            ▼
+                                                       ConfigHub Spaces
+                                                       (one Unit per file)
+                                                            │
+                                                            │ apply (cub-side)
+                                                            ▼
+                                                         Kubernetes
+```
+
+Day-2 commands operate on the same work-dir:
+
+- `installer plan` — show what's different between the work-dir and
+  ConfigHub.
+- `installer update` — apply local changes to ConfigHub inside a
+  ChangeSet.
+- `installer upgrade` — re-pull a (new or same) package version,
+  re-render, and stage the result. `installer upgrade-apply`
+  promotes the staged tree and runs update.
+
+The installer never pushes to your cluster. Cluster apply is
+ConfigHub's job (typically via `cub unit apply`, ArgoCD, or Flux —
+configured separately).
+
+## Find a package
+
+Today, package discovery is convention-based — you find a package by
+its OCI ref (`oci://host/repo:tag`). Once you have a candidate ref:
+
+```bash
+# What's in this artifact? Reads only the manifest + config blob,
+# does not pull the layer.
+installer inspect oci://ghcr.io/myorg/statusboard:0.1.0
+
+# What versions are available?
+installer list oci://ghcr.io/myorg/statusboard
+```
+
+For private registries, log in first:
+
+```bash
+installer login ghcr.io
+# uses ~/.docker/config.json; same auth as docker / podman
+```
+
+Once you've decided to install, pull it locally:
+
+```bash
+installer pull oci://ghcr.io/myorg/statusboard:0.1.0 ./statusboard
+installer doc ./statusboard
+# Shows components, inputs, externalRequires, dependencies — the
+# operator-facing surface of the package.
+```
+
+## Install: pull → wizard → render → upload
+
+The end-to-end install is four commands. The first three operate
+locally; only the fourth touches ConfigHub.
+
+```bash
+WD=/tmp/statusboard-install
+mkdir -p $WD
+
+# 1. Pull the package + answer the wizard.
+installer wizard oci://ghcr.io/myorg/statusboard:0.1.0 \
+  --work-dir $WD \
+  --namespace statusboard
+
+# Interactive prompts (skip with --non-interactive + flags):
+#   Components: [minimal/default/all/selected]
+#   Number of replicas:  [1]
+#   ...
+```
+
+The wizard pulls the package into `$WD/package/` and writes its
+output to `$WD/out/spec/`. If you prefer to script the wizard:
+
+```bash
+installer wizard oci://ghcr.io/myorg/statusboard:0.1.0 \
+  --work-dir $WD --non-interactive \
+  --namespace statusboard \
+  --components default \
+  --input replicas=3
+```
+
+Then render:
+
+```bash
+# 2. Render: kustomize build + function chain → out/manifests/
+installer render $WD
+```
+
+Inspect what was produced before pushing to ConfigHub:
+
+```bash
+ls $WD/out/manifests/
+# deployment-statusboard-statusboard.yaml
+# namespace-statusboard.yaml
+# service-statusboard-statusboard.yaml
+```
+
+You can edit these files directly — the next `plan` / `update` will
+diff your edits against ConfigHub. But editing rendered output is
+usually the wrong layer; prefer editing `out/spec/inputs.yaml` and
+re-running `installer render`. See "Where to make changes" below.
+
+Finally, upload to ConfigHub:
+
+```bash
+# 3. Upload: one Unit per file, plus an installer-record Unit
+#    holding installer.yaml + spec/ docs.
+installer upload $WD --space statusboard-prod
+```
+
+`installer upload` records the destination Space (and your active
+cub organization + server) into `$WD/out/spec/upload.yaml` so
+subsequent commands re-enter without you re-typing.
+
+For multi-package installs (a parent that declares dependencies),
+use `--space-pattern` instead of `--space`:
+
+```bash
+installer upload $WD --space-pattern '{{.PackageName}}-prod'
+# Each package — parent + each locked dep — gets its own Space.
+```
+
+## Where to make changes
+
+There are three layers of override, in increasing flexibility and
+decreasing reversibility. Use the lowest layer that fits.
+
+### 1. Wizard inputs (install-time)
+
+When you re-render with a different selection / inputs, the install
+re-derives the manifests. This is the right layer for choices the
+package author exposed as inputs: replica counts, names, tunable
+behaviors. Edit `$WD/out/spec/inputs.yaml` and re-render, or re-run
+the wizard:
+
+```bash
+# Re-run the wizard. If a prior install is recorded, it offers
+# "Re-use last choices?" — answer no to walk every prompt with the
+# prior values pre-filled.
+installer wizard oci://ghcr.io/myorg/statusboard:0.1.0 --work-dir $WD
+
+# Or hand-edit:
+$EDITOR $WD/out/spec/inputs.yaml
+installer render $WD
+```
+
+Then `installer plan $WD` to see what the change would do, and
+`installer update $WD --yes` to apply it.
+
+### 2. `--set-image` overrides (install-time, image-only)
+
+The most common day-2 change is a container image tag bump (mirror,
+patch release). If the package declares an `images:` block in its
+chosen base, you can override at upgrade time without editing the
+package source:
+
+```bash
+installer upgrade $WD oci://ghcr.io/myorg/statusboard:0.1.0 \
+    --set-image myorg/statusboard=myorg/statusboard:1.2.4 \
+    --apply
+```
+
+The override is recorded in `$WD/out/spec/inputs.yaml` under
+`spec.imageOverrides`, so subsequent upgrades carry it forward unless
+you pass a different `--set-image` for the same name. If the package
+doesn't declare an `images:` block, this fails fast with a message
+naming the missing block.
+
+### 3. Post-install ConfigHub mutations
+
+Once Units are in ConfigHub, you can mutate them directly:
+
+```bash
+cub function do --space statusboard-prod set-container-image \
+    deployment-statusboard-statusboard app myorg/statusboard:1.2.5
+```
+
+These edits survive re-render: `installer update` uses
+`--merge-external-source`, which only writes paths that changed in
+the new render. Your post-install ConfigHub edits are preserved.
+
+This is the right layer for changes that don't warrant a re-render
+— ad-hoc fixes, exploratory tuning, anything where you want the
+change tracked in cub's revision history rather than your work-dir.
+
+### What NOT to do
+
+- **Don't edit the package source tree** (`$WD/package/`). The next
+  `installer pull` or `installer upgrade` overwrites it. If you find
+  yourself running `kustomize edit` against `$WD/package/...`, stop —
+  use `--set-image` or post-install mutations instead. (See
+  [Principle 1](./principles.md#1-package-files-are-read-only-to-consumers).)
+
+## Day-2: plan, update, revert
+
+### Plan
+
+`installer plan $WD` is read-only. It shows three things per Space:
+
+```
+Plan: 1 to add, 2 to change, 0 to delete.
+
+Space statusboard-prod:
+  + ingress-tls-cert
+  ~ deployment-statusboard-statusboard
+      Resource: apps/v1/Deployment statusboard/statusboard
+        ~ [Update] spec.replicas
+          1 →     3
+  ~ service-statusboard-statusboard
+      ...
+
+Images in statusboard-prod (post-render):
+      Deployment/statusboard [app] myorg/statusboard:1.2.4
+```
+
+Plan computes the diff by listing existing Units (filtered by the
+`Component=<package>` label) and dry-running a merge of each
+rendered file against ConfigHub. Empty diff (after filtering
+ConfigHub bookkeeping) means no change.
+
+The `Images:` footer is built from the rendered manifests locally,
+so it reflects what would land if you ran update — independent of
+whether plan shows other changes.
+
+### Update
+
+`installer update $WD` re-runs the same plan and executes it inside
+a ChangeSet:
+
+```bash
+installer update $WD --yes
+# == Space statusboard-prod (statusboard@0.1.0) ==
+# ChangeSet: statusboard-prod/installer-update-20260514-…
+# Successfully updated unit deployment-statusboard-statusboard …
+#
+# Applied: 0 created, 1 updated, 0 deleted.
+# Updates revertable via:
+#   cub unit update --patch --space statusboard-prod \
+#       --restore Before:ChangeSet:installer-update-20260514-… \
+#       --where "Slug IN ('deployment-statusboard-statusboard')"
+```
+
+The ChangeSet name is printed and the precise revert command is
+written to stdout — copy/paste it later if you need to roll back.
+
+`--yes` is required when stdin isn't a TTY and the plan contains
+deletes; otherwise update prompts per delete.
+
+A re-run on a converged work-dir is a no-op (no ChangeSet opened):
+
+```bash
+installer update $WD
+# No changes.
+```
+
+### Revert
+
+To revert an update, run the printed `cub unit update --patch
+--restore` command. **Note the ChangeSet revert scope:**
+
+- Only **updates** are reverted by `--restore Before:ChangeSet:…`.
+- **Creates** from that update are not reverted automatically — to
+  undo a create, delete the Unit (`cub unit delete --space S
+  <slug>`).
+- **Deletes** from that update are not reverted automatically —
+  re-render and re-run `installer update` to re-create.
+
+If you need to roll back a multi-Unit change, this is where having
+the Component label pays off:
+
+```bash
+# Delete every Unit this package owns in this Space.
+cub unit delete --space statusboard-prod \
+    --where "Labels.Component='statusboard'"
+# Then re-render + re-update from the work-dir's prior state.
+```
+
+## Upgrade: re-pull, re-render, plan, apply
+
+`installer upgrade` stages a re-pull + re-render in `$WD/.upgrade/`
+without touching the active install. `installer upgrade-apply`
+atomically promotes the staged tree and runs update.
+
+### Routine upgrade
+
+```bash
+installer upgrade $WD oci://ghcr.io/myorg/statusboard:0.2.0
+# Staging upgrade in /tmp/.../.upgrade
+# Prior install loaded from confighub.
+# Wizard wrote .upgrade/out/spec/{selection,inputs}.yaml
+# Adopted new default for input "metrics_port": 9090
+# Adopted new default-flagged component(s): metrics-collector
+# Plan: 0 to add, 2 to change, 0 to delete.
+# ...
+#
+# Next: installer upgrade-apply /tmp/...   (or rerun with --apply)
+```
+
+The plan is printed; nothing in ConfigHub changed yet. Review, then
+promote:
+
+```bash
+installer upgrade-apply $WD --yes
+```
+
+This atomically swaps `.upgrade/package` → `package` and
+`.upgrade/out` → `out`, archives the prior tree to `.upgrade-prev/`
+(kept for one rollback step), then runs update with a distinctive
+ChangeSet slug `installer-upgrade-<from>-to-<to>-<timestamp>`.
+
+For a one-shot upgrade + execute, chain with `--apply`:
+
+```bash
+installer upgrade $WD oci://ghcr.io/myorg/statusboard:0.2.0 --apply --yes
+```
+
+### Image-only upgrade
+
+A common case is "same package version, new image tag" — e.g., a
+patch-level container bump:
+
+```bash
+installer upgrade $WD oci://ghcr.io/myorg/statusboard:0.2.0 \
+    --set-image myorg/statusboard=myorg/statusboard:0.2.1 \
+    --apply
+```
+
+Plan output should be a one-line image change. The override is
+persisted; the next upgrade without `--set-image` carries it
+forward.
+
+### Schema-diff handling
+
+When the new package's input schema differs from the old, upgrade
+behaves as follows (no operator action needed in most cases):
+
+- **New input with default**: silently adopted. Logged.
+- **New required input without default**: prompted in interactive
+  mode; in non-interactive mode, upgrade fails fast naming each
+  missing input. Run `installer wizard $WD <new-ref>` interactively
+  to answer them, then re-run upgrade.
+- **Removed input**: silently dropped from the new `inputs.yaml`.
+- **Type-changed input**: upgrade errors. Re-run `installer wizard`
+  to re-answer.
+
+For components, similar rules: if your prior selection matched the
+old package's `default` preset exactly, the upgrade adopts the new
+package's default preset (so a newly-flagged `default: true`
+component flows in automatically). Otherwise the prior list is
+filtered to components that still exist.
+
+### Re-collecting facts (collector packages)
+
+If the package declares a collector, upgrade re-runs it. This is the
+right behavior when cluster state has changed in a way the
+collector picks up (a worker was rotated, the cub server moved,
+etc.) — even with the same `<ref>`:
+
+```bash
+installer upgrade $WD oci://ghcr.io/myorg/statusboard:0.2.0
+# even if 0.2.0 is what you already have — re-runs the collector.
+```
+
+## Trust + signing
+
+When a package author signs their releases, you can verify on every
+pull. Two ways:
+
+### One-off verification
+
+```bash
+installer verify oci://ghcr.io/myorg/statusboard:0.1.0 --key cosign.pub
+# or for keyless (Sigstore Fulcio + OIDC):
+installer verify oci://ghcr.io/myorg/statusboard:0.1.0 \
+    --identity author@myorg.com --issuer https://accounts.google.com
+```
+
+### Enforced policy
+
+Configure `~/.config/installer/policy.yaml` to require signatures on
+every fetch. When the file exists, `installer pull` and `installer
+deps update` enforce verification automatically.
+
+```yaml
+# ~/.config/installer/policy.yaml
+apiVersion: installer.confighub.com/v1alpha1
+kind: SigningPolicy
+spec:
+  enforce: true
+  trustedKeys:
+    - publicKey: |
+        -----BEGIN PUBLIC KEY-----
+        MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE...
+        -----END PUBLIC KEY-----
+      repoPrefix: oci://ghcr.io/myorg/    # only enforce on this prefix
+  trustedKeyless:
+    - identity: author@myorg.com
+      issuer: https://accounts.google.com
+      repoPrefix: oci://ghcr.io/myorg/
+```
+
+`enforce: true` makes verification mandatory. Setting `enforce:
+false` keeps the policy advisory (pulls still succeed on mismatch
+but log a warning).
+
+## Multi-package installs
+
+Some packages declare dependencies on other installer packages. The
+flow gets one extra step (`deps update`):
+
+```bash
+WD=/tmp/stack-install
+installer wizard oci://ghcr.io/myorg/stack:1.0.0 --work-dir $WD --namespace stack
+
+# Resolve the dependency DAG — writes out/spec/lock.yaml pinning
+# each dep to a manifest digest.
+installer deps update $WD
+
+# Render parent + each dep into its own subtree.
+installer render $WD
+ls $WD/out/manifests/         # parent's manifests
+ls $WD/out/<dep-name>/manifests/  # each dep's manifests
+
+# Upload one Space per package.
+installer upload $WD --space-pattern '{{.PackageName}}-prod'
+```
+
+Plan / update / upgrade work the same way — each operates across
+all locked packages, opens one ChangeSet per Space when there are
+updates, and prints a per-Space revert command.
+
+`installer deps tree $WD` shows the resolved DAG if you want to
+audit who depends on what.
+
+## Re-entering an install from a fresh machine
+
+The `out/spec/upload.yaml` file written by `installer upload` is
+what bootstraps everything. From a fresh clone of the work-dir, all
+day-2 commands work because they read `upload.yaml` to find the
+Spaces.
+
+If the work-dir is genuinely lost (disk failure, lost laptop), the
+package's `installer-record` Unit on ConfigHub holds the full spec
++ a copy of `upload.yaml`. Recover with:
+
+```bash
+WD=/tmp/recovered
+mkdir -p $WD
+# Pull the package source.
+installer pull oci://ghcr.io/myorg/statusboard:0.1.0 $WD/package
+
+# Pull the installer-record Unit body and split it into spec docs.
+mkdir -p $WD/out/spec
+cub unit data --space statusboard-prod installer-record \
+    > $WD/out/spec/installer-record.yaml
+# (Splitting it back into selection.yaml / inputs.yaml / facts.yaml
+# / upload.yaml is a manual step today; an `installer recover`
+# command will automate this.)
+
+installer render $WD
+installer plan $WD       # should be No changes if cub is in sync
+```
+
+## Common errors
+
+### `--set-image was given but bases/.../kustomization.yaml has no images: block`
+
+The package author hasn't declared the image as overridable. Two
+options: (1) ask the author to add an `images:` block declaring the
+image you want to override; (2) make the change post-install via
+`cub function do set-container-image` instead.
+
+### `cub context organization mismatch: upload.yaml recorded org_… current cub context is org_…`
+
+Your active cub context is signed into a different organization than
+the one the install was uploaded to. Switch with `cub context set
+<name>` or `cub auth login` against the recorded organization.
+
+### `nothing to apply: …/.upgrade missing package and/or out`
+
+You ran `installer upgrade-apply` without first staging an upgrade.
+Run `installer upgrade $WD <ref>` first, then upgrade-apply.
+
+### `package declares dependencies but … lock.yaml does not exist`
+
+You ran `installer render` before `installer deps update` on a
+multi-package install. Run `installer deps update $WD` first.
+
+### `the new package adds N required input(s) that the prior install did not answer`
+
+A non-interactive `installer upgrade` ran against a package version
+that adds new required inputs. Run `installer wizard $WD <new-ref>`
+interactively to answer them, then re-run upgrade.
+
+### Non-existent revert: `change_set_id value does not match Unit ChangeSetID`
+
+You're trying to update or restore a Unit that's currently locked
+inside an open ChangeSet (typically a still-running `installer
+update` from another shell). Wait for it to finish, then re-run.
+
+### `cub unit data installer-record: … not found`
+
+The installer-record Unit was deleted from cub, or the recorded
+Space slug in `upload.yaml` is stale. The wizard's prior-state load
+falls back to local `out/spec/*.yaml` automatically with a warning.
+If you want to refresh ConfigHub from local state, re-run
+`installer upload $WD --space <slug>` against the same Space.
+
+## Quick reference
+
+| Task | Command |
+|---|---|
+| Discover what's in a registry | `installer inspect <ref>` / `installer list <repo>` |
+| Pull a package locally | `installer pull <ref> <dir>` |
+| Read the package's surface | `installer doc <dir>` |
+| Install (interactive) | `installer wizard <ref> --work-dir $WD --namespace <ns>` |
+| Install (scripted) | `installer wizard <ref> --work-dir $WD --non-interactive --namespace <ns> --components default` |
+| Render after editing inputs | `installer render $WD` |
+| Push to ConfigHub | `installer upload $WD --space <slug>` |
+| Preview cub-side changes | `installer plan $WD` |
+| Apply cub-side changes | `installer update $WD --yes` |
+| Bump an image | `installer upgrade $WD <same-ref> --set-image NAME=REF --apply` |
+| Upgrade to a new version | `installer upgrade $WD <new-ref>` then `installer upgrade-apply $WD` |
+| One-shot upgrade | `installer upgrade $WD <new-ref> --apply` |
+| Resolve deps | `installer deps update $WD` (multi-package only) |
+| Verify a signature | `installer verify <ref> --key cosign.pub` |
+| Make signature mandatory | edit `~/.config/installer/policy.yaml` |
+
+## Where to go next
+
+- [author-guide.md](./author-guide.md) — what package authors are
+  responsible for. Reading it once will make the consumer side feel
+  obvious.
+- [principles.md](./principles.md) — the doctrine the installer is
+  anchored to. Worth re-reading after your first few installs.


### PR DESCRIPTION
## Summary

Three new user-facing docs, cleanly distinct from the contributor-facing design docs ([`principles.md`](docs/principles.md), [`package-management.md`](docs/package-management.md), [`lifecycle.md`](docs/lifecycle.md), and their `-plan.md` companions). Closes the "Documentation for package authors and for package consumers" roadmap item.

- **[`docs/author-guide.md`](docs/author-guide.md)** — package author reference. Mental model, file organization, the full `installer.yaml` schema field-by-field (`bases`, `components`, `inputs`, `functionChainTemplate`, `externalRequires`, `provides`, `clusterSingleton`, `externalManifests`, `collector`, `validation`, `dependencies`, `conflicts`, `replaces`, `bundleExamples`), how the install pipeline consumes each declaration, authoring best practices anchored to [`principles.md`](docs/principles.md), publishing + signing, version-to-version evolution rules (what schema diffs are safe, what aren't), and common author tasks.
- **[`docs/author-tutorial.md`](docs/author-tutorial.md)** — 30-minute hands-on walkthrough. Authors a `statusboard` package from an empty directory: minimum viable package → namespace-rewriting function chain → wizard input → kustomize `images:` block for `--set-image` → opt-in component with `default: true` → second component with `requires:` → interactive wizard → `installer package` + `installer push` + signing. Built fresh (not just a tour of `examples/hello-app`) so every decision is visible.
- **[`docs/consumer-guide.md`](docs/consumer-guide.md)** — operator/installer guide. Find a package, install (pull → wizard → render → upload), three layers of override (wizard inputs / `--set-image` / post-install ConfigHub mutations) and when to use which, day-2 (plan / update / revert with the precise revert command), upgrade (routine + image-only + schema-diff handling + fact-recollection), trust + signing policy, multi-package installs, recovery from a fresh machine via the `installer-record` Unit, troubleshooting common errors, and a one-page quick-reference command table.

README updates:
- New **User docs** section above **Design docs**, framing each by audience: user docs are how-to/reference for authors and operators; design docs explain _why_ the installer works the way it does and are for installer contributors.
- Drop "Documentation for package authors and for package consumers" from Roadmap.

## Test plan

- [x] `wc -l` ≈ 1930 lines added across three new docs.
- [x] All four files preview correctly in GitHub Markdown (verified locally).
- [x] No claims about commands that don't exist (cross-referenced against `installer --help` and the schema in `pkg/api/`).
- [x] Recovery section honestly notes that an `installer recover` command is not yet shipped (manual split required today).
- [x] Troubleshooting section uses verbatim error messages from the implementation.
- [x] Inter-doc links resolve (relative paths, all targets exist).
- [x] No code changes — docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)