### PR TITLE
Rename Go module to github.com/confighub/installer

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 confighubai
+Copyright (c) 2026 ConfigHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ The binary doubles as a `cub` plugin. After publishing a release that includes
 a platform binary at the path `bin/installer`, install with:
 
 ```bash
-cub plugin install confighubai/installer
+cub plugin install confighub/installer
 ```
 
 The `cub-plugin.yaml` at the repo root tells cub the entry point. Once
@@ -282,10 +282,10 @@ authoring packages, the user docs above are what you want.
   phased build plan for bundling, OCI publish, dependency declaration
   and resolution, and signing. Phases 0–8 shipped.
 - [Day-2 lifecycle: interactive wizard, plan, update, upgrade](docs/lifecycle.md)
-  + [implementation plan](docs/lifecycle-plan.md) — spec and phased
-  build plan for the interactive wizard, prior-state re-entry, plan
-  vs ConfigHub, ChangeSet-wrapped update, staged upgrade with
-  schema-diff, and `--set-image` overrides. Phases A–E shipped.
+  - [implementation plan](docs/lifecycle-plan.md) — spec and phased
+    build plan for the interactive wizard, prior-state re-entry, plan
+    vs ConfigHub, ChangeSet-wrapped update, staged upgrade with
+    schema-diff, and `--set-image` overrides. Phases A–E shipped.
 
 ## Multi-package example
 

--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/confighubai/installer/internal/cli"
+	"github.com/confighub/installer/internal/cli"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/confighubai/installer
+module github.com/confighub/installer
 
 go 1.25.0
 

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/confighubai/installer/internal/deps"
-	ipkg "github.com/confighubai/installer/internal/pkg"
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/internal/deps"
+	ipkg "github.com/confighub/installer/internal/pkg"
+	"github.com/confighub/installer/pkg/api"
 )
 
 func newDepsCmd() *cobra.Command {

--- a/internal/cli/doc.go
+++ b/internal/cli/doc.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	ipkg "github.com/confighubai/installer/internal/pkg"
-	"github.com/confighubai/installer/pkg/api"
+	ipkg "github.com/confighub/installer/internal/pkg"
+	"github.com/confighub/installer/pkg/api"
 )
 
 func sortedMapKeys(m map[string]any) []string {

--- a/internal/cli/edit.go
+++ b/internal/cli/edit.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/pkg/api"
 )
 
 // `installer edit` lets package authors mutate installer.yaml fields

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/pkg/api"
 )
 
 // defaultValidators is the validator chain `installer init` seeds new

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	ipkg "github.com/confighubai/installer/internal/pkg"
+	ipkg "github.com/confighub/installer/internal/pkg"
 )
 
 func newInspectCmd() *cobra.Command {

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	ipkg "github.com/confighubai/installer/internal/pkg"
+	ipkg "github.com/confighub/installer/internal/pkg"
 )
 
 func newListCmd() *cobra.Command {

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
-	ipkg "github.com/confighubai/installer/internal/pkg"
+	ipkg "github.com/confighub/installer/internal/pkg"
 )
 
 func newLoginCmd() *cobra.Command {

--- a/internal/cli/logout.go
+++ b/internal/cli/logout.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	ipkg "github.com/confighubai/installer/internal/pkg"
+	ipkg "github.com/confighub/installer/internal/pkg"
 )
 
 func newLogoutCmd() *cobra.Command {

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -12,8 +12,8 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
-	"github.com/confighubai/installer/internal/cubctx"
-	"github.com/confighubai/installer/internal/userconfig"
+	"github.com/confighub/installer/internal/cubctx"
+	"github.com/confighub/installer/internal/userconfig"
 )
 
 // kubernetesResourcesPackageName must match

--- a/internal/cli/package.go
+++ b/internal/cli/package.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/confighubai/installer/internal/bundle"
-	ipkg "github.com/confighubai/installer/internal/pkg"
+	"github.com/confighub/installer/internal/bundle"
+	ipkg "github.com/confighub/installer/internal/pkg"
 )
 
 func newPackageCmd() *cobra.Command {

--- a/internal/cli/plan.go
+++ b/internal/cli/plan.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/confighubai/installer/internal/cubctx"
-	"github.com/confighubai/installer/internal/deps"
-	"github.com/confighubai/installer/internal/diff"
-	ipkg "github.com/confighubai/installer/internal/pkg"
-	"github.com/confighubai/installer/internal/upload"
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/internal/cubctx"
+	"github.com/confighub/installer/internal/deps"
+	"github.com/confighub/installer/internal/diff"
+	ipkg "github.com/confighub/installer/internal/pkg"
+	"github.com/confighub/installer/internal/upload"
+	"github.com/confighub/installer/pkg/api"
 )
 
 func newPlanCmd() *cobra.Command {

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	ipkg "github.com/confighubai/installer/internal/pkg"
+	ipkg "github.com/confighub/installer/internal/pkg"
 )
 
 func newPullCmd() *cobra.Command {

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	ipkg "github.com/confighubai/installer/internal/pkg"
+	ipkg "github.com/confighub/installer/internal/pkg"
 )
 
 func newPushCmd() *cobra.Command {

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/confighubai/installer/internal/deps"
-	ipkg "github.com/confighubai/installer/internal/pkg"
-	"github.com/confighubai/installer/internal/render"
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/internal/deps"
+	ipkg "github.com/confighub/installer/internal/pkg"
+	"github.com/confighub/installer/internal/render"
+	"github.com/confighub/installer/pkg/api"
 )
 
 func newRenderCmd() *cobra.Command {

--- a/internal/cli/sign.go
+++ b/internal/cli/sign.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/confighubai/installer/internal/sign"
+	"github.com/confighub/installer/internal/sign"
 )
 
 func newSignCmd() *cobra.Command {

--- a/internal/cli/tag.go
+++ b/internal/cli/tag.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	ipkg "github.com/confighubai/installer/internal/pkg"
+	ipkg "github.com/confighub/installer/internal/pkg"
 )
 
 func newTagCmd() *cobra.Command {

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/confighubai/installer/internal/changeset"
-	"github.com/confighubai/installer/internal/cubctx"
-	"github.com/confighubai/installer/internal/diff"
-	ipkg "github.com/confighubai/installer/internal/pkg"
-	"github.com/confighubai/installer/internal/upload"
+	"github.com/confighub/installer/internal/changeset"
+	"github.com/confighub/installer/internal/cubctx"
+	"github.com/confighub/installer/internal/diff"
+	ipkg "github.com/confighub/installer/internal/pkg"
+	"github.com/confighub/installer/internal/upload"
 )
 
 // refreshInstallerRecordHook builds an Apply PostSpaceHook that

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -12,14 +12,14 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
-	"github.com/confighubai/installer/internal/cubctx"
-	"github.com/confighubai/installer/internal/deps"
-	"github.com/confighubai/installer/internal/diff"
-	ipkg "github.com/confighubai/installer/internal/pkg"
-	"github.com/confighubai/installer/internal/render"
-	"github.com/confighubai/installer/internal/upload"
-	"github.com/confighubai/installer/internal/wizard"
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/internal/cubctx"
+	"github.com/confighub/installer/internal/deps"
+	"github.com/confighub/installer/internal/diff"
+	ipkg "github.com/confighub/installer/internal/pkg"
+	"github.com/confighub/installer/internal/render"
+	"github.com/confighub/installer/internal/upload"
+	"github.com/confighub/installer/internal/wizard"
+	"github.com/confighub/installer/pkg/api"
 )
 
 // upgradeStageDir is the sibling of work-dir/package and work-dir/out

--- a/internal/cli/upgrade_apply.go
+++ b/internal/cli/upgrade_apply.go
@@ -10,13 +10,13 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/confighubai/installer/internal/changeset"
-	"github.com/confighubai/installer/internal/cubctx"
-	"github.com/confighubai/installer/internal/deps"
-	"github.com/confighubai/installer/internal/diff"
-	ipkg "github.com/confighubai/installer/internal/pkg"
-	"github.com/confighubai/installer/internal/upload"
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/internal/changeset"
+	"github.com/confighub/installer/internal/cubctx"
+	"github.com/confighub/installer/internal/deps"
+	"github.com/confighub/installer/internal/diff"
+	ipkg "github.com/confighub/installer/internal/pkg"
+	"github.com/confighub/installer/internal/upload"
+	"github.com/confighub/installer/pkg/api"
 )
 
 func newUpgradeApplyCmd() *cobra.Command {

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/confighubai/installer/internal/deps"
-	ipkg "github.com/confighubai/installer/internal/pkg"
-	"github.com/confighubai/installer/internal/upload"
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/internal/deps"
+	ipkg "github.com/confighub/installer/internal/pkg"
+	"github.com/confighub/installer/internal/upload"
+	"github.com/confighub/installer/pkg/api"
 )
 
 func newUploadCmd() *cobra.Command {

--- a/internal/cli/userstate_helpers.go
+++ b/internal/cli/userstate_helpers.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/confighubai/installer/internal/cubctx"
-	"github.com/confighubai/installer/internal/upload"
-	"github.com/confighubai/installer/internal/userconfig"
+	"github.com/confighub/installer/internal/cubctx"
+	"github.com/confighub/installer/internal/upload"
+	"github.com/confighub/installer/internal/userconfig"
 )
 
 // recordedPackages is the allowlist of package names whose upload

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/confighubai/installer/internal/sign"
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/internal/sign"
+	"github.com/confighub/installer/pkg/api"
 )
 
 func newVerifyCmd() *cobra.Command {

--- a/internal/cli/vet.go
+++ b/internal/cli/vet.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	ipkg "github.com/confighubai/installer/internal/pkg"
-	"github.com/confighubai/installer/internal/render"
-	"github.com/confighubai/installer/pkg/api"
+	ipkg "github.com/confighub/installer/internal/pkg"
+	"github.com/confighub/installer/internal/render"
+	"github.com/confighub/installer/pkg/api"
 )
 
 func newVetCmd() *cobra.Command {

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -9,10 +9,10 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
-	"github.com/confighubai/installer/internal/cubctx"
-	ipkg "github.com/confighubai/installer/internal/pkg"
-	"github.com/confighubai/installer/internal/wizard"
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/internal/cubctx"
+	ipkg "github.com/confighub/installer/internal/pkg"
+	"github.com/confighub/installer/internal/wizard"
+	"github.com/confighub/installer/pkg/api"
 )
 
 func newWizardCmd() *cobra.Command {

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -22,7 +22,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/pkg/api"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/deps/lock.go
+++ b/internal/deps/lock.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/pkg/api"
 )
 
 // Annotation key under which the resolver records a hash of the root

--- a/internal/deps/resolver.go
+++ b/internal/deps/resolver.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 
-	"github.com/confighubai/installer/internal/sign"
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/internal/sign"
+	"github.com/confighub/installer/pkg/api"
 )
 
 // Options configure a Resolve call.

--- a/internal/deps/resolver_test.go
+++ b/internal/deps/resolver_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	ipkg "github.com/confighubai/installer/internal/pkg"
-	"github.com/confighubai/installer/pkg/api"
+	ipkg "github.com/confighub/installer/internal/pkg"
+	"github.com/confighub/installer/pkg/api"
 )
 
 // mockSource implements Source by returning canned manifests + tag lists,

--- a/internal/deps/source.go
+++ b/internal/deps/source.go
@@ -11,8 +11,8 @@ import (
 	"context"
 	"strings"
 
-	ipkg "github.com/confighubai/installer/internal/pkg"
-	"github.com/confighubai/installer/pkg/api"
+	ipkg "github.com/confighub/installer/internal/pkg"
+	"github.com/confighub/installer/pkg/api"
 )
 
 // Source is the resolver's view of a package registry. It returns one

--- a/internal/diff/apply.go
+++ b/internal/diff/apply.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/confighubai/installer/internal/changeset"
-	"github.com/confighubai/installer/internal/upload"
+	"github.com/confighub/installer/internal/changeset"
+	"github.com/confighub/installer/internal/upload"
 )
 
 // PackageRefresher is the hook Apply calls after each Space's Unit

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -19,7 +19,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/confighubai/installer/internal/upload"
+	"github.com/confighub/installer/internal/upload"
 )
 
 // Plan is the diff between a work-dir's rendered output and the live

--- a/internal/pkg/load.go
+++ b/internal/pkg/load.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/pkg/api"
 )
 
 // Loaded is a parsed package on disk: the root directory and the parsed manifest.

--- a/internal/pkg/oci.go
+++ b/internal/pkg/oci.go
@@ -20,9 +20,9 @@ import (
 	"oras.land/oras-go/v2/content/memory"
 	"oras.land/oras-go/v2/registry/remote"
 
-	"github.com/confighubai/installer/internal/bundle"
-	"github.com/confighubai/installer/internal/version"
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/internal/bundle"
+	"github.com/confighub/installer/internal/version"
+	"github.com/confighub/installer/pkg/api"
 )
 
 // PushResult is what Push returns about a completed push.

--- a/internal/pkg/oci_test.go
+++ b/internal/pkg/oci_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/opencontainers/go-digest"
 	"oras.land/oras-go/v2/content/memory"
 
-	"github.com/confighubai/installer/internal/bundle"
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/internal/bundle"
+	"github.com/confighub/installer/pkg/api"
 )
 
 const testInstallerYAML = `apiVersion: installer.confighub.com/v1alpha1

--- a/internal/pkg/pull.go
+++ b/internal/pkg/pull.go
@@ -16,8 +16,8 @@ import (
 	"oras.land/oras-go/v2/content/file"
 	"oras.land/oras-go/v2/registry/remote"
 
-	"github.com/confighubai/installer/internal/sign"
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/internal/sign"
+	"github.com/confighub/installer/pkg/api"
 )
 
 // Pull resolves a package reference to a local directory ready for Load.

--- a/internal/render/chain.go
+++ b/internal/render/chain.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/pkg/api"
 	fapi "github.com/confighub/sdk/core/function/api"
 	"github.com/confighub/sdk/core/workerapi"
 	funcimpl "github.com/confighub/sdk/function-impl"

--- a/internal/render/compose.go
+++ b/internal/render/compose.go
@@ -19,8 +19,8 @@ import (
 	"os"
 	"path/filepath"
 
-	ipkg "github.com/confighubai/installer/internal/pkg"
-	"github.com/confighubai/installer/pkg/api"
+	ipkg "github.com/confighub/installer/internal/pkg"
+	"github.com/confighub/installer/pkg/api"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/render/e2e_test.go
+++ b/internal/render/e2e_test.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"testing"
 
-	ipkg "github.com/confighubai/installer/internal/pkg"
-	"github.com/confighubai/installer/internal/render"
-	"github.com/confighubai/installer/internal/selection"
-	"github.com/confighubai/installer/internal/wizard"
+	ipkg "github.com/confighub/installer/internal/pkg"
+	"github.com/confighub/installer/internal/render"
+	"github.com/confighub/installer/internal/selection"
+	"github.com/confighub/installer/internal/wizard"
 )
 
 // TestEndToEnd_HelloApp drives the example package through wizard → render

--- a/internal/render/images.go
+++ b/internal/render/images.go
@@ -10,8 +10,8 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	ipkg "github.com/confighubai/installer/internal/pkg"
-	"github.com/confighubai/installer/pkg/api"
+	ipkg "github.com/confighub/installer/internal/pkg"
+	"github.com/confighub/installer/pkg/api"
 )
 
 // applyImageOverrides runs `kustomize edit set image <name>=<ref>` for

--- a/internal/render/images_test.go
+++ b/internal/render/images_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	ipkg "github.com/confighubai/installer/internal/pkg"
-	"github.com/confighubai/installer/pkg/api"
+	ipkg "github.com/confighub/installer/internal/pkg"
+	"github.com/confighub/installer/pkg/api"
 )
 
 func TestApplyImageOverridesNoOpWhenEmpty(t *testing.T) {

--- a/internal/render/multipkg.go
+++ b/internal/render/multipkg.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"path/filepath"
 
-	ipkg "github.com/confighubai/installer/internal/pkg"
-	"github.com/confighubai/installer/internal/selection"
-	"github.com/confighubai/installer/pkg/api"
+	ipkg "github.com/confighub/installer/internal/pkg"
+	"github.com/confighub/installer/internal/selection"
+	"github.com/confighub/installer/pkg/api"
 )
 
 // Fetcher resolves a locked dependency to a local directory the renderer

--- a/internal/render/multipkg_test.go
+++ b/internal/render/multipkg_test.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/confighubai/installer/internal/render"
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/internal/render"
+	"github.com/confighub/installer/pkg/api"
 )
 
 const depPackageYAML = `apiVersion: installer.confighub.com/v1alpha1

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	ipkg "github.com/confighubai/installer/internal/pkg"
-	"github.com/confighubai/installer/pkg/api"
+	ipkg "github.com/confighub/installer/internal/pkg"
+	"github.com/confighub/installer/pkg/api"
 )
 
 // Options controls Render. All fields are required except Facts.

--- a/internal/render/split.go
+++ b/internal/render/split.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/pkg/api"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/render/validators_test.go
+++ b/internal/render/validators_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/pkg/api"
 )
 
 // passingResource is a minimal valid Deployment manifest. Used as the

--- a/internal/selection/solver.go
+++ b/internal/selection/solver.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/pkg/api"
 )
 
 // Resolve takes the package manifest, the user's chosen base name (may be ""),

--- a/internal/selection/solver_test.go
+++ b/internal/selection/solver_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/confighubai/installer/internal/selection"
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/internal/selection"
+	"github.com/confighub/installer/pkg/api"
 )
 
 func mkPkg() *api.Package {

--- a/internal/sign/cosign_integration_test.go
+++ b/internal/sign/cosign_integration_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 	"time"
 
-	ipkg "github.com/confighubai/installer/internal/pkg"
-	"github.com/confighubai/installer/internal/sign"
-	"github.com/confighubai/installer/pkg/api"
+	ipkg "github.com/confighub/installer/internal/pkg"
+	"github.com/confighub/installer/internal/sign"
+	"github.com/confighub/installer/pkg/api"
 )
 
 // TestCosignSignAndVerify exercises the real cosign binary against a local

--- a/internal/sign/sign.go
+++ b/internal/sign/sign.go
@@ -17,7 +17,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/pkg/api"
 )
 
 // Defaults

--- a/internal/sign/sign_test.go
+++ b/internal/sign/sign_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/pkg/api"
 )
 
 const policyYAML = `apiVersion: installer.confighub.com/v1alpha1

--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -24,8 +24,8 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/confighubai/installer/internal/cubctx"
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/internal/cubctx"
+	"github.com/confighub/installer/pkg/api"
 )
 
 // Package is one unit-of-upload — the parent or a locked dep.

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/pkg/api"
 )
 
 func TestRenderSpaceSlug(t *testing.T) {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,7 +1,7 @@
 // Package version exposes the installer build version. The default is "dev";
 // release builds set it via -ldflags:
 //
-//	go build -ldflags "-X github.com/confighubai/installer/internal/version.Version=0.4.0" ./cmd/installer
+//	go build -ldflags "-X github.com/confighub/installer/internal/version.Version=0.4.0" ./cmd/installer
 package version
 
 // Version is overridden at build time. Recorded in ConfigBlob.BundleInfo so

--- a/internal/wizard/interactive.go
+++ b/internal/wizard/interactive.go
@@ -9,7 +9,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
 
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/pkg/api"
 )
 
 // Component-set presets the wizard offers as the high-level shortcut to

--- a/internal/wizard/interactive_test.go
+++ b/internal/wizard/interactive_test.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/pkg/api"
 )
 
 func TestResolvePreset(t *testing.T) {

--- a/internal/wizard/prior.go
+++ b/internal/wizard/prior.go
@@ -8,8 +8,8 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/confighubai/installer/internal/upload"
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/internal/upload"
+	"github.com/confighub/installer/pkg/api"
 )
 
 // PriorState bundles the documents we recover from a prior install. Any

--- a/internal/wizard/prior_test.go
+++ b/internal/wizard/prior_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/confighubai/installer/internal/upload"
+	"github.com/confighub/installer/internal/upload"
 )
 
 func TestLoadPriorStateNone(t *testing.T) {

--- a/internal/wizard/schemadiff.go
+++ b/internal/wizard/schemadiff.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/pkg/api"
 )
 
 // InputDiff is the result of comparing the input schemas of an old

--- a/internal/wizard/schemadiff_test.go
+++ b/internal/wizard/schemadiff_test.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/pkg/api"
 )
 
 func TestDiffInputs_Carry(t *testing.T) {

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -12,9 +12,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/confighubai/installer/internal/collector"
-	"github.com/confighubai/installer/internal/selection"
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/internal/collector"
+	"github.com/confighub/installer/internal/selection"
+	"github.com/confighub/installer/pkg/api"
 )
 
 // RawAnswers are CLI-flag-shaped: parsed but not yet validated against the

--- a/pkg/api/parse_test.go
+++ b/pkg/api/parse_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/confighubai/installer/pkg/api"
+	"github.com/confighub/installer/pkg/api"
 )
 
 const validPackage = `apiVersion: installer.confighub.com/v1alpha1


### PR DESCRIPTION
## Summary

The repo moved from `github.com/confighubai/installer` to `github.com/confighub/installer`. This PR rewrites every `github.com/confighubai/installer` import + reference to the new path.

- `go.mod` module path bumped.
- Every `.go` file's imports rewritten (63 files).
- `go.sum` regenerated via `go mod tidy`.
- README and LICENSE updates from the prior commit (cub plugin path → `confighub/installer`, copyright holder → "ConfigHub Inc.") kept as-is.

No semantic changes — only the import path. Other `confighubai/*` strings in the tree (`oci://ghcr.io/confighubai/cert-manager`, `oci://ghcr.io/confighubai/foo`, etc.) are synthetic example refs in test fixtures and design docs representing where _other_ packages might live; they were intentionally NOT renamed.

## Test plan

- [x] `go build ./...` passes under the new module path.
- [x] `go test ./...` — full suite green (every package now reports `ok github.com/confighub/installer/...`).
- [x] `grep -rln 'confighubai/installer' .` returns no matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)