### PR TITLE
Align signing docs with shipped CLI; drop stubbed push --sign

### DIFF
--- a/docs/author-guide.md
+++ b/docs/author-guide.md
@@ -766,21 +766,23 @@ What's refused:
 
 ## Signing
 
-`installer push` accepts `--sign` to attach a cosign signature
-(keyed or keyless). Operators verify with `installer verify` or by
-configuring `~/.config/installer/policy.yaml` to require signatures
-matching trusted keys / identities — when that policy exists,
-`installer pull` and `installer deps update` enforce verification on
-every fetch.
+After `installer push`, attach a cosign signature with
+`installer sign <ref>`. Keyless mode (Sigstore Fulcio + Rekor) is
+the default; pass `--key <ref>` for keyed mode. Operators verify
+with `installer verify` or by configuring
+`~/.config/installer/policy.yaml` to require signatures matching
+trusted keys / identities — when that policy exists, `installer
+pull` and `installer deps update` enforce verification on every
+fetch. Requires the `cosign` binary on PATH (override via
+`INSTALLER_COSIGN_BIN`).
 
 ```bash
-# Keyed signing.
-installer push my-package-0.1.0.tgz oci://ghcr.io/myorg/my-package:0.1.0 \
-    --sign --key cosign.key
+# Keyless (Sigstore Fulcio + Rekor — interactive OIDC flow).
+# Add --yes to skip the cosign confirmation prompt in CI.
+installer sign oci://ghcr.io/myorg/my-package:0.1.0 --yes
 
-# Keyless (Sigstore Fulcio, OIDC).
-installer push my-package-0.1.0.tgz oci://ghcr.io/myorg/my-package:0.1.0 \
-    --sign --keyless
+# Keyed.
+installer sign oci://ghcr.io/myorg/my-package:0.1.0 --key cosign.key
 ```
 
 If your package will be consumed by people you don't know, sign every
@@ -943,9 +945,11 @@ case.)
 1. Bump `metadata.version` per SemVer.
 2. `installer package ./my-package -o my-package-X.Y.Z.tgz` — record
    the printed sha256.
-3. `installer push my-package-X.Y.Z.tgz oci://.../my-package:X.Y.Z
-   --sign` (or `--key` / `--keyless`).
-4. Optionally `installer tag oci://.../my-package:X.Y.Z latest` if
+3. `installer push my-package-X.Y.Z.tgz oci://.../my-package:X.Y.Z`.
+4. `installer sign oci://.../my-package:X.Y.Z --yes` (keyless) or
+   `installer sign oci://.../my-package:X.Y.Z --key cosign.key`
+   (keyed).
+5. Optionally `installer tag oci://.../my-package:X.Y.Z latest` if
    you publish a moving `latest` tag (most don't — a SemVer tag is
    reproducible).
 

--- a/docs/author-tutorial.md
+++ b/docs/author-tutorial.md
@@ -475,23 +475,26 @@ installer inspect oci://ghcr.io/myorg/statusboard:0.1.0
 installer pull oci://ghcr.io/myorg/statusboard:0.1.0 ./statusboard-pulled
 ```
 
-For production releases, sign with cosign — keyed:
+For production releases, sign with `installer sign` after push.
+Keyless (Sigstore Fulcio + Rekor) is the default — an interactive
+OIDC flow opens a browser; `--yes` skips cosign's TTY confirmation
+prompt for CI:
+
+```bash
+installer sign oci://ghcr.io/myorg/statusboard:0.1.0 --yes
+```
+
+Or keyed:
 
 ```bash
 cosign generate-key-pair
-installer push statusboard-0.1.0.tgz oci://ghcr.io/myorg/statusboard:0.1.0 \
-    --sign --key cosign.key
+installer sign oci://ghcr.io/myorg/statusboard:0.1.0 --key cosign.key
 ```
 
-Or keyless (Sigstore Fulcio + OIDC):
-
-```bash
-installer push statusboard-0.1.0.tgz oci://ghcr.io/myorg/statusboard:0.1.0 \
-    --sign --keyless
-```
-
-Operators can configure `~/.config/installer/policy.yaml` to require
-signatures on every pull.
+Requires the `cosign` binary on PATH (override via
+`INSTALLER_COSIGN_BIN`). Operators can configure
+`~/.config/installer/policy.yaml` to require signatures on every
+pull.
 
 ## Step 9: release a 0.2.0
 

--- a/docs/consumer-guide.md
+++ b/docs/consumer-guide.md
@@ -422,11 +422,13 @@ spec:
         -----BEGIN PUBLIC KEY-----
         MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE...
         -----END PUBLIC KEY-----
-      repoPrefix: oci://ghcr.io/myorg/    # only enforce on this prefix
+      repos:                              # each entry is a prefix; empty list = all repos
+        - oci://ghcr.io/myorg/
   trustedKeyless:
     - identity: author@myorg.com
       issuer: https://accounts.google.com
-      repoPrefix: oci://ghcr.io/myorg/
+      repos:
+        - oci://ghcr.io/myorg/
 ```
 
 `enforce: true` makes verification mandatory. Setting `enforce:

--- a/docs/package-management.md
+++ b/docs/package-management.md
@@ -319,7 +319,7 @@ surfaced in `installer inspect` and `installer doc`.
 
 ## Signing
 
-`installer push --sign` and `installer verify` use cosign (keyed or keyless).
+`installer sign` and `installer verify` use cosign (keyed or keyless).
 When a local policy file is present (`~/.config/installer/policy.yaml`),
 `pull` and `deps update` enforce verification before trusting an artifact's
 digest.

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -10,7 +10,6 @@ import (
 )
 
 func newPushCmd() *cobra.Command {
-	var sign bool
 	cmd := &cobra.Command{
 		Use:   "push <pkg.tgz|dir> <oci-ref>",
 		Short: "Push a packaged installer to an OCI registry",
@@ -23,12 +22,11 @@ The package is NOT rendered — only bundled. This differs from Kustomizer's
 push, which renders before uploading.
 
 ref must include a tag: oci://host/repo:tag. Digest-only refs are not
-supported because registries cannot accept blob pushes to a digest.`,
+supported because registries cannot accept blob pushes to a digest.
+
+To attach a cosign signature, run "installer sign <ref>" after push.`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if sign {
-				return fmt.Errorf("--sign not yet implemented; see docs/package-management-plan.md (Phase 7)")
-			}
 			ctx := context.Background()
 			res, err := ipkg.Push(ctx, args[0], args[1])
 			if err != nil {
@@ -40,6 +38,5 @@ supported because registries cannot accept blob pushes to a digest.`,
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&sign, "sign", false, "sign the pushed artifact with cosign (Phase 7)")
 	return cmd
 }


### PR DESCRIPTION
## Summary

- The author guide and tutorial described `installer push --sign [--key|--keyless]` as the publishing flow, but the implementation puts signing in a separate `installer sign <ref>` command (keyless by default, `--key` for keyed, `--yes` to skip the TTY prompt). The `push --sign` flag was a stub that returned "not yet implemented"; `--keyless` never existed. Verified by running `installer sign oci://ghcr.io/confighub/worker-installer:v0.1.42` and `installer verify ... --identity ... --issuer ...` against the live binary.
- Rewrote the Signing sections in `docs/author-guide.md` and `docs/author-tutorial.md` to use `installer sign` after `installer push`; split the "cut a release" checklist into separate push and sign steps.
- Removed the stubbed `--sign` flag from `installer push`. Long help now points operators at `installer sign <ref>` instead. `go build ./...` clean.
- Fixed `docs/consumer-guide.md` policy example: field is `repos:` (a list of prefix strings), not `repoPrefix:` — matches `pkg/api/policy.go`.
- One-line fix to the `docs/package-management.md` design doc so it doesn't reference a removed flag.

## Test plan

- [x] `go build ./...`
- [x] `bin/installer push --help` no longer advertises `--sign`
- [x] `bin/installer sign --help` and `bin/installer verify --help` unchanged
- [ ] Re-walk the author tutorial's Step 8 against a real registry to confirm the new sign commands match operator muscle memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)