### PR TITLE
Run the function chain as a kustomize transformer plugin; add AppConfig support

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,6 @@ upgrade --set-image preflight rejection`. Spaces created with the
 
 ## Roadmap
 
-- AppConfig support.
 - Better Secrets support (currently we generate secrets during fact collection).
 - `installer preflight` — evaluate `externalRequires` against a live cluster.
 - Automatic apply ordering (CRDs before custom resources, Namespace before

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ spec:
   clusterSingleton: [] # leader-election leases this package claims
   externalManifests: [] # remote release-tarball manifests to fetch + merge
   inputs: [] # wizard prompts
-  functionChainTemplate: # one or more groups of function invocations
+  transformers: # one or more groups of function invocations
     - toolchain: Kubernetes/YAML
       whereResource: ""
       invocations:
@@ -291,6 +291,11 @@ authoring packages, the user docs above are what you want.
     build plan for the interactive wizard, prior-state re-entry, plan
     vs ConfigHub, ChangeSet-wrapped update, staged upgrade with
     schema-diff, and `--set-image` overrides. Phases A–E shipped.
+- [Kustomize transformer plugin and AppConfig support](docs/transformer.md)
+  — design for the `installer transformer` exec plugin (folds the
+  function chain into kustomize), durable `out/compose/`,
+  component-scoped function-chain mixins, and AppConfig support via
+  `configMapGenerator` round-trip. Not yet implemented.
 
 ## Multi-package example
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,9 @@ bin/installer wizard ./examples/hello-app \
   --select monitoring --select ingress \
   --namespace demo
 
-# 3. Render: composes the kustomization, runs kustomize, runs the function
-#    chain, writes one file per resource to /tmp/hello/out/manifests/.
+# 3. Render: composes a kustomization in out/compose/ with the ConfigHub
+#    function chain wired in as a kustomize transformer plugin, runs
+#    `kustomize build`, writes one file per resource to out/manifests/.
 bin/installer render /tmp/hello
 
 # 4. Upload to ConfigHub. Records the destination Space(s) in
@@ -143,12 +144,21 @@ After `wizard` and `render`, the working dir looks like:
     │   ├── deployment-<ns>-<name>.yaml
     │   ├── service-<ns>-<name>.yaml
     │   └── ...
+    ├── compose/              # the synthesized kustomization driving render
+    │   ├── kustomization.yaml    # references the chosen base + components
+    │   ├── transformers.yaml     # resolved ConfigHubTransformers (chain)
+    │   ├── validators.yaml       # resolved ConfigHubValidators (if any)
+    │   └── installer-transformer.sh   # exec wrapper kustomize invokes
     └── spec/                 # the "installer record" (also uploadable as Units)
         ├── selection.yaml    # base + closure-resolved components
         ├── inputs.yaml       # validated wizard answers
-        ├── function-chain.yaml   # the resolved chain that ran
+        ├── function-chain.yaml   # the resolved chain that ran (audit copy)
         └── manifest-index.yaml   # filename → kind/name/namespace
 ```
+
+`out/compose/` is durable, not a temp dir. You can `cd out/compose &&
+kustomize build --enable-exec --enable-alpha-plugins .` to reproduce
+the render byte-for-byte outside the installer.
 
 The two spec docs (`selection.yaml`, `inputs.yaml`) are the load-bearing inputs
 to re-render: edit them, re-run `installer render`, get a deterministic new set
@@ -194,11 +204,17 @@ spec:
 
 See `examples/hello-app/` for a complete working package.
 
-The function chain template uses Go `text/template` syntax with `.Inputs`,
-`.Selection`, and `.Package` in scope. Each group's `toolchain` and
-`whereResource` are applied per-group (different groups can target different
-toolchains — e.g., `Kubernetes/YAML` for manifests, `AppConfig/Properties` for
-shipped config files).
+The `transformers:` list is resolved with Go `text/template` syntax —
+`{{ .Namespace }}`, `{{ .Inputs.* }}`, `{{ .Selection.* }}`,
+`{{ .Facts.* }}`, `{{ .Package.* }}` — then emitted as a
+`ConfigHubTransformers` KRM function config that kustomize invokes
+through the `installer transformer` exec plugin. Each group's
+`toolchain` and `whereResource` are applied per-group, so a single
+chain can mutate raw Kubernetes manifests with `Kubernetes/YAML` and
+AppConfig-carried files (`AppConfig/Properties`, `AppConfig/Env`, …)
+in the same render. Components can carry their own `transformers:`
+and `validators:` lists; they append to the package-wide chain only
+when the component is selected.
 
 ## Plugin install
 

--- a/docs/author-guide.md
+++ b/docs/author-guide.md
@@ -744,11 +744,18 @@ toolchain annotation and:
   (`commonLabels`, `namespace`, `namePrefix`, `replacements`)
   continue to decorate the carrier ConfigMap normally.
 
-At upload time, an annotated ConfigMap becomes the triple
-ConfigHub uses for AppConfig: an AppConfig Unit (toolchain from the
-annotation, data = the extracted raw file), a ConfigMapRenderer
-Target, and a Kubernetes/YAML Unit for the rendered manifest,
-linked via the existing intra-Space link inference.
+At upload time, an annotated ConfigMap becomes a four-piece bundle:
+an AppConfig Unit (toolchain from the annotation, data = the
+extracted raw file), a ConfigMapRenderer Target attached to it, a
+placeholder Kubernetes/YAML ConfigMap Unit whose slug matches the
+kustomize-generated name (so other workloads in the Space link to
+it by name via the existing intra-Space inference), and a live-state
+`MergeUnits` link from the placeholder to the AppConfig Unit so the
+runtime ConfigMap name flows through to the workload reference at
+apply time.
+
+The worker the renderer Target uses is `<space>/server-worker` by
+default; override with `installer upload --appconfig-worker <slug>`.
 
 ### disableNameSuffixHash
 

--- a/docs/author-guide.md
+++ b/docs/author-guide.md
@@ -266,7 +266,7 @@ prompts.
 A list of validating-function invocation groups, run automatically
 at the end of every `installer render` against the post-mutation
 output. Each group has the same shape as
-[`functionChainTemplate`](#specfunctionchaintemplate) — a toolchain,
+[`transformers`](#specfunctionchaintemplate) — a toolchain,
 optional `whereResource` filter, ordered `invocations` — but every
 named function must be a Validating function (`Mutating: false`,
 `Validating: true`). Validators do not modify the rendered
@@ -316,10 +316,10 @@ existing render to check the new validators without re-rendering.
 
 `whereResource` filters in `validators[].whereResource` use the same
 qualified path syntax as
-[`functionChainTemplate`](#specfunctionchaintemplate) —
+[`transformers`](#specfunctionchaintemplate) —
 `ConfigHub.ResourceType = 'apps/v1/Deployment'`, etc.
 
-### `spec.functionChainTemplate`
+### `spec.transformers`
 
 A list of function-invocation groups. At render time the template is
 resolved against the operator's answers (via Go `text/template`,
@@ -330,7 +330,7 @@ invocation; the output of each group feeds the next group.
 
 ```yaml
 spec:
-  functionChainTemplate:
+  transformers:
     - toolchain: Kubernetes/YAML        # required per group
       whereResource: ""                 # optional; empty = all resources
       description: Set the namespace on every namespaced resource.
@@ -689,7 +689,7 @@ images:
 If image changes are expected to be frequent (per-component image
 registries, multi-arch by tag, image-by-URI rewrites), declare image
 inputs and a `set-container-image` group in
-`functionChainTemplate` instead. Reach for that only if the
+`transformers` instead. Reach for that only if the
 `images:` block is genuinely insufficient.
 
 ### Components, not flags
@@ -833,7 +833,7 @@ removed component.
 
 ### Changing the function chain
 
-Any change in `functionChainTemplate` re-runs against the new render
+Any change in `transformers` re-runs against the new render
 on upgrade. Render is deterministic; the next plan shows the
 resulting diff, and operators can review before applying.
 
@@ -909,7 +909,7 @@ installer edit add input replicas \
     --prompt "Number of replicas"
 ```
 
-Then reference it from `functionChainTemplate` invocations as
+Then reference it from `transformers` invocations as
 `{{ .Inputs.replicas }}`. Use `installer edit set input <name>` to
 modify, `installer edit remove input <name>` to drop.
 

--- a/docs/author-guide.md
+++ b/docs/author-guide.md
@@ -203,6 +203,30 @@ spec:
   Empty means valid for all bases.
 - `externalRequires:` declares this component's preconditions, in
   addition to package-level + base-level requires.
+- `transformers:` and `validators:` are component-scoped mixins. Same
+  shape as `spec.transformers` / `spec.validators` (see below), but
+  the groups only run when this component is selected. They're
+  appended to the package-wide chain in the order components appear
+  in `spec.components`, so re-render is deterministic regardless of
+  which order the operator passes `--select`. All groups still run
+  in a single in-process executor pass — adding a component-scoped
+  transformer costs nothing extra at render time.
+
+  Example: a `monitoring` component that adds a ServiceMonitor and
+  wants to pin its scrape interval per-namespace can keep that
+  mutation co-located with the component declaration:
+
+  ```yaml
+  components:
+    - name: monitoring
+      path: components/monitoring
+      transformers:
+        - toolchain: Kubernetes/YAML
+          whereResource: "ConfigHub.ResourceType = 'monitoring.coreos.com/v1/ServiceMonitor'"
+          invocations:
+            - name: yq-i
+              args: ['.spec.endpoints[].interval = "{{ .Inputs.scrape_interval }}"']
+  ```
 
 ### `spec.inputs`
 
@@ -650,6 +674,100 @@ Supported kinds: `cronjob`, `daemonset`, `deployment`, `hpa`
 `installer new --update-kustomization` (default true) appends the
 new file to your package's `bases/default/kustomization.yaml`'s
 resources list.
+
+## Application configuration files (AppConfig)
+
+When your workload reads a properties file, an env file, a TOML
+config, or any of the other supported application-configuration
+formats, you have two choices: hardcode it into a `ConfigMap`
+manifest as a literal `data:` map, or keep it in its native format
+and let kustomize's `configMapGenerator` bake it into a ConfigMap.
+
+The installer prefers the second path: the config stays in its
+native format (a real `.properties`, `.toml`, `.env`, etc. file in
+your package tree) so per-format ConfigHub functions can mutate it
+correctly, ConfigHub can validate against a schema, and the upload
+step can split the rendered output into an AppConfig Unit + a
+ConfigMapRenderer Target so day-2 edits stay in the source format
+too.
+
+### Author contract
+
+Annotate the `configMapGenerator` entry with
+`installer.confighub.com/toolchain` pointing at the matching
+AppConfig toolchain. The installer reads the annotation off the
+rendered ConfigMap (kustomize copies generator annotations onto the
+output), so the contract is "tag once, here":
+
+```yaml
+# bases/default/kustomization.yaml
+configMapGenerator:
+  - name: app-config
+    files:
+      - application.properties
+    options:
+      annotations:
+        installer.confighub.com/toolchain: AppConfig/Properties
+
+  - name: app-env
+    envs:
+      - .env
+    options:
+      disableNameSuffixHash: true
+      annotations:
+        installer.confighub.com/toolchain: AppConfig/Env
+```
+
+Supported toolchain values:
+
+- `AppConfig/Properties` — Java-style `.properties`
+- `AppConfig/Env` — `.env` / `KEY=value`
+- `AppConfig/TOML`, `AppConfig/INI`, `AppConfig/YAML`,
+  `AppConfig/JSON`, `AppConfig/Text` — match the file extension
+
+### What the installer does with it
+
+At render time, the `installer transformer` plugin (which kustomize
+invokes as an exec transformer) recognizes ConfigMaps carrying the
+toolchain annotation and:
+
+- Derives the carrier shape (`installer.confighub.com/appconfig-mode`:
+  `file` if the generator used `files:`, `env` if it used `envs:`) by
+  inspecting `data:`. For file mode it also records
+  `installer.confighub.com/appconfig-source-key` — the `data:` key
+  whose value is the raw config file body. Authors can pre-set both
+  annotations to override the inference.
+- Routes any `AppConfig/*` function group in `spec.transformers` to
+  the matching ConfigMap: extract the raw config from `data:`, run
+  the function in the AppConfig toolchain, write the mutated content
+  back into `data:`. Other kustomize transformers
+  (`commonLabels`, `namespace`, `namePrefix`, `replacements`)
+  continue to decorate the carrier ConfigMap normally.
+
+At upload time, an annotated ConfigMap becomes the triple
+ConfigHub uses for AppConfig: an AppConfig Unit (toolchain from the
+annotation, data = the extracted raw file), a ConfigMapRenderer
+Target, and a Kubernetes/YAML Unit for the rendered manifest,
+linked via the existing intra-Space link inference.
+
+### disableNameSuffixHash
+
+Kustomize hashes `configMapGenerator` names by default
+(`my-app-config-h7df9k2`), which means each config change rolls a
+new ConfigMap and rolls any consuming workload that references it.
+Setting `disableNameSuffixHash: true` keeps a stable name; the
+installer maps that into a mutable ConfigMap mode (`RevisionHistoryLimit=0`)
+on the renderer Target at upload time so day-2 edits update in
+place. Use the default (hashed names) when you want
+versioned, immutable ConfigMaps; use `disableNameSuffixHash: true`
+when you want hash-annotation-driven rolling restarts.
+
+### secretGenerator
+
+`secretGenerator` is not tagged with installer annotations. Secrets
+flow through the existing sensitive-resource pathway: rendered to
+`out/secrets/`, never uploaded as Units. The roadmap for a better
+secrets story is tracked separately.
 
 ## Authoring best practices
 

--- a/docs/author-guide.md
+++ b/docs/author-guide.md
@@ -735,7 +735,11 @@ toolchain annotation and:
   `file` if the generator used `files:`, `env` if it used `envs:`) by
   inspecting `data:`. For file mode it also records
   `installer.confighub.com/appconfig-source-key` — the `data:` key
-  whose value is the raw config file body. Authors can pre-set both
+  whose value is the raw config file body. And it records
+  `installer.confighub.com/appconfig-mutable` (`true` or `false`)
+  by matching the rendered ConfigMap name against kustomize's
+  `-<10-char hash>` suffix — present iff `disableNameSuffixHash`
+  was its default of `false`. Authors can pre-set any of the three
   annotations to override the inference.
 - Routes any `AppConfig/*` function group in `spec.transformers` to
   the matching ConfigMap: extract the raw config from `data:`, run

--- a/docs/author-guide.md
+++ b/docs/author-guide.md
@@ -230,8 +230,8 @@ spec:
 
 ### `spec.inputs`
 
-Wizard prompts. Referenced in the function-chain template as
-`{{ .Inputs.<name> }}`.
+Wizard prompts. Referenced in `spec.transformers` (and
+`spec.validators`) as `{{ .Inputs.<name> }}`.
 
 ```yaml
 spec:
@@ -605,12 +605,16 @@ what isn't.
    dependencies) — resolves the DAG and writes `out/spec/lock.yaml`.
 
 4. **`installer render <work-dir>`** — composes a synthetic top-level
-   kustomization that references your chosen base + components, runs
-   `kustomize build`, then runs your function-chain template
-   (resolved with `.Inputs` / `.Selection` / `.Package` / `.Namespace`
-   / `.Facts`). For multi-package installs, each dep is rendered into
-   its own subtree under `out/<dep-name>/`. Output lands as one
-   resource per file in `out/manifests/`.
+   kustomization under `out/compose/` that references your chosen
+   base + components, resolves your `spec.transformers` /
+   `spec.validators` against `.Inputs` / `.Selection` / `.Package` /
+   `.Namespace` / `.Facts`, writes them as KRM function configs, and
+   runs `kustomize build --enable-exec --enable-alpha-plugins`.
+   Kustomize invokes the `installer transformer` subcommand as an
+   exec plugin to run each function group in process; the result
+   lands as one resource per file in `out/manifests/`. For
+   multi-package installs, each dep is rendered into its own subtree
+   under `out/<dep-name>/`.
 
 5. **`installer upload <work-dir>`** — creates one Space per package
    (parent + each locked dep) and one Unit per rendered file, plus
@@ -834,8 +838,8 @@ Your package's rendered output ends up as literal Kubernetes YAML in
 ConfigHub Units. Don't ship Go-template syntax, Helm placeholders, or
 `{{ }}`-style variables in resources after kustomize build — they
 won't be re-templated. If a value needs to vary at install time,
-either declare an input + function-chain mutation, or expose it as a
-kustomize image / replicas / patch transformer.
+either declare an input + a `spec.transformers` mutation, or expose
+it as a kustomize image / replicas / patch transformer.
 
 ### Design for re-render
 
@@ -851,7 +855,7 @@ captured once and replayed thereafter.
 Container images, replica counts, env vars — anything ConfigHub has a
 function for (`set-container-image`, `set-replicas`, `set-env`) — is
 post-install ConfigHub mutation territory. Don't add an input and
-function-chain step for these unless the value is install-time-only
+`spec.transformers` step for these unless the value is install-time-only
 (captured at install and never tuned afterward). The wizard should
 ask the small number of things that genuinely need to be answered
 once, up front.
@@ -1063,7 +1067,7 @@ installer vet <work-dir>
 ```
 
 Runs `spec.validators` against the existing `out/manifests/`
-without re-running kustomize + the function chain. Useful when you
+without re-running kustomize. Useful when you
 added a new validator (e.g., `vet-images`) and want to check the
 existing render before re-rendering. (Render auto-runs validators
 too; `vet` is for the validator-list-changed-but-render-unchanged

--- a/docs/author-tutorial.md
+++ b/docs/author-tutorial.md
@@ -9,7 +9,7 @@ shortcuts (`installer init` / `new` / `edit` / `vet`) so you author
 By the end you'll have:
 
 - A working package with a base, two opt-in components, an input,
-  a function-chain template, and the recommended validator chain.
+  a `transformers:` chain, and the recommended validator chain.
 - An `images:` block so operators can override container tags
   without editing your source.
 - A bundled `.tgz` ready to push to an OCI registry.
@@ -60,9 +60,10 @@ installer init .
 ```
 
 `installer init` writes the manifest with one default base, a
-`set-namespace` function-chain group, and the recommended validator
-chain (`vet-schemas`, `vet-merge-keys`, `vet-format`). We'll fix the
-package name in a moment. Have a look at what was created:
+`set-namespace` group under `spec.transformers`, and the recommended
+validator chain (`vet-schemas`, `vet-merge-keys`, `vet-format`).
+We'll fix the package name in a moment. Have a look at what was
+created:
 
 ```bash
 cat installer.yaml
@@ -147,7 +148,7 @@ Two things to notice:
   (resource requests, readiness/liveness/startup probes,
   `securityContext`, `automountServiceAccountToken: false`)
   because they were applied by the kubernetes-resources package's
-  function chain at template-creation time.
+  `transformers` chain at template-creation time.
 
 ## Step 2: a wizard input
 
@@ -161,10 +162,10 @@ installer edit add input replicas \
     --description "How many statusboard pods to run."
 ```
 
-Wire it into the function chain. The chain already has
+Wire it into `spec.transformers`. The chain already has
 `set-namespace` from `installer init`; we want to add `set-replicas`
-after it. There's no `installer edit` for function-chain entries
-yet, so hand-edit `installer.yaml`:
+after it. There's no `installer edit` for transformer entries yet,
+so hand-edit `installer.yaml`:
 
 ```yaml
   transformers:
@@ -411,8 +412,8 @@ installer render /tmp/statusboard
 
 The default validator chain (`vet-schemas`, `vet-merge-keys`,
 `vet-format`) ran during render in steps 1–5. To re-run validators
-against the existing render — without re-running kustomize and the
-function chain — use `installer vet`:
+against the existing render — without re-running kustomize — use
+`installer vet`:
 
 ```bash
 installer vet /tmp/statusboard

--- a/docs/author-tutorial.md
+++ b/docs/author-tutorial.md
@@ -76,7 +76,7 @@ cat installer.yaml
 #     - name: default
 #       path: bases/default
 #       default: true
-#   functionChainTemplate:
+#   transformers:
 #     - toolchain: Kubernetes/YAML
 #       invocations:
 #         - name: set-namespace
@@ -167,7 +167,7 @@ after it. There's no `installer edit` for function-chain entries
 yet, so hand-edit `installer.yaml`:
 
 ```yaml
-  functionChainTemplate:
+  transformers:
     - toolchain: Kubernetes/YAML
       invocations:
         - name: set-namespace

--- a/docs/consumer-guide.md
+++ b/docs/consumer-guide.md
@@ -112,7 +112,8 @@ installer wizard oci://ghcr.io/myorg/statusboard:0.1.0 \
 Then render:
 
 ```bash
-# 2. Render: kustomize build + function chain → out/manifests/
+# 2. Render: kustomize build with the ConfigHub function chain wired in
+#    as a kustomize transformer plugin → out/manifests/.
 installer render $WD
 ```
 
@@ -149,6 +150,15 @@ use `--space-pattern` instead of `--space`:
 installer upload $WD --space-pattern '{{.PackageName}}-prod'
 # Each package — parent + each locked dep — gets its own Space.
 ```
+
+If the package ships application-config files (a `configMapGenerator`
+tagged with `installer.confighub.com/toolchain`, e.g.
+`AppConfig/Properties` or `AppConfig/Env`), `installer upload` also
+creates a `ConfigMapRenderer` Target plus a separate AppConfig Unit
+holding the raw config body. The renderer Target needs a worker;
+the installer defaults to `<space>/server-worker`. Override with
+`installer upload $WD --space ... --appconfig-worker <slug>` if your
+Space's renderer worker lives under a different slug.
 
 ## Where to make changes
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -336,7 +336,7 @@ the recommended path depends on how often the override is expected:
   re-render — see Principle 1: package files are read-only; we never
   rely on prior `kustomize edit` output surviving an `installer pull`).
 - **Frequent / structured override** — package author declares an image
-  input and a `set-container-image` group in `functionChainTemplate`.
+  input and a `set-container-image` group in `transformers`.
   Operator answers the input through the wizard. No `--set-image`
   involved; `installer upgrade` carries the value through the spec
   like any other input.

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -351,7 +351,7 @@ operator can see the eventual image set without applying anything.
 `installer plan` against an `--set-image` value targeting a package
 whose base has no `images:` transformer fails fast with a useful
 message: "package's base kustomization.yaml has no `images:` block;
-declare one to use --set-image, or use a function-chain input." This
+declare one to use --set-image, or use a `spec.transformers` input." This
 keeps the package author's contract explicit.
 
 ## Common scenarios

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -27,7 +27,7 @@ of the two supported channels keeps changes discoverable and survivable.
 How to apply: if you find yourself reaching for `kustomize edit` against
 a package directory or hand-editing a `bases/*/kustomization.yaml`,
 stop. Either declare an input for it (and let the package's
-`functionChainTemplate` consume it), or do it post-install in ConfigHub.
+`transformers` consume it), or do it post-install in ConfigHub.
 The one allowed package-file mutation is `kustomize edit set image`
 applied by the installer itself behind `--set-image` (see Principle 4).
 
@@ -113,7 +113,7 @@ recommended pattern, in order of decreasing user friction:
 do set-container-image` on the uploaded Unit. This is the default
    recommendation.
 2. **Package author declares image inputs and a `set-container-image`
-   group in `functionChainTemplate`** when image changes are expected
+   group in `transformers`** when image changes are expected
    to be common (per-component image registries, multi-arch by tag,
    image-by-URI rewrites). Inputs surface in the wizard; the function
    chain consumes them at render time.

--- a/docs/transformer.md
+++ b/docs/transformer.md
@@ -334,28 +334,48 @@ write-back; failures become `ResourceList.results`.
 #### Upload split
 
 At upload, ConfigMaps with `installer.confighub.com/toolchain` are
-split into the standard ConfigHub triple:
+split into four ConfigHub objects:
 
-- AppConfig Unit. Slug `<gen-name>-appconfig`. Toolchain from the
-  annotation. Data = extracted raw file body.
-- ConfigMapRenderer Target. Slug `<gen-name>-renderer`. Provider
-  `ConfigMapRenderer`. Toolchain from the annotation.
-  Livestate-type `Kubernetes/YAML`. Options:
-  - `AsKeyValue=true` if mode=env AND toolchain=AppConfig/Env. The
+- **AppConfig Unit** (slug `<carrier-name>-appconfig`). Toolchain
+  from the annotation. Data = the extracted raw file body. Day-2
+  source of truth in the native format.
+- **ConfigMapRenderer Target** (slug `<carrier-name>-renderer`).
+  Provider `ConfigMapRenderer`, toolchain from the annotation,
+  livestate-type `Kubernetes/YAML`. Attached to the AppConfig Unit
+  so applying it renders a ConfigMap in the cluster. Worker is
+  `<space>/<--appconfig-worker>` (default `server-worker`). Options:
+  - `AsKeyValue=true` iff mode=env AND toolchain=AppConfig/Env. The
     bridge ignores it for non-Env toolchains; we set it only where
     it's meaningful.
-  - `RevisionHistoryLimit=0` if `disableNameSuffixHash: true`
-    (mutable name, hash annotation on the consuming workload).
-    Otherwise a small positive default (immutable name, versioned
-    history). Default value TBD — see open questions.
-- Kubernetes/YAML Unit. Slug `<gen-name>-configmap`. Data = the
-  rendered ConfigMap YAML. `--target <renderer>`.
-- Link the K8s Unit to the AppConfig Unit via the existing
-  intra-Space link inference in `internal/upload/links.go`.
+  - `RevisionHistoryLimit` is left at the bridge default for the
+    MVP. A future enhancement will set it from a `disableNameSuffixHash`
+    derived annotation; the rendered ConfigMap name alone isn't
+    a reliable signal of the generator's hash setting.
+- **Placeholder Kubernetes/YAML ConfigMap Unit** (slug =
+  `<carrier-name>`, matching the kustomize-generated name).
+  Body is empty at upload; populated at apply time via the live-merge
+  link below. Inherits the upload-wide `--target` flag (typically a
+  Kubernetes namespace target) so it applies into the same place as
+  every other rendered manifest. Other workload Units in the Space
+  reference the carrier by name, so existing intra-Space link
+  inference (`internal/upload/links.go`) wires them into this
+  placeholder without any new logic.
+- **Live-merge link** (slug `<carrier-name>-from-<carrier-name>-appconfig`).
+  `--use-live-state --auto-update --update-type MergeUnits`. Pulls
+  the rendered ConfigMap from the AppConfig Unit's live state into
+  the placeholder's Data so the runtime ConfigMap name (with its
+  hash suffix) flows through to the workload's
+  `volumeMounts` / `envFrom` reference.
 
-The `manifest-index.yaml` schema gains fields recording the
-AppConfig source-key and toolchain, so `update` / `upgrade` can
-reason about ConfigMaps that have split provenance.
+The rendered ConfigMap YAML in `out/manifests/` is NOT uploaded as a
+Unit — the renderer Target re-derives the ConfigMap from the
+AppConfig Unit's content at apply time, and the placeholder + link
+pair handles the namespace/reference wiring.
+
+The `manifest-index.yaml` schema can later gain fields recording the
+AppConfig source-key and toolchain so `update` / `upgrade` can
+reason about ConfigMaps that have split provenance; deferred to a
+follow-up.
 
 #### Why not a custom wrapper kind
 
@@ -425,14 +445,22 @@ We test all of these against AppConfig-bearing ConfigMaps:
    `transformers:` and `validators:` to each entry in
    `spec.components`. Resolved alongside the package-wide chain in
    declaration order, emitted as a single `out/compose/transformers.yaml`.
-5. **AppConfig annotation contract + auto-injection.** Pre-pass scans
-   `configMapGenerator:` entries, derives `appconfig-mode` and
-   `appconfig-source-key`, injects annotations.
-6. **AppConfig transformer round-trip.** Extract from `data:`,
-   invoke, write back. Both mutating and validating groups.
-7. **AppConfig upload split.** AppConfig Unit + ConfigMapRenderer
-   Target + Kubernetes/YAML Unit + link. Update
-   `manifest-index.yaml` schema. Refresh consumer-guide.md.
+5. **AppConfig annotation contract. ✅** Documented in
+   author-guide.md; the transformer reads
+   `installer.confighub.com/toolchain` from kustomize-copied
+   generator annotations.
+6. **AppConfig transformer round-trip + annotation injection. ✅**
+   `installer transformer` runs a pre-pass that derives and injects
+   `appconfig-mode` (file/env, from data: shape) and
+   `appconfig-source-key`. Function groups with toolchain
+   `AppConfig/*` extract from `data:`, invoke, write back. Both
+   mutating and validating paths supported.
+7. **AppConfig upload split. ✅** Detected ConfigMaps become a
+   four-piece bundle: renderer Target, AppConfig Unit, placeholder
+   Kubernetes/YAML ConfigMap Unit (slug matches the carrier name so
+   intra-Space link inference works), and a live-state MergeUnits
+   link from placeholder → AppConfig Unit. Behind
+   `--appconfig-worker` (default `server-worker`).
 8. **Cleanup.** Remove the AppConfig roadmap bullet from
    README.md once 5–7 land.
 

--- a/docs/transformer.md
+++ b/docs/transformer.md
@@ -277,7 +277,7 @@ entry onto the rendered ConfigMap, so the `toolchain` annotation
 is what reaches the installer transformer (running as an exec
 plugin) and the upload step (reading `out/manifests/`).
 
-The installer transformer infers two more annotations from the
+The installer transformer infers three more annotations from the
 rendered carrier and injects them back onto the ConfigMap so
 downstream consumers (upload, drift) see one canonical contract:
 
@@ -289,12 +289,23 @@ downstream consumers (upload, drift) see one canonical contract:
   file-mode only. The `data:` key whose value is the raw config
   body. Skipped when there's a single `data:` key (the unambiguous
   case).
+- `installer.confighub.com/appconfig-mutable: true | false` —
+  derived from the rendered ConfigMap's name pattern. Kustomize
+  appends a `-<10-char hash>` suffix iff `disableNameSuffixHash`
+  is false (the generator default), so the regex
+  `-[a-z0-9]{10}$` is a reliable signal. Matched → immutable
+  (versioned ConfigMaps, each content change rolls a new one);
+  unmatched → mutable (stable name, hash annotation on the
+  consuming workload triggers restarts). The upload step reads
+  this to set `RevisionHistoryLimit=0` on the renderer Target in
+  the mutable case.
 
-Authors don't write the mode or source-key annotations; the
-transformer infers and injects them. Authors who need to override
-the inference (rare: file-shaped `.env` content, or an ambiguous
-`data:` shape) can set the annotation explicitly on the generator
-entry and the transformer respects it.
+Authors don't write the mode, source-key, or mutable annotations
+themselves; the transformer infers and injects them. Authors who
+need to override the inference (rare: file-shaped `.env` content,
+an ambiguous `data:` shape, or a basename that happens to end in 10
+lowercase-alphanumeric chars) can set the annotation explicitly on
+the generator entry and the transformer respects it.
 
 We deliberately don't modify the package's `kustomization.yaml`
 files — that would conflict with the read-only-package principle.
@@ -347,10 +358,12 @@ split into four ConfigHub objects:
   - `AsKeyValue=true` iff mode=env AND toolchain=AppConfig/Env. The
     bridge ignores it for non-Env toolchains; we set it only where
     it's meaningful.
-  - `RevisionHistoryLimit` is left at the bridge default for the
-    MVP. A future enhancement will set it from a `disableNameSuffixHash`
-    derived annotation; the rendered ConfigMap name alone isn't
-    a reliable signal of the generator's hash setting.
+  - `RevisionHistoryLimit=0` iff `appconfig-mutable=true` (the
+    transformer pre-pass infers this from kustomize's hash-suffix
+    convention; see "Author contract" above). Mutable ConfigMaps
+    update in place; immutable ones (the kustomize default) leave
+    `RevisionHistoryLimit` at the bridge default so cub retains
+    a few revisions for rollback.
 - **Placeholder Kubernetes/YAML ConfigMap Unit** (slug =
   `<carrier-name>`, matching the kustomize-generated name).
   Body is empty at upload; populated at apply time via the live-merge

--- a/docs/transformer.md
+++ b/docs/transformer.md
@@ -196,50 +196,51 @@ mixin path.
 existing author muscle memory. Resolved by today's
 `resolveChainTemplate`, emitted as `out/compose/transformers.yaml`.
 
-**Component-scoped mixins.** Components can drop KRM function
-configs in their own directory and list them in the component's
-own `kustomization.yaml` (`kind: Component`) `transformers:` /
-`validators:` lists:
+**Component-scoped mixins.** Each component declaration in
+`installer.yaml.spec.components` can carry optional `transformers:` and
+`validators:` fields. They take the same FunctionGroup shape as the
+package-wide list and only run when the component is selected.
+Components contribute their groups in the order they appear in
+`spec.components` so re-render is deterministic regardless of which
+order the operator passed `--select`. All groups — package-wide and
+component-scoped — are resolved together and emitted as a single
+`out/compose/transformers.yaml`, so the in-process executor still
+runs them in one kustomize subprocess.
 
 ```yaml
-# packages/<pkg>/components/observability/kustomization.yaml
-apiVersion: kustomize.config.k8s.io/v1alpha1
-kind: Component
-resources:
-  - servicemonitor.yaml
-transformers:
-  - transformers.yaml
-```
-
-```yaml
-# packages/<pkg>/components/observability/transformers.yaml
-apiVersion: installer.confighub.com/v1alpha1
-kind: ConfigHubTransformers
-metadata:
-  name: observability-chain
-  annotations:
-    config.kubernetes.io/function: { exec: { path: installer-transformer.sh } }
+# packages/<pkg>/installer.yaml
 spec:
-  groups:
+  components:
+    - name: observability
+      path: components/observability
+      transformers:
+        - toolchain: Kubernetes/YAML
+          whereResource: "ConfigHub.ResourceType = 'monitoring.coreos.com/v1/ServiceMonitor'"
+          invocations:
+            - name: yq-i
+              args: ['.spec.namespaceSelector.matchNames = ["{{ .Namespace }}"]']
+  transformers:
     - toolchain: Kubernetes/YAML
-      whereResource: "ConfigHub.ResourceType = 'monitoring.coreos.com/v1/ServiceMonitor'"
       invocations:
-        - name: yq-i
-          args: ['--expr=.spec.namespaceSelector.matchNames = ["{{ .Namespace }}"]']
+        - {name: set-namespace, args: ["{{ .Namespace }}"]}
 ```
 
-**Detection rule for the pre-pass.** Any file in the package tree
-whose top-level `apiVersion` starts with `installer.confighub.com/`
-is templated by the installer before kustomize runs. Resolved
-copies land under `out/compose/components/<name>/`; the package
-tree stays read-only (principle: package files are read-only).
+Authors who'd rather use the kustomize-native pattern — declaring a
+KRM function config inside the component directory and referencing
+it from the component's own `kustomization.yaml` `transformers:`
+list — can do that too against raw kustomize, pointing
+`exec.path` at `installer-transformer.sh`. The installer doesn't
+manage those files; they're the user's surface area and bypass the
+installer's template-resolution pre-pass.
 
-**Built-in `namespace:` transformer.** Authors who prefer
-kustomize's built-in `namespace:` field over the `set-namespace`
-function can write `namespace: "{{ .Namespace }}"`. The same
-pre-pass applies to `kustomization.yaml` files in the package
-tree, with the same variable allowlist and `missingkey=error`
-semantics.
+**Built-in `namespace:` transformer.** Not yet implemented — would
+let authors who prefer kustomize's built-in `namespace:` field over
+the `set-namespace` function write `namespace: "{{ .Namespace }}"`
+directly in `kustomization.yaml`. That requires a templating
+pre-pass over package `kustomization.yaml` files, with resolved
+copies written to `out/compose/` (the package tree stays
+read-only). Deferred; for now, package authors use
+`spec.transformers` with `set-namespace`.
 
 ### AppConfig
 
@@ -271,19 +272,35 @@ The annotation key is generalized to
 the same mechanism can roundtrip future non-Kubernetes toolchains
 that have a natural ConfigMap (or equivalent) carrier.
 
-The installer's compose pre-pass scans every `configMapGenerator:`
-entry it pulls in. For each entry carrying
-`installer.confighub.com/toolchain`, it auto-injects:
+Kustomize copies `options.annotations` from a `configMapGenerator`
+entry onto the rendered ConfigMap, so the `toolchain` annotation
+is what reaches the installer transformer (running as an exec
+plugin) and the upload step (reading `out/manifests/`).
 
-- `installer.confighub.com/appconfig-mode: file` if the entry uses
-  `files:`,
-- `installer.confighub.com/appconfig-mode: env` if the entry uses
-  `envs:`,
-- `installer.confighub.com/appconfig-source-key: <name>` for
-  file-mode entries when the source-key isn't the only `data:` key.
+The installer transformer infers two more annotations from the
+rendered carrier and injects them back onto the ConfigMap so
+downstream consumers (upload, drift) see one canonical contract:
 
-Authors don't write the mode annotation themselves — it's derived
-from the generator spec. They can override it if they need to.
+- `installer.confighub.com/appconfig-mode: file | env` — derived
+  from the `data:` shape. `AppConfig/Env` always implies env mode
+  unless the data looks file-shaped; everything else implies file
+  mode.
+- `installer.confighub.com/appconfig-source-key: <name>` —
+  file-mode only. The `data:` key whose value is the raw config
+  body. Skipped when there's a single `data:` key (the unambiguous
+  case).
+
+Authors don't write the mode or source-key annotations; the
+transformer infers and injects them. Authors who need to override
+the inference (rare: file-shaped `.env` content, or an ambiguous
+`data:` shape) can set the annotation explicitly on the generator
+entry and the transformer respects it.
+
+We deliberately don't modify the package's `kustomization.yaml`
+files — that would conflict with the read-only-package principle.
+Injection at the transformer stage means the resolved annotations
+ride into `out/manifests/` cleanly and the package tree stays
+untouched.
 
 #### Transformer round-trip
 
@@ -390,24 +407,24 @@ We test all of these against AppConfig-bearing ConfigMaps:
 
 ## Phasing
 
-1. **Lift chain execution.** Move `runChain`, `runValidators`,
+1. **Lift chain execution. ✅** Moved `runChain`, `runValidators`,
    `parseFunctionArguments`, `ValidatorFailure`,
    `FormatValidatorFailures`, `decodeValidatorFailures` from
    `internal/render/chain.go` into a new `internal/chainexec/`
-   package. Render and `installer vet` import it. No behavior
-   change. Existing unit + e2e tests must pass unchanged.
-2. **Add `installer transformer` subcommand.** Standalone-usable.
-   Documented in author-guide.md and consumer-guide.md.
-3. **Kustomize-driven render with durable `out/compose/`.** Switch
-   `Render` to generate `out/compose/` artifacts and invoke
-   `kustomize build --enable-exec --enable-alpha-plugins`. Hide
-   behind `--render-mode=kustomize` (default: legacy in this phase).
-4. **Component-scoped function configs.** Pre-pass for any file in
-   the package tree whose `apiVersion` starts with
-   `installer.confighub.com/`. Same templating surface as
-   `installer.yaml.spec.transformers`. Also extend the
-   pre-pass to `kustomization.yaml` files (so `namespace: "{{
-   .Namespace }}"` works).
+   package. Render and `installer vet` import it.
+2. **`installer transformer` subcommand. ✅** Standalone-usable
+   KRM Functions exec plugin. Two functionConfig kinds:
+   `ConfigHubTransformers` and `ConfigHubValidators`.
+3. **Kustomize-driven render with durable `out/compose/`. ✅**
+   Single path: `Render` generates `out/compose/{kustomization,
+   transformers, validators}.yaml` and a one-line
+   `installer-transformer.sh` wrapper, then invokes `kustomize
+   build --enable-exec --enable-alpha-plugins`. No legacy
+   fallback; the in-process chain code path is gone.
+4. **Component-scoped transformer mixins. ✅** Added optional
+   `transformers:` and `validators:` to each entry in
+   `spec.components`. Resolved alongside the package-wide chain in
+   declaration order, emitted as a single `out/compose/transformers.yaml`.
 5. **AppConfig annotation contract + auto-injection.** Pre-pass scans
    `configMapGenerator:` entries, derives `appconfig-mode` and
    `appconfig-source-key`, injects annotations.
@@ -416,10 +433,8 @@ We test all of these against AppConfig-bearing ConfigMaps:
 7. **AppConfig upload split.** AppConfig Unit + ConfigMapRenderer
    Target + Kubernetes/YAML Unit + link. Update
    `manifest-index.yaml` schema. Refresh consumer-guide.md.
-8. **Equivalence + flip.** Diff existing examples and packages
-   under legacy vs. kustomize mode. Flip default to kustomize. Mark
-   legacy deprecated. Remove the AppConfig roadmap bullet from
-   README.md. Drop legacy after one release.
+8. **Cleanup.** Remove the AppConfig roadmap bullet from
+   README.md once 5–7 land.
 
 ## Open questions
 

--- a/docs/transformer.md
+++ b/docs/transformer.md
@@ -1,0 +1,438 @@
+# Kustomize transformer plugin and AppConfig support — Design
+
+Status: design. Not implemented. Phased plan at the bottom; task tracking
+lives outside this doc.
+
+Companion to [`principles.md`](./principles.md) (configuration as data,
+two layers of override) and [`lifecycle.md`](./lifecycle.md) (the
+plan / update / upgrade loop). This doc covers two changes:
+
+1. Folding the ConfigHub function chain into kustomize as an exec
+   transformer plugin instead of running it as a post-`kustomize build`
+   step.
+2. Supporting `AppConfig/*` toolchains in installer packages by routing
+   them through kustomize's `configMapGenerator`.
+
+The two are intertwined: AppConfig only makes sense if the function
+chain can operate on it from inside the kustomize pipeline.
+
+## Goals
+
+- Run the function chain and validators as a kustomize transformer
+  plugin. The plugin is a real, non-hidden subcommand of `installer`
+  so anyone can use it standalone against raw kustomize.
+- Make `out/compose/` durable, not a temp dir. Operators can
+  reproduce a render byte-for-byte with `cd out/compose && kustomize
+  build`.
+- Let components carry their own function chains (mixins) in the
+  kustomize-native way: a KRM function config listed under the
+  component's own `kustomization.yaml` `transformers:`.
+- Support `AppConfig/*` toolchains in the function chain without
+  introducing a new KRM wrapper kind. AppConfig content stays in
+  ConfigMaps in the rendered tree; the transformer reverses the
+  ConfigMap → AppConfig content boundary in-process, mutates, and
+  writes back.
+- At upload, materialize annotated ConfigMaps into the right
+  ConfigHub triple: AppConfig Unit + ConfigMapRenderer Target +
+  Kubernetes/YAML Unit, linked via existing intra-Space link
+  inference.
+
+## Non-goals
+
+- Generalized templating. The variable surface stays restricted to
+  `.Namespace`, `.Inputs`, `.Selection`, `.Facts`, `.Package` with
+  `missingkey=error`. Same constraint everywhere we accept
+  templated text.
+- A custom KRM kind to ferry non-Kubernetes config through KRM
+  function pipelines. See [kpt issue
+  3118](https://github.com/kptdev/kpt/issues/3118) — the kustomize
+  community never settled the question. We sidestep it by piggybacking
+  on `configMapGenerator`.
+- Secrets. The current `out/secrets/` opt-out path stays; secrets
+  are never uploaded. A better secrets story is on the roadmap.
+
+## Background
+
+Today `internal/render/render.go` shells out to `kustomize build`,
+then runs the function chain in-process via
+`funcimpl.NewStandardExecutor`. Authors declare the chain in
+`installer.yaml.spec.transformers` and validators in
+`installer.yaml.spec.validators`. Both are resolved against installer
+state with a restricted Go template pass (`resolveChainTemplate`,
+`resolveValidatorTemplate`) before execution.
+
+Three constraints from the current setup carry into the new design:
+
+- The function chain is part of the render contract — re-rendering
+  must produce identical output for identical inputs. This rules out
+  general templating.
+- The chain runs as one in-process executor. Each group's output
+  feeds the next. Subprocess fan-out per group would be a regression.
+- `whereResource` is a ConfigHub filter expression (not CEL) —
+  evaluated by the function executor against resources, with field
+  references like `ConfigHub.ResourceType = 'apps/v1/Deployment'`.
+  See [filter concepts](https://docs.confighub.com/markdown/background/concepts/filters.md).
+
+## Design
+
+### `installer transformer` subcommand
+
+First-class CLI verb. Reads a KRM `ResourceList` from stdin, joins
+`items` into a YAML doc stream, runs the chain encoded in
+`functionConfig.spec.groups`, splits the result back into `items`,
+writes the `ResourceList` to stdout. Validator failures emit
+`ResourceList.results` with `severity: error` so kustomize fails the
+build.
+
+Two `functionConfig` kinds:
+
+- `ConfigHubTransformers` — mutating; all groups run in one process
+  call (preserves today's in-process executor pattern).
+- `ConfigHubValidators` — non-mutating; rejects mutating functions
+  before any invocation runs (mirrors current `runValidators`).
+
+Both share the same shape:
+
+```yaml
+apiVersion: installer.confighub.com/v1alpha1
+kind: ConfigHubTransformers   # or ConfigHubValidators
+metadata:
+  name: transformers
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ./installer-transformer.sh
+spec:
+  groups:
+    - toolchain: Kubernetes/YAML
+      whereResource: "ConfigHub.ResourceType = 'apps/v1/Deployment'"
+      invocations:
+        - name: set-container-image
+          args: ["kuberay-operator", "quay.io/kuberay/operator:v1.6.1"]
+```
+
+`whereResource` is ConfigHub's filter syntax — passed through to the
+function executor's `FunctionInvocationOptions.WhereResource`
+unchanged.
+
+The same binary is usable outside the installer. Drop a
+`ConfigHubTransformers` config into any kustomization, reference it
+from `transformers:`, and as long as `installer-transformer.sh` is
+reachable from kustomize's working directory (PATH, a shipped
+wrapper, or a symlink) it works against raw kustomize.
+
+### Kustomize-driven render in installer
+
+`compose.go` writes everything kustomize needs into a durable
+`out/compose/` instead of a temp dir:
+
+```
+<work-dir>/out/
+├── manifests/                 # per-resource non-sensitive output
+├── secrets/                   # per-resource sensitive output (unchanged)
+├── spec/                      # selection, inputs, facts, function-chain, manifest-index
+└── compose/
+    ├── kustomization.yaml     # synthesized: resources, transformers, validators, images
+    ├── transformers.yaml             # resolved package-level ConfigHubTransformers
+    ├── validators.yaml        # resolved ConfigHubValidators
+    ├── installer-transformer.sh  # exec wrapper (one line, chmod +x)
+    └── components/<name>/...  # pre-resolved component-scoped configs (if any)
+```
+
+`Render` rewrites `out/compose/` on every render. Same render is
+reproducible by anyone with `installer-transformer.sh` on PATH (or
+present alongside the kustomization in `out/compose/`):
+
+```
+cd <work-dir>/out/compose
+kustomize build --enable-exec --enable-alpha-plugins
+```
+
+The exec wrapper exists because the KRM
+`config.kubernetes.io/function` annotation's `exec.path` accepts no
+args. Wrapper is one line:
+
+```sh
+#!/bin/sh
+exec "$INSTALLER_BIN" transformer
+```
+
+`$INSTALLER_BIN` is baked in at render time pointing at the
+currently-running installer binary, so wrapper and binary always
+match. For users running raw kustomize without the installer, ship
+the wrapper alongside `installer` in release artifacts.
+
+#### Why all groups in one transformer pass
+
+A subprocess per group would mean N round-trips of YAML parse +
+serialize for the same in-process executor work we do today. One
+`ConfigHubTransformers` with `spec.groups: [...]` keeps the
+existing data flow: one subprocess, one parse, N executor invocations
+sharing in-process state, one serialize. Groups still feed each
+other through `ConfigData`, same as today's `runChain`.
+
+#### Built-in transformer ordering
+
+Kustomize runs its built-ins (`namePrefix`, `nameSuffix`,
+`commonLabels`, `commonAnnotations`, `namespace`, `replacements`,
+`configMapGenerator`, `secretGenerator`, `images:`) before
+user-listed transformers, unless they're explicitly placed in the
+`transformers:` list ([plugin orchestration
+docs](https://kubectl.docs.kubernetes.io/guides/extending_kustomize/#plugin-orchestration)).
+The installer relies on this: by default our `ConfigHubTransformers`
+runs last, so it sees the post-built-in resources — including the
+ConfigMaps that `configMapGenerator` produced. Authors who need to
+interleave (e.g. mutate before `commonLabels` decorates) can
+explicitly list our transformer earlier in their component's
+`transformers:`.
+
+### Hybrid templating
+
+The package surface stays familiar; components get a kustomize-native
+mixin path.
+
+**Package-wide chain** stays in
+`installer.yaml.spec.transformers`. Existing tests,
+existing author muscle memory. Resolved by today's
+`resolveChainTemplate`, emitted as `out/compose/transformers.yaml`.
+
+**Component-scoped mixins.** Components can drop KRM function
+configs in their own directory and list them in the component's
+own `kustomization.yaml` (`kind: Component`) `transformers:` /
+`validators:` lists:
+
+```yaml
+# packages/<pkg>/components/observability/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - servicemonitor.yaml
+transformers:
+  - transformers.yaml
+```
+
+```yaml
+# packages/<pkg>/components/observability/transformers.yaml
+apiVersion: installer.confighub.com/v1alpha1
+kind: ConfigHubTransformers
+metadata:
+  name: observability-chain
+  annotations:
+    config.kubernetes.io/function: { exec: { path: installer-transformer.sh } }
+spec:
+  groups:
+    - toolchain: Kubernetes/YAML
+      whereResource: "ConfigHub.ResourceType = 'monitoring.coreos.com/v1/ServiceMonitor'"
+      invocations:
+        - name: yq-i
+          args: ['--expr=.spec.namespaceSelector.matchNames = ["{{ .Namespace }}"]']
+```
+
+**Detection rule for the pre-pass.** Any file in the package tree
+whose top-level `apiVersion` starts with `installer.confighub.com/`
+is templated by the installer before kustomize runs. Resolved
+copies land under `out/compose/components/<name>/`; the package
+tree stays read-only (principle: package files are read-only).
+
+**Built-in `namespace:` transformer.** Authors who prefer
+kustomize's built-in `namespace:` field over the `set-namespace`
+function can write `namespace: "{{ .Namespace }}"`. The same
+pre-pass applies to `kustomization.yaml` files in the package
+tree, with the same variable allowlist and `missingkey=error`
+semantics.
+
+### AppConfig
+
+#### Author contract
+
+Authors use standard `configMapGenerator` and annotate it once with
+the toolchain:
+
+```yaml
+configMapGenerator:
+  - name: app-config
+    files:
+      - application.properties
+    options:
+      annotations:
+        installer.confighub.com/toolchain: "AppConfig/Properties"
+
+  - name: app-env
+    envs:
+      - .env
+    options:
+      disableNameSuffixHash: true
+      annotations:
+        installer.confighub.com/toolchain: "AppConfig/Env"
+```
+
+The annotation key is generalized to
+`installer.confighub.com/toolchain`, not `appconfig-toolchain`, so
+the same mechanism can roundtrip future non-Kubernetes toolchains
+that have a natural ConfigMap (or equivalent) carrier.
+
+The installer's compose pre-pass scans every `configMapGenerator:`
+entry it pulls in. For each entry carrying
+`installer.confighub.com/toolchain`, it auto-injects:
+
+- `installer.confighub.com/appconfig-mode: file` if the entry uses
+  `files:`,
+- `installer.confighub.com/appconfig-mode: env` if the entry uses
+  `envs:`,
+- `installer.confighub.com/appconfig-source-key: <name>` for
+  file-mode entries when the source-key isn't the only `data:` key.
+
+Authors don't write the mode annotation themselves — it's derived
+from the generator spec. They can override it if they need to.
+
+#### Transformer round-trip
+
+When a `FunctionGroup` declares `toolchain: AppConfig/*`, the
+transformer:
+
+1. Pre-filters `ResourceList.items` to ConfigMaps whose
+   `installer.confighub.com/toolchain` annotation matches the
+   group's `toolchain`. The group's `whereResource` then filters
+   further over the carrier ConfigMap — kind, name, labels — using
+   standard ConfigHub filter syntax. Intra-content filtering is
+   the function's own job, via its arguments.
+2. For each match, extracts the raw AppConfig content from `data:`:
+   - file-mode: the value at `appconfig-source-key`.
+   - env-mode: re-emit a `.env`-shaped doc from the flat key/value
+     map.
+3. Invokes the executor against that content as a single doc, with
+   the group's invocations.
+4. Writes the mutated content back into `data:`:
+   - file-mode: replace the source-key value.
+   - env-mode: re-parse the mutated `.env` into key/value pairs
+     and replace the ConfigMap's `data:`.
+
+Other kustomize transformers (`commonLabels`, `namespace`,
+`namePrefix`, `replacements`) continue to decorate the ConfigMap
+normally — the data round-trip is invisible to them.
+
+Validators on AppConfig run the same way: extract, validate, no
+write-back; failures become `ResourceList.results`.
+
+#### Upload split
+
+At upload, ConfigMaps with `installer.confighub.com/toolchain` are
+split into the standard ConfigHub triple:
+
+- AppConfig Unit. Slug `<gen-name>-appconfig`. Toolchain from the
+  annotation. Data = extracted raw file body.
+- ConfigMapRenderer Target. Slug `<gen-name>-renderer`. Provider
+  `ConfigMapRenderer`. Toolchain from the annotation.
+  Livestate-type `Kubernetes/YAML`. Options:
+  - `AsKeyValue=true` if mode=env AND toolchain=AppConfig/Env. The
+    bridge ignores it for non-Env toolchains; we set it only where
+    it's meaningful.
+  - `RevisionHistoryLimit=0` if `disableNameSuffixHash: true`
+    (mutable name, hash annotation on the consuming workload).
+    Otherwise a small positive default (immutable name, versioned
+    history). Default value TBD — see open questions.
+- Kubernetes/YAML Unit. Slug `<gen-name>-configmap`. Data = the
+  rendered ConfigMap YAML. `--target <renderer>`.
+- Link the K8s Unit to the AppConfig Unit via the existing
+  intra-Space link inference in `internal/upload/links.go`.
+
+The `manifest-index.yaml` schema gains fields recording the
+AppConfig source-key and toolchain, so `update` / `upgrade` can
+reason about ConfigMaps that have split provenance.
+
+#### Why not a custom wrapper kind
+
+We considered defining a new KRM kind (e.g.
+`installer.confighub.com/v1alpha1, kind: AppConfig`) that would
+carry the raw file body through the kustomize pipeline, with the
+ConfigMap synthesized at the end. Three problems:
+
+1. Built-in kustomize transformers (`commonLabels`, `namespace`,
+   `replacements`) only decorate Kubernetes resources by GVK. Our
+   wrapper kind would be invisible to them, so any author wanting
+   common-labels behavior on their AppConfig would have to
+   re-implement it. ConfigMap-as-carrier gets the decoration for
+   free.
+2. Downstream consumers (other transformers, validators, KRM
+   functions written elsewhere) would need to learn our kind.
+   That's the kpt 3118 problem.
+3. Two sources of truth: the wrapper and the synthesized
+   ConfigMap. Diffing, upgrade, drift all get harder.
+
+ConfigMap-as-carrier + reverse-on-extract pays a small cost
+(re-parsing data on every AppConfig function group invocation) and
+buys full kustomize compatibility.
+
+### Built-in transformer interactions
+
+We test all of these against AppConfig-bearing ConfigMaps:
+
+- `images:` — already driven by `installer --set-image`. Works
+  unchanged; ConfigHub functions see the post-image-set Deployment.
+- `namespace:` — supported either via the `set-namespace` function
+  in the chain or via the kustomize built-in with `{{ .Namespace }}`
+  templating in `kustomization.yaml`.
+- `commonLabels:` / `commonAnnotations:` — applied before the
+  ConfigHub transformer. Transformer sees decorated resources.
+  AppConfig ConfigMaps still extract cleanly because `data:` is
+  untouched by label/annotation transforms.
+- `namePrefix:` / `nameSuffix:` — applied to the rendered ConfigMap.
+  The AppConfig Unit slug is derived from the
+  `configMapGenerator.name` (the pre-prefix logical name), so the
+  AppConfig slug stays stable across rename mutations.
+- `replacements:` — applied before our transformer when in the
+  default slot.
+- `configMapGenerator:` / `secretGenerator:` — run before
+  transformers, so AppConfig hashing and data-merging happen before
+  the transformer extracts. `secretGenerator` is not annotated;
+  secrets continue to flow into `out/secrets/` and are never
+  uploaded.
+
+## Phasing
+
+1. **Lift chain execution.** Move `runChain`, `runValidators`,
+   `parseFunctionArguments`, `ValidatorFailure`,
+   `FormatValidatorFailures`, `decodeValidatorFailures` from
+   `internal/render/chain.go` into a new `internal/chainexec/`
+   package. Render and `installer vet` import it. No behavior
+   change. Existing unit + e2e tests must pass unchanged.
+2. **Add `installer transformer` subcommand.** Standalone-usable.
+   Documented in author-guide.md and consumer-guide.md.
+3. **Kustomize-driven render with durable `out/compose/`.** Switch
+   `Render` to generate `out/compose/` artifacts and invoke
+   `kustomize build --enable-exec --enable-alpha-plugins`. Hide
+   behind `--render-mode=kustomize` (default: legacy in this phase).
+4. **Component-scoped function configs.** Pre-pass for any file in
+   the package tree whose `apiVersion` starts with
+   `installer.confighub.com/`. Same templating surface as
+   `installer.yaml.spec.transformers`. Also extend the
+   pre-pass to `kustomization.yaml` files (so `namespace: "{{
+   .Namespace }}"` works).
+5. **AppConfig annotation contract + auto-injection.** Pre-pass scans
+   `configMapGenerator:` entries, derives `appconfig-mode` and
+   `appconfig-source-key`, injects annotations.
+6. **AppConfig transformer round-trip.** Extract from `data:`,
+   invoke, write back. Both mutating and validating groups.
+7. **AppConfig upload split.** AppConfig Unit + ConfigMapRenderer
+   Target + Kubernetes/YAML Unit + link. Update
+   `manifest-index.yaml` schema. Refresh consumer-guide.md.
+8. **Equivalence + flip.** Diff existing examples and packages
+   under legacy vs. kustomize mode. Flip default to kustomize. Mark
+   legacy deprecated. Remove the AppConfig roadmap bullet from
+   README.md. Drop legacy after one release.
+
+## Open questions
+
+- `RevisionHistoryLimit` default for the immutable (hashed-name)
+  case. 10? 5? Match the cub default. Decide before phase 7.
+- Whether component-supplied transformer configs should be
+  template-resolved at compose time (current plan) or via a small
+  vars-KRM function injected upstream in the transformers list.
+  Compose-time is simpler and preserves the principle of
+  read-only package files; revisit if components ever need
+  per-resource variable substitution that can't be hoisted.
+- Whether to surface a CLI hint when an annotated `configMapGenerator`
+  with `disableNameSuffixHash: false` is used by a workload that
+  doesn't have `envFrom`/`volume` plumbed — i.e. catch the common
+  "I forgot to wire the ConfigMap into the Pod" mistake at render
+  time. Defer.

--- a/examples/example-base/installer.yaml
+++ b/examples/example-base/installer.yaml
@@ -10,7 +10,7 @@ spec:
       default: true
       description: Shared Namespace + ConfigMap for downstream packages.
 
-  functionChainTemplate:
+  transformers:
     # Rename the Namespace resource to the install-time --namespace.
     - toolchain: Kubernetes/YAML
       whereResource: "ConfigHub.ResourceType = 'v1/Namespace'"

--- a/examples/example-stack/installer.yaml
+++ b/examples/example-stack/installer.yaml
@@ -18,7 +18,7 @@ spec:
       package: oci://localhost:5555/installer-e2e/example-base
       version: "^0.1.0"
 
-  functionChainTemplate:
+  transformers:
     - toolchain: Kubernetes/YAML
       whereResource: ""
       invocations:

--- a/examples/gaie/installer.yaml
+++ b/examples/gaie/installer.yaml
@@ -30,7 +30,7 @@ spec:
     - { kind: CRD, name: inferencemodelrewrites.inference.networking.x-k8s.io }
     - { kind: CRD, name: inferencepoolimports.inference.networking.x-k8s.io }
 
-  functionChainTemplate:
+  transformers:
     # Rename the sample-pool Namespace resource (when sample-pool is selected)
     # and set metadata.namespace on every namespace-scoped resource. The
     # namespace comes from the wizard's --namespace flag. The base is CRDs

--- a/examples/hello-app/installer.yaml
+++ b/examples/hello-app/installer.yaml
@@ -30,7 +30,7 @@ spec:
           name: cert-manager
           issuerKind: ClusterIssuer
 
-  functionChainTemplate:
+  transformers:
     # Rename the Namespace resource and set metadata.namespace on every
     # namespace-scoped resource. The namespace comes from the wizard's
     # --namespace flag.

--- a/examples/kuberay/installer.yaml
+++ b/examples/kuberay/installer.yaml
@@ -31,7 +31,7 @@ spec:
     - kind: leader-election-lease
       name: kuberay-operator
 
-  functionChainTemplate:
+  transformers:
     # Rename the operator's Namespace resource, set metadata.namespace on
     # every namespace-scoped resource, and upsert subjects[].namespace on
     # every ServiceAccount subject in the operator's RoleBinding and

--- a/internal/chainexec/chainexec.go
+++ b/internal/chainexec/chainexec.go
@@ -1,0 +1,254 @@
+// Package chainexec executes ConfigHub FunctionChain and validator groups
+// against config data. It's the shared core consumed by `installer render`
+// (after template resolution) and by `installer transformer` (which receives
+// already-resolved groups from a KRM ResourceList functionConfig). Template
+// resolution itself lives in internal/render — it depends on installer state
+// that's irrelevant to the kustomize-side caller.
+package chainexec
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/confighub/installer/pkg/api"
+	fapi "github.com/confighub/sdk/core/function/api"
+	"github.com/confighub/sdk/core/workerapi"
+	funcimpl "github.com/confighub/sdk/function-impl"
+)
+
+// RunChain executes the resolved FunctionChain against the input YAML stream.
+// Each group fires one FunctionInvocationRequest; the response's ConfigData
+// feeds the next group. Mirrors invokeLocalFunctions in cub's worker_install.
+func RunChain(ctx context.Context, chain *api.FunctionChain, input []byte) ([]byte, error) {
+	executor := funcimpl.NewStandardExecutor(nil, true)
+	registered := executor.RegisteredFunctions()
+
+	data := input
+	for i, group := range chain.Spec.Groups {
+		toolchain := workerapi.ToolchainType(group.Toolchain)
+		fns, ok := registered[toolchain]
+		if !ok {
+			return nil, fmt.Errorf("group %d: no functions registered for toolchain %q", i, group.Toolchain)
+		}
+
+		invs := make(fapi.FunctionInvocationList, 0, len(group.Invocations))
+		for _, inv := range group.Invocations {
+			if _, exists := fns[inv.Name]; !exists {
+				return nil, fmt.Errorf("group %d: function %q not registered for toolchain %q",
+					i, inv.Name, group.Toolchain)
+			}
+			args, err := ParseFunctionArguments(inv.Args)
+			if err != nil {
+				return nil, fmt.Errorf("group %d, function %q: %w", i, inv.Name, err)
+			}
+			invs = append(invs, fapi.FunctionInvocation{
+				FunctionName: inv.Name,
+				Arguments:    args,
+			})
+		}
+
+		req := &fapi.FunctionInvocationRequest{
+			FunctionContext: fapi.FunctionContext{ToolchainType: toolchain},
+			ConfigData:      data,
+			FunctionInvocationOptions: fapi.FunctionInvocationOptions{
+				WhereResource: group.WhereResource,
+				StopOnError:   true,
+			},
+			FunctionInvocations: invs,
+		}
+		resp, err := executor.Invoke(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("group %d (%s): %w", i, group.Toolchain, err)
+		}
+		if !resp.Success {
+			return nil, fmt.Errorf("group %d (%s): %v", i, group.Toolchain, resp.ErrorMessages)
+		}
+		if len(resp.ConfigData) > 0 {
+			data = resp.ConfigData
+		}
+	}
+	return data, nil
+}
+
+// ValidatorFailure is one failing validation result. Returned by
+// RunValidators; formatted into operator-facing error messages via
+// FormatValidatorFailures.
+type ValidatorFailure struct {
+	Group        int
+	FunctionName string
+	UnitSlug     string
+	Details      []string
+}
+
+// RunValidators executes validator groups against data. Each group is invoked
+// with StopOnError=false so every validator runs and the operator sees a
+// complete report. Returns nil on full success.
+//
+// Validators must be Validating functions (Mutating=false). Mutating functions
+// in the validators list are rejected before any invocation runs — the
+// validators list is a contract, not a generic chain.
+func RunValidators(ctx context.Context, groups []api.FunctionGroup, data []byte) ([]ValidatorFailure, error) {
+	if len(groups) == 0 {
+		return nil, nil
+	}
+	executor := funcimpl.NewStandardExecutor(nil, true)
+	registered := executor.RegisteredFunctions()
+
+	var failures []ValidatorFailure
+	for i, group := range groups {
+		toolchain := workerapi.ToolchainType(group.Toolchain)
+		fns, ok := registered[toolchain]
+		if !ok {
+			return nil, fmt.Errorf("validators group %d: no functions registered for toolchain %q", i, group.Toolchain)
+		}
+		invs := make(fapi.FunctionInvocationList, 0, len(group.Invocations))
+		for _, inv := range group.Invocations {
+			sig, exists := fns[inv.Name]
+			if !exists {
+				return nil, fmt.Errorf("validators group %d: function %q not registered for toolchain %q",
+					i, inv.Name, group.Toolchain)
+			}
+			if sig.Mutating || !sig.Validating {
+				return nil, fmt.Errorf("validators group %d: function %q is not a validating function — declare it under transformers instead",
+					i, inv.Name)
+			}
+			args, err := ParseFunctionArguments(inv.Args)
+			if err != nil {
+				return nil, fmt.Errorf("validators group %d, function %q: %w", i, inv.Name, err)
+			}
+			invs = append(invs, fapi.FunctionInvocation{
+				FunctionName: inv.Name,
+				Arguments:    args,
+			})
+		}
+		req := &fapi.FunctionInvocationRequest{
+			FunctionContext: fapi.FunctionContext{ToolchainType: toolchain},
+			ConfigData:      data,
+			FunctionInvocationOptions: fapi.FunctionInvocationOptions{
+				WhereResource: group.WhereResource,
+				StopOnError:   false,
+			},
+			FunctionInvocations: invs,
+		}
+		resp, err := executor.Invoke(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("validators group %d (%s): %w", i, group.Toolchain, err)
+		}
+		failures = append(failures, decodeValidatorFailures(i, group, resp)...)
+	}
+	return failures, nil
+}
+
+// decodeValidatorFailures walks the executor response's Outputs map and pulls
+// out failing ValidationResults. Outputs is keyed by OutputType with
+// JSON-encoded bodies; validators emit OutputTypeValidationResult or
+// OutputTypeValidationResultList. A non-empty resp.ErrorMessages also surfaces
+// as a synthetic failure so the operator sees executor-level errors
+// (StopOnError=false only stops the group, not individual invocation errors).
+func decodeValidatorFailures(groupIdx int, group api.FunctionGroup, resp *fapi.FunctionInvocationResponse) []ValidatorFailure {
+	var failures []ValidatorFailure
+	for _, msg := range resp.ErrorMessages {
+		failures = append(failures, ValidatorFailure{
+			Group:    groupIdx,
+			UnitSlug: resp.UnitSlug,
+			Details:  []string{msg},
+		})
+	}
+	for outType, body := range resp.Outputs {
+		if outType != fapi.OutputTypeValidationResult && outType != fapi.OutputTypeValidationResultList {
+			continue
+		}
+		var list fapi.ValidationResultList
+		if err := json.Unmarshal(body, &list); err != nil {
+			var single fapi.ValidationResult
+			if err2 := json.Unmarshal(body, &single); err2 != nil {
+				failures = append(failures, ValidatorFailure{
+					Group:        groupIdx,
+					FunctionName: "(decode)",
+					UnitSlug:     resp.UnitSlug,
+					Details:      []string{fmt.Sprintf("could not decode validator output: %v", err)},
+				})
+				continue
+			}
+			list = fapi.ValidationResultList{single}
+		}
+		for _, r := range list {
+			if !r.Passed {
+				failures = append(failures, validatorFailureFor(groupIdx, group, resp.UnitSlug, r))
+			}
+		}
+	}
+	return failures
+}
+
+func validatorFailureFor(groupIdx int, group api.FunctionGroup, unitSlug string, r fapi.ValidationResult) ValidatorFailure {
+	name := r.FunctionName
+	if name == "" && r.Index < len(group.Invocations) {
+		name = group.Invocations[r.Index].Name
+	}
+	details := append([]string(nil), r.Details...)
+	for _, iss := range r.Issues {
+		details = append(details, iss.Message)
+	}
+	for _, av := range r.FailedAttributes {
+		details = append(details, fmt.Sprintf("%s: %v", av.Path, av.Value))
+	}
+	return ValidatorFailure{
+		Group:        groupIdx,
+		FunctionName: name,
+		UnitSlug:     unitSlug,
+		Details:      details,
+	}
+}
+
+// FormatValidatorFailures renders a list of failures as a multi-line error
+// message suitable for the operator. Empty slice → empty string.
+func FormatValidatorFailures(failures []ValidatorFailure) string {
+	if len(failures) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d validator failure(s):\n", len(failures))
+	for _, f := range failures {
+		prefix := f.FunctionName
+		if f.UnitSlug != "" {
+			prefix = f.UnitSlug + "/" + prefix
+		}
+		if len(f.Details) == 0 {
+			fmt.Fprintf(&b, "  - %s: failed\n", prefix)
+			continue
+		}
+		for _, d := range f.Details {
+			fmt.Fprintf(&b, "  - %s: %s\n", prefix, d)
+		}
+	}
+	return b.String()
+}
+
+// ParseFunctionArguments converts cub-CLI-shaped arg strings into the
+// FunctionArgument form the executor expects. An arg of the form
+// `--name=value` becomes a named argument with ParameterName=name; a bare arg
+// becomes a positional argument with Value=<arg>.
+//
+// Mirrors the parser in public/cmd/cub/function_do.go so chain templates can
+// use the same `--liveness-path=/internal/ok` style as worker_install.go.
+func ParseFunctionArguments(args []string) ([]fapi.FunctionArgument, error) {
+	out := make([]fapi.FunctionArgument, 0, len(args))
+	namedMode := false
+	for _, a := range args {
+		if strings.HasPrefix(a, "--") && strings.Contains(a, "=") {
+			namedMode = true
+			parts := strings.SplitN(a, "=", 2)
+			name := strings.TrimPrefix(parts[0], "--")
+			out = append(out, fapi.FunctionArgument{ParameterName: name, Value: parts[1]})
+			continue
+		}
+		if namedMode {
+			return nil, fmt.Errorf("positional argument %q cannot follow named arguments", a)
+		}
+		out = append(out, fapi.FunctionArgument{Value: a})
+	}
+	return out, nil
+}

--- a/internal/chainexec/chainexec_test.go
+++ b/internal/chainexec/chainexec_test.go
@@ -1,4 +1,4 @@
-package render
+package chainexec
 
 import (
 	"context"
@@ -51,7 +51,7 @@ spec:
 `
 
 func TestRunValidators_NoValidatorsIsNoOp(t *testing.T) {
-	failures, err := runValidators(context.Background(), nil, []byte(passingResource))
+	failures, err := RunValidators(context.Background(), nil, []byte(passingResource))
 	if err != nil {
 		t.Fatalf("nil groups should be a no-op, got %v", err)
 	}
@@ -69,9 +69,9 @@ func TestRunValidators_PassingResource(t *testing.T) {
 			{Name: "vet-format"},
 		},
 	}}
-	failures, err := runValidators(context.Background(), groups, []byte(passingResource))
+	failures, err := RunValidators(context.Background(), groups, []byte(passingResource))
 	if err != nil {
-		t.Fatalf("runValidators: %v", err)
+		t.Fatalf("RunValidators: %v", err)
 	}
 	if len(failures) != 0 {
 		t.Errorf("expected no failures, got: %s", FormatValidatorFailures(failures))
@@ -86,9 +86,9 @@ func TestRunValidators_FailingResource(t *testing.T) {
 			{Name: "vet-merge-keys"},
 		},
 	}}
-	failures, err := runValidators(context.Background(), groups, []byte(failingResource))
+	failures, err := RunValidators(context.Background(), groups, []byte(failingResource))
 	if err != nil {
-		t.Fatalf("runValidators: %v", err)
+		t.Fatalf("RunValidators: %v", err)
 	}
 	if len(failures) == 0 {
 		t.Fatal("expected failures, got none")
@@ -104,14 +104,14 @@ func TestRunValidators_FailingResource(t *testing.T) {
 func TestRunValidators_RejectsMutatingFunctions(t *testing.T) {
 	// set-namespace is a mutating function; declaring it under
 	// validators is a programming error in the package author's
-	// installer.yaml. runValidators must reject before invoking.
+	// installer.yaml. RunValidators must reject before invoking.
 	groups := []api.FunctionGroup{{
 		Toolchain: "Kubernetes/YAML",
 		Invocations: []api.FunctionInvocation{
 			{Name: "set-namespace", Args: []string{"foo"}},
 		},
 	}}
-	_, err := runValidators(context.Background(), groups, []byte(passingResource))
+	_, err := RunValidators(context.Background(), groups, []byte(passingResource))
 	if err == nil {
 		t.Fatal("expected error for mutating function in validators list")
 	}
@@ -127,7 +127,7 @@ func TestRunValidators_UnknownFunction(t *testing.T) {
 			{Name: "vet-bogus-does-not-exist"},
 		},
 	}}
-	_, err := runValidators(context.Background(), groups, []byte(passingResource))
+	_, err := RunValidators(context.Background(), groups, []byte(passingResource))
 	if err == nil {
 		t.Fatal("expected error for unknown function")
 	}

--- a/internal/cli/appconfig.go
+++ b/internal/cli/appconfig.go
@@ -1,0 +1,372 @@
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/confighub/installer/internal/chainexec"
+	"github.com/confighub/installer/pkg/api"
+)
+
+// AppConfig annotation keys. `toolchain` is the only one authors write by
+// hand; mode and source-key are derived by the transformer from the carrier
+// ConfigMap's data: shape (authors can pre-set them to override the
+// inference).
+const (
+	annoToolchain = "installer.confighub.com/toolchain"
+	annoMode      = "installer.confighub.com/appconfig-mode"
+	annoSourceKey = "installer.confighub.com/appconfig-source-key"
+
+	appConfigModeFile = "file"
+	appConfigModeEnv  = "env"
+)
+
+// isAppConfigToolchain reports whether the given group toolchain identifies
+// content stored in a ConfigMap carrier (vs. a top-level Kubernetes/YAML
+// resource).
+func isAppConfigToolchain(t string) bool {
+	return strings.HasPrefix(t, "AppConfig/")
+}
+
+// configMapShape is the slice of a ConfigMap manifest the AppConfig
+// round-trip needs. Other fields (binaryData, immutable, kustomize
+// annotations like config.kubernetes.io/path) are carried through as
+// `Extra` so we can re-emit a ConfigMap that differs from the input only in
+// the fields we explicitly touched.
+type configMapShape struct {
+	APIVersion string            `yaml:"apiVersion"`
+	Kind       string            `yaml:"kind"`
+	Metadata   configMapMetadata `yaml:"metadata"`
+	Data       map[string]string `yaml:"data,omitempty"`
+	// Extra captures every other top-level field so we can round-trip
+	// without dropping content we don't care about.
+	Extra map[string]any `yaml:",inline"`
+}
+
+type configMapMetadata struct {
+	Name        string            `yaml:"name"`
+	Namespace   string            `yaml:"namespace,omitempty"`
+	Labels      map[string]string `yaml:"labels,omitempty"`
+	Annotations map[string]string `yaml:"annotations,omitempty"`
+	Extra       map[string]any    `yaml:",inline"`
+}
+
+// appConfigCarrier wraps a configMapShape with the decoded AppConfig
+// metadata derived from its annotations. Held briefly while we run a
+// function over the content and write it back.
+type appConfigCarrier struct {
+	itemIndex int             // index into resourceList.Items
+	shape     *configMapShape // decoded form (we re-encode after mutation)
+	toolchain string
+	mode      string
+	sourceKey string // file mode only
+}
+
+// injectAppConfigAnnotations walks the ResourceList for ConfigMaps tagged
+// with installer.confighub.com/toolchain. For each it derives the
+// appconfig-mode (file/env, by inspecting data:) and, when in file mode,
+// the appconfig-source-key (the single data: key, or the explicit override
+// the author already wrote). The resolved annotations are re-injected onto
+// the item so downstream consumers (the AppConfig round-trip below, the
+// upload step) see one canonical contract.
+//
+// Returns an error for malformed inputs: unknown toolchain values, file
+// mode with multiple data keys and no explicit source-key, env mode with
+// keys that look like file paths.
+func injectAppConfigAnnotations(list *resourceList) error {
+	for i := range list.Items {
+		shape, ok, err := decodeIfConfigMapWithToolchain(&list.Items[i])
+		if err != nil {
+			return err
+		}
+		if !ok {
+			continue
+		}
+		if err := validateAndFillAnnotations(shape); err != nil {
+			return fmt.Errorf("ConfigMap %s/%s: %w", shape.Metadata.Namespace, shape.Metadata.Name, err)
+		}
+		if err := encodeShapeIntoItem(&list.Items[i], shape); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// decodeIfConfigMapWithToolchain returns the decoded shape only when the
+// item is a ConfigMap carrying installer.confighub.com/toolchain. Cheap
+// fast-path: we Decode into a tiny header first to filter, then re-decode
+// the full shape only for matches.
+func decodeIfConfigMapWithToolchain(item *yaml.Node) (*configMapShape, bool, error) {
+	var header struct {
+		APIVersion string `yaml:"apiVersion"`
+		Kind       string `yaml:"kind"`
+		Metadata   struct {
+			Annotations map[string]string `yaml:"annotations"`
+		} `yaml:"metadata"`
+	}
+	if err := item.Decode(&header); err != nil {
+		// Items that don't decode as KRM-shaped resources (rare) are
+		// not AppConfig carriers.
+		return nil, false, nil
+	}
+	if header.Kind != "ConfigMap" || !strings.HasPrefix(header.APIVersion, "v1") && header.APIVersion != "v1" {
+		return nil, false, nil
+	}
+	if _, ok := header.Metadata.Annotations[annoToolchain]; !ok {
+		return nil, false, nil
+	}
+	var shape configMapShape
+	if err := item.Decode(&shape); err != nil {
+		return nil, false, fmt.Errorf("decode ConfigMap: %w", err)
+	}
+	return &shape, true, nil
+}
+
+func validateAndFillAnnotations(shape *configMapShape) error {
+	if shape.Metadata.Annotations == nil {
+		return fmt.Errorf("annotations dropped during decode") // shouldn't happen — toolchain was present
+	}
+	toolchain := shape.Metadata.Annotations[annoToolchain]
+	if !isAppConfigToolchain(toolchain) {
+		return fmt.Errorf("annotation %s=%q must be an AppConfig/* toolchain", annoToolchain, toolchain)
+	}
+
+	mode := shape.Metadata.Annotations[annoMode]
+	if mode == "" {
+		mode = inferMode(shape, toolchain)
+	}
+	if mode != appConfigModeFile && mode != appConfigModeEnv {
+		return fmt.Errorf("annotation %s=%q must be %q or %q", annoMode, mode, appConfigModeFile, appConfigModeEnv)
+	}
+	shape.Metadata.Annotations[annoMode] = mode
+
+	if mode == appConfigModeFile {
+		key := shape.Metadata.Annotations[annoSourceKey]
+		if key == "" {
+			keys := sortedDataKeys(shape)
+			if len(keys) != 1 {
+				return fmt.Errorf("file mode requires exactly one data: key or an explicit %s annotation (have %d keys: %v)",
+					annoSourceKey, len(keys), keys)
+			}
+			key = keys[0]
+			shape.Metadata.Annotations[annoSourceKey] = key
+		}
+		if _, ok := shape.Data[key]; !ok {
+			return fmt.Errorf("%s=%q references a data key that doesn't exist (keys: %v)",
+				annoSourceKey, key, sortedDataKeys(shape))
+		}
+	} else {
+		// env mode shouldn't carry a source-key annotation. Tolerate but
+		// strip it so downstream code doesn't see contradictory state.
+		delete(shape.Metadata.Annotations, annoSourceKey)
+	}
+	return nil
+}
+
+// inferMode picks env when the toolchain is AppConfig/Env and the data:
+// shape doesn't look like a single file blob. For non-Env toolchains we
+// always pick file (the carrier is meant to hold a file body).
+func inferMode(shape *configMapShape, toolchain string) string {
+	if toolchain != "AppConfig/Env" {
+		return appConfigModeFile
+	}
+	// AppConfig/Env normally maps to env mode (data keys are env-var
+	// names). But if there's a single data key whose value looks
+	// multi-line (i.e. someone stored a .env *file body* under a single
+	// key via files: rather than envs:), it's file mode.
+	keys := sortedDataKeys(shape)
+	if len(keys) == 1 && strings.ContainsRune(shape.Data[keys[0]], '\n') {
+		return appConfigModeFile
+	}
+	return appConfigModeEnv
+}
+
+func sortedDataKeys(shape *configMapShape) []string {
+	keys := make([]string, 0, len(shape.Data))
+	for k := range shape.Data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// runAppConfigGroup handles one FunctionGroup whose toolchain is
+// AppConfig/*. Each matching ConfigMap is round-tripped independently
+// through chainexec (extract content from data: → run function group →
+// write mutated content back). The `mutating` flag selects between
+// RunChain (chain mode) and RunValidators (validators mode); in validators
+// mode the failures are appended to `results` annotated with the carrier
+// ConfigMap's identity.
+//
+// Carrier-level whereResource filtering (beyond toolchain-annotation
+// match) is deferred — the function executor's own WhereResource is
+// passed through to the per-content invocation, so functions that
+// support intra-content path filters still work.
+func runAppConfigGroup(
+	ctx context.Context,
+	list *resourceList,
+	group api.FunctionGroup,
+	mutating bool,
+	results *[]krmResult,
+) error {
+	for i := range list.Items {
+		shape, ok, err := decodeIfConfigMapWithToolchain(&list.Items[i])
+		if err != nil {
+			return err
+		}
+		if !ok {
+			continue
+		}
+		if shape.Metadata.Annotations[annoToolchain] != group.Toolchain {
+			continue
+		}
+		carrier := &appConfigCarrier{
+			itemIndex: i,
+			shape:     shape,
+			toolchain: shape.Metadata.Annotations[annoToolchain],
+			mode:      shape.Metadata.Annotations[annoMode],
+			sourceKey: shape.Metadata.Annotations[annoSourceKey],
+		}
+		content, err := extractAppConfigContent(carrier)
+		if err != nil {
+			return fmt.Errorf("ConfigMap %s/%s: %w", shape.Metadata.Namespace, shape.Metadata.Name, err)
+		}
+		if mutating {
+			mutated, err := chainexec.RunChain(ctx, &api.FunctionChain{
+				APIVersion: api.APIVersion,
+				Kind:       api.KindFunctionChain,
+				Spec:       api.FunctionChainSpec{Groups: []api.FunctionGroup{group}},
+			}, content)
+			if err != nil {
+				return fmt.Errorf("ConfigMap %s/%s: %w", shape.Metadata.Namespace, shape.Metadata.Name, err)
+			}
+			if err := writeAppConfigContent(carrier, mutated); err != nil {
+				return fmt.Errorf("ConfigMap %s/%s: %w", shape.Metadata.Namespace, shape.Metadata.Name, err)
+			}
+			if err := encodeShapeIntoItem(&list.Items[i], shape); err != nil {
+				return err
+			}
+		} else {
+			failures, err := chainexec.RunValidators(ctx, []api.FunctionGroup{group}, content)
+			if err != nil {
+				return fmt.Errorf("ConfigMap %s/%s: %w", shape.Metadata.Namespace, shape.Metadata.Name, err)
+			}
+			carrierName := configMapDisplayName(shape)
+			for _, f := range failures {
+				prefix := f.FunctionName
+				if prefix == "" {
+					prefix = group.Toolchain
+				}
+				prefix = carrierName + "/" + prefix
+				if len(f.Details) == 0 {
+					*results = append(*results, krmResult{
+						Message:  fmt.Sprintf("%s: failed", prefix),
+						Severity: "error",
+					})
+					continue
+				}
+				for _, d := range f.Details {
+					*results = append(*results, krmResult{
+						Message:  fmt.Sprintf("%s: %s", prefix, d),
+						Severity: "error",
+					})
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// extractAppConfigContent pulls the raw AppConfig file body out of the
+// carrier ConfigMap's data: map. file mode reads data[sourceKey]
+// verbatim; env mode reconstructs a .env-shaped doc by joining the
+// key/value pairs (sorted for determinism).
+func extractAppConfigContent(c *appConfigCarrier) ([]byte, error) {
+	switch c.mode {
+	case appConfigModeFile:
+		body, ok := c.shape.Data[c.sourceKey]
+		if !ok {
+			return nil, fmt.Errorf("data[%q] missing", c.sourceKey)
+		}
+		return []byte(body), nil
+	case appConfigModeEnv:
+		var buf bytes.Buffer
+		for _, k := range sortedDataKeys(c.shape) {
+			fmt.Fprintf(&buf, "%s=%s\n", k, c.shape.Data[k])
+		}
+		return buf.Bytes(), nil
+	default:
+		return nil, fmt.Errorf("unknown appconfig-mode %q", c.mode)
+	}
+}
+
+// writeAppConfigContent is extractAppConfigContent's inverse. file mode
+// overwrites data[sourceKey]; env mode parses the mutated .env-shaped
+// content back into key/value pairs and replaces data: wholesale. Lines
+// starting with '#' or blank are ignored on the env-parse side so
+// authors / functions can include comments without breaking parity.
+func writeAppConfigContent(c *appConfigCarrier, content []byte) error {
+	switch c.mode {
+	case appConfigModeFile:
+		if c.shape.Data == nil {
+			c.shape.Data = map[string]string{}
+		}
+		c.shape.Data[c.sourceKey] = string(content)
+		return nil
+	case appConfigModeEnv:
+		next := map[string]string{}
+		scanner := bufio.NewScanner(bytes.NewReader(content))
+		for scanner.Scan() {
+			line := scanner.Text()
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+				continue
+			}
+			eq := strings.IndexByte(line, '=')
+			if eq < 0 {
+				return fmt.Errorf("env-mode AppConfig line lacks '=': %q", line)
+			}
+			next[strings.TrimSpace(line[:eq])] = line[eq+1:]
+		}
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("scan env content: %w", err)
+		}
+		c.shape.Data = next
+		return nil
+	default:
+		return fmt.Errorf("unknown appconfig-mode %q", c.mode)
+	}
+}
+
+// encodeShapeIntoItem marshals the shape back into the original item's
+// yaml.Node slot. We re-Unmarshal so the resulting node carries the right
+// internal scalar styles for the encoder downstream.
+func encodeShapeIntoItem(item *yaml.Node, shape *configMapShape) error {
+	body, err := yaml.Marshal(shape)
+	if err != nil {
+		return fmt.Errorf("marshal ConfigMap: %w", err)
+	}
+	var node yaml.Node
+	if err := yaml.Unmarshal(body, &node); err != nil {
+		return fmt.Errorf("re-parse ConfigMap: %w", err)
+	}
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		*item = *node.Content[0]
+	} else {
+		*item = node
+	}
+	return nil
+}
+
+func configMapDisplayName(shape *configMapShape) string {
+	if shape.Metadata.Namespace != "" {
+		return shape.Metadata.Namespace + "/" + shape.Metadata.Name
+	}
+	return shape.Metadata.Name
+}

--- a/internal/cli/appconfig.go
+++ b/internal/cli/appconfig.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -14,6 +15,17 @@ import (
 	"github.com/confighub/installer/pkg/api"
 )
 
+// kustomizeHashSuffix matches kustomize's configMapGenerator hash suffix:
+// `-` followed by exactly 10 lowercase-alphanumeric chars at end-of-name.
+// Anchored to the end so author-chosen names like `my-app-v1` aren't
+// misdetected. When matched on the rendered ConfigMap, the carrier was
+// generated with disableNameSuffixHash=false (kustomize default) →
+// immutable mode → ConfigMap rolls on every content change. When not
+// matched, the name is stable → mutable mode → ConfigMap is updated in
+// place. Authors can override the inference by pre-setting
+// installer.confighub.com/appconfig-mutable explicitly.
+var kustomizeHashSuffix = regexp.MustCompile(`-[a-z0-9]{10}$`)
+
 // AppConfig annotation keys. `toolchain` is the only one authors write by
 // hand; mode and source-key are derived by the transformer from the carrier
 // ConfigMap's data: shape (authors can pre-set them to override the
@@ -22,6 +34,7 @@ const (
 	annoToolchain = "installer.confighub.com/toolchain"
 	annoMode      = "installer.confighub.com/appconfig-mode"
 	annoSourceKey = "installer.confighub.com/appconfig-source-key"
+	annoMutable   = "installer.confighub.com/appconfig-mutable"
 
 	appConfigModeFile = "file"
 	appConfigModeEnv  = "env"
@@ -165,6 +178,18 @@ func validateAndFillAnnotations(shape *configMapShape) error {
 		// env mode shouldn't carry a source-key annotation. Tolerate but
 		// strip it so downstream code doesn't see contradictory state.
 		delete(shape.Metadata.Annotations, annoSourceKey)
+	}
+
+	// Mutability is inferred from kustomize's hash-suffix convention on
+	// the rendered name unless the author pre-set the annotation. The
+	// inference works because kustomize appends `-<10-char hash>` exactly
+	// when disableNameSuffixHash is false (the generator default).
+	if _, set := shape.Metadata.Annotations[annoMutable]; !set {
+		if kustomizeHashSuffix.MatchString(shape.Metadata.Name) {
+			shape.Metadata.Annotations[annoMutable] = "false"
+		} else {
+			shape.Metadata.Annotations[annoMutable] = "true"
+		}
 	}
 	return nil
 }

--- a/internal/cli/appconfig_test.go
+++ b/internal/cli/appconfig_test.go
@@ -1,0 +1,182 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestTransformer_AppConfigAnnotationInjection_FileMode verifies the
+// pre-pass infers appconfig-mode=file and the unique source-key for a
+// ConfigMap with one data: file under installer.confighub.com/toolchain.
+// No function group is declared; the transformer's only job here is the
+// canonical-annotation pass.
+func TestTransformer_AppConfigAnnotationInjection_FileMode(t *testing.T) {
+	input := `apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+items:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: app-config
+      namespace: demo
+      annotations:
+        installer.confighub.com/toolchain: AppConfig/Properties
+    data:
+      application.properties: |
+        a=1
+        b=2
+functionConfig:
+  apiVersion: installer.confighub.com/v1alpha1
+  kind: ConfigHubTransformers
+  metadata: {name: noop}
+  spec: {groups: []}
+`
+	out, err := runTransformer(context.Background(), []byte(input))
+	if err != nil {
+		t.Fatalf("runTransformer: %v", err)
+	}
+	cm := firstConfigMap(t, out)
+	if cm.Metadata.Annotations[annoMode] != appConfigModeFile {
+		t.Errorf("appconfig-mode: want %q, got %q", appConfigModeFile, cm.Metadata.Annotations[annoMode])
+	}
+	if cm.Metadata.Annotations[annoSourceKey] != "application.properties" {
+		t.Errorf("appconfig-source-key: want application.properties, got %q",
+			cm.Metadata.Annotations[annoSourceKey])
+	}
+}
+
+// TestTransformer_AppConfigAnnotationInjection_EnvMode verifies the
+// pre-pass picks env mode for an AppConfig/Env ConfigMap whose data: holds
+// env-shaped key/value pairs.
+func TestTransformer_AppConfigAnnotationInjection_EnvMode(t *testing.T) {
+	input := `apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+items:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: app-env
+      annotations:
+        installer.confighub.com/toolchain: AppConfig/Env
+    data:
+      FOO: bar
+      BAZ: qux
+functionConfig:
+  apiVersion: installer.confighub.com/v1alpha1
+  kind: ConfigHubTransformers
+  metadata: {name: noop}
+  spec: {groups: []}
+`
+	out, err := runTransformer(context.Background(), []byte(input))
+	if err != nil {
+		t.Fatalf("runTransformer: %v", err)
+	}
+	cm := firstConfigMap(t, out)
+	if cm.Metadata.Annotations[annoMode] != appConfigModeEnv {
+		t.Errorf("appconfig-mode: want %q, got %q", appConfigModeEnv, cm.Metadata.Annotations[annoMode])
+	}
+	if _, present := cm.Metadata.Annotations[annoSourceKey]; present {
+		t.Errorf("env mode should not carry a source-key annotation, got %q",
+			cm.Metadata.Annotations[annoSourceKey])
+	}
+}
+
+// TestTransformer_AppConfigAnnotationInjection_RejectsAmbiguous fails the
+// pre-pass when file mode has multiple data keys and no explicit
+// source-key annotation — there's no safe automatic pick.
+func TestTransformer_AppConfigAnnotationInjection_RejectsAmbiguous(t *testing.T) {
+	input := `apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+items:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: app-config
+      annotations:
+        installer.confighub.com/toolchain: AppConfig/Properties
+    data:
+      first.properties: a=1
+      second.properties: b=2
+functionConfig:
+  apiVersion: installer.confighub.com/v1alpha1
+  kind: ConfigHubTransformers
+  metadata: {name: noop}
+  spec: {groups: []}
+`
+	_, err := runTransformer(context.Background(), []byte(input))
+	if err == nil {
+		t.Fatal("expected error for ambiguous file-mode ConfigMap")
+	}
+	if !strings.Contains(err.Error(), annoSourceKey) {
+		t.Errorf("error should point at the missing source-key annotation: %v", err)
+	}
+}
+
+// TestTransformer_AppConfigChainRoundTrip runs an AppConfig/Properties
+// function (set-string-path) against a ConfigMap-carried .properties
+// file and verifies the mutation lands inside data:.
+func TestTransformer_AppConfigChainRoundTrip(t *testing.T) {
+	input := `apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+items:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: app-config
+      namespace: demo
+      annotations:
+        installer.confighub.com/toolchain: AppConfig/Properties
+    data:
+      application.properties: |
+        configHub.configSchema=AppProperties
+        server.port=8080
+        server.host=localhost
+functionConfig:
+  apiVersion: installer.confighub.com/v1alpha1
+  kind: ConfigHubTransformers
+  metadata: {name: chain}
+  spec:
+    groups:
+      - toolchain: AppConfig/Properties
+        invocations:
+          - name: set-int-path
+            args: ["AppProperties", "server.port", "9090"]
+`
+	out, err := runTransformer(context.Background(), []byte(input))
+	if err != nil {
+		t.Fatalf("runTransformer: %v", err)
+	}
+	cm := firstConfigMap(t, out)
+	got := cm.Data["application.properties"]
+	if !strings.Contains(got, "server.port=9090") {
+		t.Errorf("expected server.port=9090 in mutated content, got:\n%s", got)
+	}
+	if !strings.Contains(got, "server.host=localhost") {
+		t.Errorf("expected server.host=localhost preserved in mutated content, got:\n%s", got)
+	}
+}
+
+// firstConfigMap unmarshals the output ResourceList and returns the first
+// ConfigMap-shaped item, decoded into configMapShape so tests can inspect
+// metadata.annotations and data: directly.
+func firstConfigMap(t *testing.T, out []byte) configMapShape {
+	t.Helper()
+	var list resourceList
+	if err := yaml.Unmarshal(out, &list); err != nil {
+		t.Fatalf("parse output ResourceList: %v\n----\n%s\n----", err, out)
+	}
+	for _, item := range list.Items {
+		var shape configMapShape
+		if err := item.Decode(&shape); err != nil {
+			continue
+		}
+		if shape.Kind == "ConfigMap" {
+			return shape
+		}
+	}
+	t.Fatalf("no ConfigMap in output:\n%s", out)
+	return configMapShape{}
+}

--- a/internal/cli/appconfig_test.go
+++ b/internal/cli/appconfig_test.go
@@ -48,6 +48,81 @@ functionConfig:
 	}
 }
 
+// TestTransformer_AppConfigAnnotationInjection_MutableInferredFromName
+// verifies the mutability inference: a stable name (no kustomize hash
+// suffix) yields mutable=true, a hashed name yields mutable=false.
+func TestTransformer_AppConfigAnnotationInjection_MutableInferredFromName(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		cmName      string
+		wantMutable string
+	}{
+		{name: "stable name → mutable", cmName: "app-config", wantMutable: "true"},
+		{name: "kustomize-hashed name → immutable", cmName: "app-config-798k5k7g9f", wantMutable: "false"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			input := `apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+items:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: ` + tc.cmName + `
+      annotations:
+        installer.confighub.com/toolchain: AppConfig/Properties
+    data:
+      application.properties: a=1
+functionConfig:
+  apiVersion: installer.confighub.com/v1alpha1
+  kind: ConfigHubTransformers
+  metadata: {name: noop}
+  spec: {groups: []}
+`
+			out, err := runTransformer(context.Background(), []byte(input))
+			if err != nil {
+				t.Fatalf("runTransformer: %v", err)
+			}
+			cm := firstConfigMap(t, out)
+			if cm.Metadata.Annotations[annoMutable] != tc.wantMutable {
+				t.Errorf("appconfig-mutable: want %q, got %q",
+					tc.wantMutable, cm.Metadata.Annotations[annoMutable])
+			}
+		})
+	}
+}
+
+// TestTransformer_AppConfigAnnotationInjection_AuthorMutableOverride
+// verifies the inference doesn't clobber an author-set value. A hashed
+// name with appconfig-mutable=true should stay mutable=true.
+func TestTransformer_AppConfigAnnotationInjection_AuthorMutableOverride(t *testing.T) {
+	input := `apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+items:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: app-config-798k5k7g9f
+      annotations:
+        installer.confighub.com/toolchain: AppConfig/Properties
+        installer.confighub.com/appconfig-mutable: "true"
+    data:
+      application.properties: a=1
+functionConfig:
+  apiVersion: installer.confighub.com/v1alpha1
+  kind: ConfigHubTransformers
+  metadata: {name: noop}
+  spec: {groups: []}
+`
+	out, err := runTransformer(context.Background(), []byte(input))
+	if err != nil {
+		t.Fatalf("runTransformer: %v", err)
+	}
+	cm := firstConfigMap(t, out)
+	if cm.Metadata.Annotations[annoMutable] != "true" {
+		t.Errorf("expected author override to win, got %q", cm.Metadata.Annotations[annoMutable])
+	}
+}
+
 // TestTransformer_AppConfigAnnotationInjection_EnvMode verifies the
 // pre-pass picks env mode for an AppConfig/Env ConfigMap whose data: holds
 // env-shaped key/value pairs.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -88,7 +88,7 @@ Refuses to overwrite an existing installer.yaml unless --force.`,
 						Default:     true,
 						Description: "Default base — replace with your package's resources.",
 					}},
-					FunctionChainTemplate: []api.FunctionGroup{{
+					Transformers: []api.FunctionGroup{{
 						Toolchain:   "Kubernetes/YAML",
 						Description: "Set the namespace on every namespaced resource.",
 						Invocations: []api.FunctionInvocation{

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -59,6 +59,8 @@ ArgoCD, Flux, or direct Kubernetes apply.`,
 		// Trust
 		newSignCmd(),
 		newVerifyCmd(),
+		// Kustomize integration
+		newTransformerCmd(),
 	)
 	return root
 }

--- a/internal/cli/transformer.go
+++ b/internal/cli/transformer.go
@@ -137,6 +137,13 @@ func runTransformer(ctx context.Context, in []byte) ([]byte, error) {
 		return nil, fmt.Errorf("decode functionConfig: %w", err)
 	}
 
+	// AppConfig annotation pre-pass runs regardless of which kind we're
+	// dispatching, so the canonical contract (toolchain + mode + source-key)
+	// is set on every annotated ConfigMap before any function group fires.
+	if err := injectAppConfigAnnotations(&list); err != nil {
+		return nil, err
+	}
+
 	switch header.Kind {
 	case kindConfigHubTransformers:
 		if err := runChainTransform(ctx, &list, header); err != nil {
@@ -173,27 +180,37 @@ func runChainTransform(ctx context.Context, list *resourceList, header functionC
 	if len(list.Items) == 0 || len(header.Spec.Groups) == 0 {
 		return nil
 	}
-	chain := &api.FunctionChain{
-		APIVersion: api.APIVersion,
-		Kind:       api.KindFunctionChain,
-		Metadata:   api.Metadata{Name: chainNameOr(header, "chain")},
-		Spec: api.FunctionChainSpec{
-			Groups: header.Spec.Groups,
-		},
+	// Groups are dispatched one at a time so AppConfig/* groups can take the
+	// per-carrier round-trip path while Kubernetes/YAML groups (and anything
+	// else top-level) run via chainexec.RunChain on the joined item stream.
+	// Each group's output mutates list.Items in place, so the data-feeds-
+	// forward semantic still holds across mixed-toolchain chains.
+	for _, group := range header.Spec.Groups {
+		if isAppConfigToolchain(group.Toolchain) {
+			if err := runAppConfigGroup(ctx, list, group, true, nil); err != nil {
+				return err
+			}
+			continue
+		}
+		stream, err := encodeItemsAsStream(list.Items)
+		if err != nil {
+			return err
+		}
+		mutated, err := chainexec.RunChain(ctx, &api.FunctionChain{
+			APIVersion: api.APIVersion,
+			Kind:       api.KindFunctionChain,
+			Metadata:   api.Metadata{Name: chainNameOr(header, "chain")},
+			Spec:       api.FunctionChainSpec{Groups: []api.FunctionGroup{group}},
+		}, stream)
+		if err != nil {
+			return err
+		}
+		items, err := decodeStreamAsItems(mutated)
+		if err != nil {
+			return err
+		}
+		list.Items = items
 	}
-	stream, err := encodeItemsAsStream(list.Items)
-	if err != nil {
-		return err
-	}
-	mutated, err := chainexec.RunChain(ctx, chain, stream)
-	if err != nil {
-		return err
-	}
-	items, err := decodeStreamAsItems(mutated)
-	if err != nil {
-		return err
-	}
-	list.Items = items
 	return nil
 }
 
@@ -201,31 +218,39 @@ func runValidatorTransform(ctx context.Context, list *resourceList, header funct
 	if len(list.Items) == 0 || len(header.Spec.Groups) == 0 {
 		return nil
 	}
-	stream, err := encodeItemsAsStream(list.Items)
-	if err != nil {
-		return err
-	}
-	failures, err := chainexec.RunValidators(ctx, header.Spec.Groups, stream)
-	if err != nil {
-		return err
-	}
-	for _, f := range failures {
-		prefix := f.FunctionName
-		if f.UnitSlug != "" {
-			prefix = f.UnitSlug + "/" + prefix
-		}
-		if len(f.Details) == 0 {
-			list.Results = append(list.Results, krmResult{
-				Message:  fmt.Sprintf("%s: failed", prefix),
-				Severity: "error",
-			})
+	for _, group := range header.Spec.Groups {
+		if isAppConfigToolchain(group.Toolchain) {
+			if err := runAppConfigGroup(ctx, list, group, false, &list.Results); err != nil {
+				return err
+			}
 			continue
 		}
-		for _, d := range f.Details {
-			list.Results = append(list.Results, krmResult{
-				Message:  fmt.Sprintf("%s: %s", prefix, d),
-				Severity: "error",
-			})
+		stream, err := encodeItemsAsStream(list.Items)
+		if err != nil {
+			return err
+		}
+		failures, err := chainexec.RunValidators(ctx, []api.FunctionGroup{group}, stream)
+		if err != nil {
+			return err
+		}
+		for _, f := range failures {
+			prefix := f.FunctionName
+			if f.UnitSlug != "" {
+				prefix = f.UnitSlug + "/" + prefix
+			}
+			if len(f.Details) == 0 {
+				list.Results = append(list.Results, krmResult{
+					Message:  fmt.Sprintf("%s: failed", prefix),
+					Severity: "error",
+				})
+				continue
+			}
+			for _, d := range f.Details {
+				list.Results = append(list.Results, krmResult{
+					Message:  fmt.Sprintf("%s: %s", prefix, d),
+					Severity: "error",
+				})
+			}
 		}
 	}
 	return nil

--- a/internal/cli/transformer.go
+++ b/internal/cli/transformer.go
@@ -1,0 +1,287 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/confighub/installer/internal/chainexec"
+	"github.com/confighub/installer/pkg/api"
+)
+
+// KRM Functions ResourceList — https://github.com/kubernetes-sigs/kustomize/blob/master/cmd/config/docs/api-conventions/functions-spec.md.
+// We accept config.kubernetes.io/v1 and kpt's older io.k8s.cli/v1alpha2 shapes
+// transparently: the difference is just the apiVersion string.
+const (
+	resourceListAPIVersion = "config.kubernetes.io/v1"
+	resourceListKind       = "ResourceList"
+
+	kindConfigHubTransformers = "ConfigHubTransformers"
+	kindConfigHubValidators   = "ConfigHubValidators"
+)
+
+// resourceList mirrors the KRM Functions ResourceList shape. Items and
+// FunctionConfig are yaml.Node so we round-trip with reasonable fidelity
+// (comments, key order, scalar styles) — the function executor only sees
+// re-marshalled bytes anyway, but kustomize-level annotations on items
+// (config.kubernetes.io/path, config.kubernetes.io/index) ride through
+// untouched.
+type resourceList struct {
+	APIVersion string      `yaml:"apiVersion"`
+	Kind       string      `yaml:"kind"`
+	Items      []yaml.Node `yaml:"items"`
+	// FunctionConfig is yaml.Node (not *yaml.Node) — yaml.v3 only
+	// special-cases the value form for capturing a subtree; the pointer form
+	// falls through to field-by-field decoding and chokes on yaml.Node's own
+	// Kind field (which is the enum, not a string).
+	FunctionConfig yaml.Node   `yaml:"functionConfig,omitempty"`
+	Results        []krmResult `yaml:"results,omitempty"`
+}
+
+type krmResult struct {
+	Message     string          `yaml:"message"`
+	Severity    string          `yaml:"severity,omitempty"`
+	ResourceRef *krmResourceRef `yaml:"resourceRef,omitempty"`
+}
+
+type krmResourceRef struct {
+	APIVersion string `yaml:"apiVersion,omitempty"`
+	Kind       string `yaml:"kind,omitempty"`
+	Name       string `yaml:"name,omitempty"`
+	Namespace  string `yaml:"namespace,omitempty"`
+}
+
+// functionConfigHeader is the slim view of the functionConfig we need to
+// dispatch on Kind and to lift Groups out of Spec. Everything else
+// (annotations, the config.kubernetes.io/function exec annotation kustomize
+// uses to find this binary) is ignored.
+type functionConfigHeader struct {
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Metadata   struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		Groups []api.FunctionGroup `yaml:"groups"`
+	} `yaml:"spec"`
+}
+
+func newTransformerCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "transformer",
+		Short: "Run ConfigHub functions as a kustomize exec transformer (reads ResourceList from stdin)",
+		Long: `Transformer is a KRM Functions exec plugin for kustomize. It reads a
+ResourceList from stdin, runs the ConfigHub function chain or validators
+encoded in the ResourceList's functionConfig against the items, and writes
+the resulting ResourceList to stdout.
+
+Two functionConfig kinds are recognized:
+
+  ConfigHubTransformers — mutating. Goes under kustomization.transformers:.
+                          spec.groups is a list of FunctionGroups whose
+                          output feeds the next.
+  ConfigHubValidators   — non-mutating. Goes under kustomization.validators:.
+                          spec.groups is a list of validator groups.
+                          Failures are emitted as ResourceList.results with
+                          severity=error; items are not modified. Kustomize
+                          fails the build when any result has severity=error.
+
+Each group's whereResource uses ConfigHub filter syntax (e.g.
+"ConfigHub.ResourceType = 'apps/v1/Deployment'"), not CEL — the expression
+is passed through verbatim to the function executor's WhereResource option.
+
+Usable standalone with raw kustomize: reference this subcommand from your
+kustomization's transformers: list via a KRM function config whose
+config.kubernetes.io/function annotation points at a wrapper that runs
+'installer transformer'.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			in, err := io.ReadAll(cmd.InOrStdin())
+			if err != nil {
+				return fmt.Errorf("read stdin: %w", err)
+			}
+			out, err := runTransformer(ctx, in)
+			if err != nil {
+				return err
+			}
+			_, err = cmd.OutOrStdout().Write(out)
+			return err
+		},
+	}
+}
+
+// runTransformer is the testable core: takes a ResourceList YAML, returns
+// the result ResourceList YAML. Function-execution errors (malformed input,
+// unsupported toolchain) are returned as Go errors → non-zero exit; validator
+// failures land in ResourceList.results with severity=error → zero exit, but
+// kustomize fails the build based on the results.
+func runTransformer(ctx context.Context, in []byte) ([]byte, error) {
+	var list resourceList
+	if err := yaml.Unmarshal(in, &list); err != nil {
+		return nil, fmt.Errorf("parse ResourceList: %w", err)
+	}
+	if list.FunctionConfig.Kind == 0 {
+		return nil, fmt.Errorf("ResourceList has no functionConfig — nothing to do")
+	}
+
+	var header functionConfigHeader
+	if err := list.FunctionConfig.Decode(&header); err != nil {
+		return nil, fmt.Errorf("decode functionConfig: %w", err)
+	}
+
+	switch header.Kind {
+	case kindConfigHubTransformers:
+		if err := runChainTransform(ctx, &list, header); err != nil {
+			return nil, err
+		}
+	case kindConfigHubValidators:
+		if err := runValidatorTransform(ctx, &list, header); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unsupported functionConfig kind %q (want %s or %s)",
+			header.Kind, kindConfigHubTransformers, kindConfigHubValidators)
+	}
+
+	if list.APIVersion == "" {
+		list.APIVersion = resourceListAPIVersion
+	}
+	if list.Kind == "" {
+		list.Kind = resourceListKind
+	}
+	var out bytes.Buffer
+	enc := yaml.NewEncoder(&out)
+	enc.SetIndent(2)
+	if err := enc.Encode(&list); err != nil {
+		return nil, fmt.Errorf("encode ResourceList: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+func runChainTransform(ctx context.Context, list *resourceList, header functionConfigHeader) error {
+	if len(list.Items) == 0 || len(header.Spec.Groups) == 0 {
+		return nil
+	}
+	chain := &api.FunctionChain{
+		APIVersion: api.APIVersion,
+		Kind:       api.KindFunctionChain,
+		Metadata:   api.Metadata{Name: chainNameOr(header, "chain")},
+		Spec: api.FunctionChainSpec{
+			Groups: header.Spec.Groups,
+		},
+	}
+	stream, err := encodeItemsAsStream(list.Items)
+	if err != nil {
+		return err
+	}
+	mutated, err := chainexec.RunChain(ctx, chain, stream)
+	if err != nil {
+		return err
+	}
+	items, err := decodeStreamAsItems(mutated)
+	if err != nil {
+		return err
+	}
+	list.Items = items
+	return nil
+}
+
+func runValidatorTransform(ctx context.Context, list *resourceList, header functionConfigHeader) error {
+	if len(list.Items) == 0 || len(header.Spec.Groups) == 0 {
+		return nil
+	}
+	stream, err := encodeItemsAsStream(list.Items)
+	if err != nil {
+		return err
+	}
+	failures, err := chainexec.RunValidators(ctx, header.Spec.Groups, stream)
+	if err != nil {
+		return err
+	}
+	for _, f := range failures {
+		prefix := f.FunctionName
+		if f.UnitSlug != "" {
+			prefix = f.UnitSlug + "/" + prefix
+		}
+		if len(f.Details) == 0 {
+			list.Results = append(list.Results, krmResult{
+				Message:  fmt.Sprintf("%s: failed", prefix),
+				Severity: "error",
+			})
+			continue
+		}
+		for _, d := range f.Details {
+			list.Results = append(list.Results, krmResult{
+				Message:  fmt.Sprintf("%s: %s", prefix, d),
+				Severity: "error",
+			})
+		}
+	}
+	return nil
+}
+
+func chainNameOr(h functionConfigHeader, fallback string) string {
+	if h.Metadata.Name != "" {
+		return h.Metadata.Name
+	}
+	return fallback
+}
+
+// encodeItemsAsStream marshals each item as a separate YAML document so the
+// chainexec executor sees a `---`-separated multi-doc stream — the same shape
+// it gets from `kustomize build` output today.
+func encodeItemsAsStream(items []yaml.Node) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	for i := range items {
+		if err := enc.Encode(&items[i]); err != nil {
+			return nil, fmt.Errorf("encode item %d: %w", i, err)
+		}
+	}
+	if err := enc.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// decodeStreamAsItems splits the multi-doc YAML stream returned by chainexec
+// back into yaml.Nodes suitable for ResourceList.items. DocumentNode wrappers
+// are unwrapped to their content; empty docs are dropped.
+func decodeStreamAsItems(stream []byte) ([]yaml.Node, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(stream))
+	var out []yaml.Node
+	for {
+		var node yaml.Node
+		err := dec.Decode(&node)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("decode item: %w", err)
+		}
+		if node.Kind == yaml.DocumentNode {
+			if len(node.Content) == 0 {
+				continue
+			}
+			out = append(out, *node.Content[0])
+			continue
+		}
+		if node.Kind == 0 {
+			continue
+		}
+		out = append(out, node)
+	}
+	return out, nil
+}

--- a/internal/cli/transformer_test.go
+++ b/internal/cli/transformer_test.go
@@ -1,0 +1,165 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestTransformer_ChainSetsNamespace runs a ConfigHubTransformers with one
+// set-namespace invocation against a Deployment whose namespace is default,
+// and verifies the output is rewritten to "demo".
+func TestTransformer_ChainSetsNamespace(t *testing.T) {
+	input := `apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+items:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: smoke
+      namespace: default
+    spec:
+      replicas: 1
+      selector: { matchLabels: { app: smoke } }
+      template:
+        metadata: { labels: { app: smoke } }
+        spec:
+          containers:
+            - name: app
+              image: nginx:1.27
+functionConfig:
+  apiVersion: installer.confighub.com/v1alpha1
+  kind: ConfigHubTransformers
+  metadata:
+    name: chain
+  spec:
+    groups:
+      - toolchain: Kubernetes/YAML
+        invocations:
+          - name: set-namespace
+            args: ["demo"]
+`
+	out, err := runTransformer(context.Background(), []byte(input))
+	if err != nil {
+		t.Fatalf("runTransformer: %v", err)
+	}
+	var got resourceList
+	if err := yaml.Unmarshal(out, &got); err != nil {
+		t.Fatalf("parse output: %v\n----\n%s\n----", err, out)
+	}
+	if got.Kind != "ResourceList" {
+		t.Errorf("output kind: want ResourceList, got %q", got.Kind)
+	}
+	if len(got.Items) != 1 {
+		t.Fatalf("output items: want 1, got %d", len(got.Items))
+	}
+	var item struct {
+		Metadata struct {
+			Namespace string `yaml:"namespace"`
+		} `yaml:"metadata"`
+	}
+	if err := got.Items[0].Decode(&item); err != nil {
+		t.Fatalf("decode item: %v", err)
+	}
+	if item.Metadata.Namespace != "demo" {
+		t.Errorf("namespace: want demo, got %q\n----\n%s\n----", item.Metadata.Namespace, out)
+	}
+}
+
+// TestTransformer_ValidatorsEmitResults runs a ConfigHubValidators against a
+// Deployment that violates vet-merge-keys (two containers named "app"). The
+// items should round-trip unchanged; results should carry severity=error.
+func TestTransformer_ValidatorsEmitResults(t *testing.T) {
+	input := `apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+items:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: smoke
+      namespace: default
+    spec:
+      replicas: 1
+      selector: { matchLabels: { app: smoke } }
+      template:
+        metadata: { labels: { app: smoke } }
+        spec:
+          containers:
+            - name: app
+              image: nginx:1.27
+            - name: app
+              image: busybox:1
+functionConfig:
+  apiVersion: installer.confighub.com/v1alpha1
+  kind: ConfigHubValidators
+  metadata:
+    name: validators
+  spec:
+    groups:
+      - toolchain: Kubernetes/YAML
+        invocations:
+          - name: vet-merge-keys
+`
+	out, err := runTransformer(context.Background(), []byte(input))
+	if err != nil {
+		t.Fatalf("runTransformer: %v", err)
+	}
+	var got resourceList
+	if err := yaml.Unmarshal(out, &got); err != nil {
+		t.Fatalf("parse output: %v\n----\n%s\n----", err, out)
+	}
+	if len(got.Results) == 0 {
+		t.Fatalf("expected validator results, got none. Output:\n%s", out)
+	}
+	sawError := false
+	for _, r := range got.Results {
+		if r.Severity == "error" && strings.Contains(r.Message, "vet-merge-keys") {
+			sawError = true
+		}
+	}
+	if !sawError {
+		t.Errorf("expected an error result mentioning vet-merge-keys; got:\n%v", got.Results)
+	}
+}
+
+// TestTransformer_RejectsUnknownKind makes sure we fail fast on functionConfig
+// kinds we don't recognize, rather than silently passing items through.
+func TestTransformer_RejectsUnknownKind(t *testing.T) {
+	input := `apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+items: []
+functionConfig:
+  apiVersion: installer.confighub.com/v1alpha1
+  kind: NotAThing
+  metadata:
+    name: oops
+  spec:
+    groups: []
+`
+	_, err := runTransformer(context.Background(), []byte(input))
+	if err == nil {
+		t.Fatal("expected error for unknown functionConfig kind")
+	}
+	if !strings.Contains(err.Error(), "unsupported functionConfig kind") {
+		t.Errorf("error should explain why: %v", err)
+	}
+}
+
+// TestTransformer_RejectsMissingFunctionConfig — without a functionConfig, the
+// transformer has nothing to do; surface that as an error rather than a
+// silent no-op so misconfigured kustomizations fail loudly.
+func TestTransformer_RejectsMissingFunctionConfig(t *testing.T) {
+	input := `apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+items: []
+`
+	_, err := runTransformer(context.Background(), []byte(input))
+	if err == nil {
+		t.Fatal("expected error when functionConfig is missing")
+	}
+	if !strings.Contains(err.Error(), "no functionConfig") {
+		t.Errorf("error should mention missing functionConfig: %v", err)
+	}
+}

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -18,11 +18,12 @@ import (
 
 func newUploadCmd() *cobra.Command {
 	var (
-		space        string
-		spacePattern string
-		target       string
-		annotations  []string
-		labels       []string
+		space         string
+		spacePattern  string
+		target        string
+		annotations   []string
+		labels        []string
+		appCfgWorker  string
 	)
 	cmd := &cobra.Command{
 		Use:   "upload <work-dir>",
@@ -148,7 +149,7 @@ intra-Space NeedsProvides links.`,
 			}
 
 			for _, pkg := range packages {
-				if err := uploadOnePackage(pkg, target, annotations, labels); err != nil {
+				if err := uploadOnePackage(pkg, target, annotations, labels, appCfgWorker); err != nil {
 					return err
 				}
 			}
@@ -175,14 +176,16 @@ intra-Space NeedsProvides links.`,
 	cmd.Flags().StringVar(&target, "target", "", "target slug; forwarded to cub unit create --target on every rendered Unit (not the installer-record Unit)")
 	cmd.Flags().StringSliceVar(&annotations, "annotation", nil, "annotation key=value to set on every rendered Unit (repeatable)")
 	cmd.Flags().StringSliceVar(&labels, "label", nil, "label key=value to set on every rendered Unit (repeatable)")
+	cmd.Flags().StringVar(&appCfgWorker, "appconfig-worker", "server-worker", "worker slug (Space-relative) to attach to ConfigMapRenderer Targets created for AppConfig-annotated ConfigMaps")
 	return cmd
 }
 
 // uploadOnePackage creates pkg.SpaceSlug if missing, uploads each rendered
-// manifest as a Unit (with --target/--annotation/--label applied), creates
-// the untargeted installer-record Unit, and runs the intra-Space link
-// inference.
-func uploadOnePackage(pkg upload.Package, target string, annotations, labels []string) error {
+// manifest as a Unit (with --target/--annotation/--label applied), splits
+// AppConfig-annotated ConfigMaps into AppConfig Unit + ConfigMapRenderer
+// Target pairs, creates the untargeted installer-record Unit, and runs
+// the intra-Space link inference.
+func uploadOnePackage(pkg upload.Package, target string, annotations, labels []string, appCfgWorker string) error {
 	fmt.Printf("== %s@%s → Space %s ==\n", pkg.Name, pkg.Version, pkg.SpaceSlug)
 
 	if err := ensureSpace(pkg.SpaceSlug); err != nil {
@@ -199,8 +202,18 @@ func uploadOnePackage(pkg upload.Package, target string, annotations, labels []s
 		if e.IsDir() {
 			continue
 		}
-		slug := trimExt(e.Name())
 		path := filepath.Join(pkg.ManifestsDir, e.Name())
+		appCfg, err := upload.DetectAppConfigManifest(path)
+		if err != nil {
+			return err
+		}
+		if appCfg != nil {
+			if err := uploadAppConfigManifest(pkg, appCfg, appCfgWorker, target, componentLabel, annotations, labels); err != nil {
+				return err
+			}
+			continue
+		}
+		slug := trimExt(e.Name())
 		cubArgs := []string{"unit", "create", "--space", pkg.SpaceSlug, "--merge-external-source", e.Name(), "--label", componentLabel}
 		if target != "" {
 			cubArgs = append(cubArgs, "--target", target)
@@ -224,6 +237,155 @@ func uploadOnePackage(pkg upload.Package, target string, annotations, labels []s
 		return err
 	}
 	return upload.ReconcileLinks(context.Background(), pkg.SpaceSlug, pkg.Name)
+}
+
+// uploadAppConfigManifest materializes the AppConfig triple in pkg's
+// Space:
+//
+//  1. ConfigMapRenderer Target — one per carrier ConfigMap.
+//  2. AppConfig Unit — Data is the extracted raw file body, target is
+//     the renderer. This is the day-2 source of truth in the native
+//     format (.properties, .env, etc.).
+//  3. Placeholder Kubernetes/YAML ConfigMap Unit — same slug as the
+//     carrier so other Units in the Space link to it by name via
+//     intra-Space link inference. Body is empty; populated at apply
+//     time via a live-state MergeUnits link to the AppConfig Unit.
+//
+// The placeholder Unit inherits the upload-wide `target` flag (typically a
+// Kubernetes namespace target) so it applies into the same place as every
+// other rendered manifest. The renderer Target itself is attached only to
+// the AppConfig Unit.
+//
+// Idempotent via --allow-exists on the Target and the link; re-running
+// upload after re-rendering refreshes the AppConfig Unit body via the
+// --merge-external-source mechanism the regular path uses.
+func uploadAppConfigManifest(pkg upload.Package, appCfg *upload.AppConfigManifest, worker, target, componentLabel string, annotations, labels []string) error {
+	fmt.Printf("AppConfig: %s (toolchain=%s, mode=%s)\n", appCfg.CarrierName, appCfg.Toolchain, appCfg.Mode)
+
+	// 1. Stage the extracted raw config in a temp file so cub unit
+	//    create reads it from disk like every other Unit body.
+	tmp, err := os.CreateTemp("", "appconfig-*-"+sanitizeForFilename(appCfg.CarrierName))
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.Write(appCfg.Content); err != nil {
+		tmp.Close()
+		return err
+	}
+	tmp.Close()
+
+	// 2. Create (or update — --allow-exists) the ConfigMapRenderer
+	//    Target. The worker arg is required by `cub target create` and
+	//    is Space-relative by convention.
+	workerRef := pkg.SpaceSlug + "/" + worker
+	targetArgs := []string{
+		"target", "create", "--allow-exists",
+		"--space", pkg.SpaceSlug,
+		appCfg.TargetSlug(), "", workerRef,
+		"--provider", "ConfigMapRenderer",
+		"--toolchain", appCfg.Toolchain,
+		"--livestate-type", "Kubernetes/YAML",
+	}
+	for _, opt := range appCfg.RendererOptions() {
+		targetArgs = append(targetArgs, "--option", opt)
+	}
+	tcmd := exec.Command("cub", targetArgs...)
+	tcmd.Stdout = os.Stdout
+	tcmd.Stderr = os.Stderr
+	if err := tcmd.Run(); err != nil {
+		return fmt.Errorf("cub target create %s in %s: %w", appCfg.TargetSlug(), pkg.SpaceSlug, err)
+	}
+
+	// 3. Create the AppConfig Unit pointing at that Target.
+	unitArgs := []string{
+		"unit", "create",
+		"--space", pkg.SpaceSlug,
+		"--toolchain", appCfg.Toolchain,
+		"--target", appCfg.TargetSlug(),
+		"--merge-external-source", filepath.Base(appCfg.ManifestPath),
+		"--label", componentLabel,
+	}
+	for _, a := range annotations {
+		unitArgs = append(unitArgs, "--annotation", a)
+	}
+	for _, l := range labels {
+		unitArgs = append(unitArgs, "--label", l)
+	}
+	unitArgs = append(unitArgs, appCfg.UnitSlug(), tmp.Name())
+	ucmd := exec.Command("cub", unitArgs...)
+	ucmd.Stdout = os.Stdout
+	ucmd.Stderr = os.Stderr
+	if err := ucmd.Run(); err != nil {
+		return fmt.Errorf("cub unit create %s in %s: %w", appCfg.UnitSlug(), pkg.SpaceSlug, err)
+	}
+
+	// 4. Create the placeholder ConfigMap Unit whose slug matches the
+	//    carrier name. Empty body — populated at apply time via the
+	//    live-merge link below. Other workload Units in the same Space
+	//    reference the carrier by name; intra-Space link inference wires
+	//    them into this placeholder so the runtime ConfigMap name flows
+	//    through.
+	placeholderArgs := []string{
+		"unit", "create",
+		"--space", pkg.SpaceSlug,
+		"--toolchain", "Kubernetes/YAML",
+		"--label", componentLabel,
+	}
+	if target != "" {
+		placeholderArgs = append(placeholderArgs, "--target", target)
+	}
+	for _, a := range annotations {
+		placeholderArgs = append(placeholderArgs, "--annotation", a)
+	}
+	for _, l := range labels {
+		placeholderArgs = append(placeholderArgs, "--label", l)
+	}
+	placeholderArgs = append(placeholderArgs, appCfg.CarrierName)
+	pcmd := exec.Command("cub", placeholderArgs...)
+	pcmd.Stdout = os.Stdout
+	pcmd.Stderr = os.Stderr
+	if err := pcmd.Run(); err != nil {
+		return fmt.Errorf("cub unit create %s in %s: %w", appCfg.CarrierName, pkg.SpaceSlug, err)
+	}
+
+	// 5. Live-state MergeUnits link from placeholder → AppConfig Unit.
+	//    --use-live-state pulls the rendered ConfigMap from the
+	//    AppConfig Unit's live state into the placeholder's Data;
+	//    --auto-update keeps it in sync as the AppConfig Unit is
+	//    re-applied. --update-type MergeUnits is the rendering link.
+	linkSlug := appCfg.CarrierName + "-from-" + appCfg.UnitSlug()
+	linkArgs := []string{
+		"link", "create", "--allow-exists", "--wait",
+		"--space", pkg.SpaceSlug,
+		"--use-live-state", "--auto-update", "--update-type", "MergeUnits",
+		"--label", componentLabel,
+		linkSlug, appCfg.CarrierName, appCfg.UnitSlug(),
+	}
+	lcmd := exec.Command("cub", linkArgs...)
+	lcmd.Stdout = os.Stdout
+	lcmd.Stderr = os.Stderr
+	if err := lcmd.Run(); err != nil {
+		return fmt.Errorf("cub link create %s in %s: %w", linkSlug, pkg.SpaceSlug, err)
+	}
+	return nil
+}
+
+// sanitizeForFilename returns name with non-[A-Za-z0-9._-] runes replaced
+// by '-' so it can be embedded in os.CreateTemp's pattern safely.
+func sanitizeForFilename(name string) string {
+	out := []byte(name)
+	for i, b := range out {
+		switch {
+		case b >= 'a' && b <= 'z',
+			b >= 'A' && b <= 'Z',
+			b >= '0' && b <= '9',
+			b == '.', b == '_', b == '-':
+		default:
+			out[i] = '-'
+		}
+	}
+	return string(out)
 }
 
 // ensureSpace creates the Space if it does not exist. Idempotent via

--- a/internal/cli/vet.go
+++ b/internal/cli/vet.go
@@ -29,7 +29,7 @@ Validators are also auto-invoked at the end of every 'installer
 render' — vet only matters when the validator list itself changes.
 
 Validators are templated against the same context as
-functionChainTemplate ({{ .Inputs.* }}, {{ .Selection.* }}, etc.),
+transformers ({{ .Inputs.* }}, {{ .Selection.* }}, etc.),
 so a validator may reference an input. The wizard's persisted
 out/spec/{inputs,selection,facts}.yaml is the source of those
 values. If those files are missing, vet fails fast (run 'installer

--- a/internal/render/chain.go
+++ b/internal/render/chain.go
@@ -3,20 +3,16 @@ package render
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"strings"
 	"text/template"
 
+	"github.com/confighub/installer/internal/chainexec"
 	"github.com/confighub/installer/pkg/api"
-	fapi "github.com/confighub/sdk/core/function/api"
-	"github.com/confighub/sdk/core/workerapi"
-	funcimpl "github.com/confighub/sdk/function-impl"
 	"gopkg.in/yaml.v3"
 )
 
 // resolveChainTemplate expands Go template expressions inside the package's
-// FunctionChainTemplate against the resolved Inputs, Selection, and Facts.
+// Transformers against the resolved Inputs, Selection, and Facts.
 // Returns the materialized FunctionChain ready to execute. Empty arg strings
 // after resolution are kept (they may legitimately encode "set this field
 // empty"); callers that want to skip empty groups should filter post-resolution.
@@ -33,7 +29,7 @@ func resolveChainTemplate(pkg *api.Package, inputs *api.Inputs, sel *api.Selecti
 	// re-parse. This lets the template author use {{ .Inputs.foo }} anywhere
 	// a string appears in the chain (function args, whereResource, even
 	// toolchain), without us having to recurse through every field.
-	srcBytes, err := yaml.Marshal(pkg.Spec.FunctionChainTemplate)
+	srcBytes, err := yaml.Marshal(pkg.Spec.Transformers)
 	if err != nil {
 		return nil, fmt.Errorf("marshal template: %w", err)
 	}
@@ -77,9 +73,9 @@ func resolveChainTemplate(pkg *api.Package, inputs *api.Inputs, sel *api.Selecti
 	}, nil
 }
 
-// resolveValidatorTemplate is the parallel of resolveChainTemplate
-// for the package's spec.validators field. Returns the resolved
-// FunctionGroup list ready to feed runValidators.
+// resolveValidatorTemplate is the parallel of resolveChainTemplate for the
+// package's spec.validators field. Returns the resolved FunctionGroup list
+// ready to feed chainexec.RunValidators.
 func resolveValidatorTemplate(pkg *api.Package, inputs *api.Inputs, sel *api.Selection, facts *api.Facts) ([]api.FunctionGroup, error) {
 	if len(pkg.Spec.Validators) == 0 {
 		return nil, nil
@@ -113,254 +109,20 @@ func resolveValidatorTemplate(pkg *api.Package, inputs *api.Inputs, sel *api.Sel
 	return groups, nil
 }
 
-// runChain executes the resolved FunctionChain against rendered manifests.
-// Each group fires one FunctionInvocationRequest; the response's ConfigData
-// feeds the next group. Mirrors invokeLocalFunctions in cub's worker_install.
-func runChain(ctx context.Context, chain *api.FunctionChain, input []byte) ([]byte, error) {
-	executor := funcimpl.NewStandardExecutor(nil, true)
-	registered := executor.RegisteredFunctions()
-
-	data := input
-	for i, group := range chain.Spec.Groups {
-		toolchain := workerapi.ToolchainType(group.Toolchain)
-		fns, ok := registered[toolchain]
-		if !ok {
-			return nil, fmt.Errorf("group %d: no functions registered for toolchain %q", i, group.Toolchain)
-		}
-
-		invs := make(fapi.FunctionInvocationList, 0, len(group.Invocations))
-		for _, inv := range group.Invocations {
-			if _, exists := fns[inv.Name]; !exists {
-				return nil, fmt.Errorf("group %d: function %q not registered for toolchain %q",
-					i, inv.Name, group.Toolchain)
-			}
-			args, err := parseFunctionArguments(inv.Args)
-			if err != nil {
-				return nil, fmt.Errorf("group %d, function %q: %w", i, inv.Name, err)
-			}
-			invs = append(invs, fapi.FunctionInvocation{
-				FunctionName: inv.Name,
-				Arguments:    args,
-			})
-		}
-
-		req := &fapi.FunctionInvocationRequest{
-			FunctionContext: fapi.FunctionContext{ToolchainType: toolchain},
-			ConfigData:      data,
-			FunctionInvocationOptions: fapi.FunctionInvocationOptions{
-				WhereResource: group.WhereResource,
-				StopOnError:   true,
-			},
-			FunctionInvocations: invs,
-		}
-		resp, err := executor.Invoke(ctx, req)
-		if err != nil {
-			return nil, fmt.Errorf("group %d (%s): %w", i, group.Toolchain, err)
-		}
-		if !resp.Success {
-			return nil, fmt.Errorf("group %d (%s): %v", i, group.Toolchain, resp.ErrorMessages)
-		}
-		if len(resp.ConfigData) > 0 {
-			data = resp.ConfigData
-		}
-	}
-	return data, nil
-}
-
-// RunValidators is the public entry point used by `installer vet`.
-// Resolves the package's spec.validators template against inputs +
-// selection + facts and runs each group against data (the
-// concatenated rendered manifests). Returns a list of failures, or
-// nil on full success.
-func RunValidators(ctx context.Context, pkg *api.Package, sel *api.Selection, inputs *api.Inputs, facts *api.Facts, data []byte) ([]ValidatorFailure, error) {
+// RunValidators is the public entry point used by `installer vet`. Resolves
+// the package's spec.validators template against inputs + selection + facts
+// and runs each group against data (the concatenated rendered manifests).
+// Returns a list of failures, or nil on full success.
+func RunValidators(ctx context.Context, pkg *api.Package, sel *api.Selection, inputs *api.Inputs, facts *api.Facts, data []byte) ([]chainexec.ValidatorFailure, error) {
 	groups, err := resolveValidatorTemplate(pkg, inputs, sel, facts)
 	if err != nil {
 		return nil, err
 	}
-	return runValidators(ctx, groups, data)
+	return chainexec.RunValidators(ctx, groups, data)
 }
 
-// ValidatorFailure is one failing validation result, surfaced in the
-// error returned by runValidators. Used by `installer render` and
-// `installer vet` to produce actionable error messages.
-type ValidatorFailure struct {
-	Group        int
-	FunctionName string
-	UnitSlug     string
-	Details      []string
-}
-
-// runValidators executes the package's Validators against data, which
-// is the post-mutation render output. Each group is invoked with
-// StopOnError=false so every validator runs and the operator sees a
-// complete report. Returns nil on full success; otherwise an error
-// summarizing every failure.
-//
-// Validators must be Validating functions (Mutating=false). Mutating
-// functions in the validators list are rejected before any invocation
-// runs — the validators list is a contract, not a generic chain.
-func runValidators(ctx context.Context, groups []api.FunctionGroup, data []byte) ([]ValidatorFailure, error) {
-	if len(groups) == 0 {
-		return nil, nil
-	}
-	executor := funcimpl.NewStandardExecutor(nil, true)
-	registered := executor.RegisteredFunctions()
-
-	var failures []ValidatorFailure
-	for i, group := range groups {
-		toolchain := workerapi.ToolchainType(group.Toolchain)
-		fns, ok := registered[toolchain]
-		if !ok {
-			return nil, fmt.Errorf("validators group %d: no functions registered for toolchain %q", i, group.Toolchain)
-		}
-		invs := make(fapi.FunctionInvocationList, 0, len(group.Invocations))
-		for _, inv := range group.Invocations {
-			sig, exists := fns[inv.Name]
-			if !exists {
-				return nil, fmt.Errorf("validators group %d: function %q not registered for toolchain %q",
-					i, inv.Name, group.Toolchain)
-			}
-			if sig.Mutating || !sig.Validating {
-				return nil, fmt.Errorf("validators group %d: function %q is not a validating function — declare it under functionChainTemplate instead",
-					i, inv.Name)
-			}
-			args, err := parseFunctionArguments(inv.Args)
-			if err != nil {
-				return nil, fmt.Errorf("validators group %d, function %q: %w", i, inv.Name, err)
-			}
-			invs = append(invs, fapi.FunctionInvocation{
-				FunctionName: inv.Name,
-				Arguments:    args,
-			})
-		}
-		req := &fapi.FunctionInvocationRequest{
-			FunctionContext: fapi.FunctionContext{ToolchainType: toolchain},
-			ConfigData:      data,
-			FunctionInvocationOptions: fapi.FunctionInvocationOptions{
-				WhereResource: group.WhereResource,
-				StopOnError:   false,
-			},
-			FunctionInvocations: invs,
-		}
-		resp, err := executor.Invoke(ctx, req)
-		if err != nil {
-			return nil, fmt.Errorf("validators group %d (%s): %w", i, group.Toolchain, err)
-		}
-		failures = append(failures, decodeValidatorFailures(i, group, resp)...)
-	}
-	return failures, nil
-}
-
-// decodeValidatorFailures walks the executor response's Outputs map
-// and pulls out failing ValidationResults. Outputs is keyed by
-// OutputType with JSON-encoded bodies; validators emit
-// OutputTypeValidationResult or OutputTypeValidationResultList. A
-// non-empty resp.ErrorMessages also surfaces as a synthetic failure
-// so the operator sees executor-level errors (e.g., StopOnError=false
-// only stops the group, not individual invocation errors).
-func decodeValidatorFailures(groupIdx int, group api.FunctionGroup, resp *fapi.FunctionInvocationResponse) []ValidatorFailure {
-	var failures []ValidatorFailure
-	for _, msg := range resp.ErrorMessages {
-		failures = append(failures, ValidatorFailure{
-			Group:    groupIdx,
-			UnitSlug: resp.UnitSlug,
-			Details:  []string{msg},
-		})
-	}
-	for outType, body := range resp.Outputs {
-		if outType != fapi.OutputTypeValidationResult && outType != fapi.OutputTypeValidationResultList {
-			continue
-		}
-		var list fapi.ValidationResultList
-		if err := json.Unmarshal(body, &list); err != nil {
-			// Fall back to a single result.
-			var single fapi.ValidationResult
-			if err2 := json.Unmarshal(body, &single); err2 != nil {
-				failures = append(failures, ValidatorFailure{
-					Group:        groupIdx,
-					FunctionName: "(decode)",
-					UnitSlug:     resp.UnitSlug,
-					Details:      []string{fmt.Sprintf("could not decode validator output: %v", err)},
-				})
-				continue
-			}
-			list = fapi.ValidationResultList{single}
-		}
-		for _, r := range list {
-			if !r.Passed {
-				failures = append(failures, validatorFailureFor(groupIdx, group, resp.UnitSlug, r))
-			}
-		}
-	}
-	return failures
-}
-
-func validatorFailureFor(groupIdx int, group api.FunctionGroup, unitSlug string, r fapi.ValidationResult) ValidatorFailure {
-	name := r.FunctionName
-	if name == "" && r.Index < len(group.Invocations) {
-		name = group.Invocations[r.Index].Name
-	}
-	details := append([]string(nil), r.Details...)
-	for _, iss := range r.Issues {
-		details = append(details, iss.Message)
-	}
-	for _, av := range r.FailedAttributes {
-		details = append(details, fmt.Sprintf("%s: %v", av.Path, av.Value))
-	}
-	return ValidatorFailure{
-		Group:        groupIdx,
-		FunctionName: name,
-		UnitSlug:     unitSlug,
-		Details:      details,
-	}
-}
-
-// FormatValidatorFailures renders a list of failures as a multi-line
-// error message suitable for the operator. Empty slice → empty string.
-func FormatValidatorFailures(failures []ValidatorFailure) string {
-	if len(failures) == 0 {
-		return ""
-	}
-	var b bytes.Buffer
-	fmt.Fprintf(&b, "%d validator failure(s):\n", len(failures))
-	for _, f := range failures {
-		prefix := f.FunctionName
-		if f.UnitSlug != "" {
-			prefix = f.UnitSlug + "/" + prefix
-		}
-		if len(f.Details) == 0 {
-			fmt.Fprintf(&b, "  - %s: failed\n", prefix)
-			continue
-		}
-		for _, d := range f.Details {
-			fmt.Fprintf(&b, "  - %s: %s\n", prefix, d)
-		}
-	}
-	return b.String()
-}
-
-// parseFunctionArguments converts cub-CLI-shaped arg strings into the
-// FunctionArgument form the executor expects. An arg of the form
-// `--name=value` becomes a named argument with ParameterName=name; a bare
-// arg becomes a positional argument with Value=<arg>.
-//
-// Mirrors the parser in public/cmd/cub/function_do.go so that chain templates
-// can use the same `--liveness-path=/internal/ok` style as worker_install.go.
-func parseFunctionArguments(args []string) ([]fapi.FunctionArgument, error) {
-	out := make([]fapi.FunctionArgument, 0, len(args))
-	namedMode := false
-	for _, a := range args {
-		if strings.HasPrefix(a, "--") && strings.Contains(a, "=") {
-			namedMode = true
-			parts := strings.SplitN(a, "=", 2)
-			name := strings.TrimPrefix(parts[0], "--")
-			out = append(out, fapi.FunctionArgument{ParameterName: name, Value: parts[1]})
-			continue
-		}
-		if namedMode {
-			return nil, fmt.Errorf("positional argument %q cannot follow named arguments", a)
-		}
-		out = append(out, fapi.FunctionArgument{Value: a})
-	}
-	return out, nil
+// FormatValidatorFailures re-exports chainexec.FormatValidatorFailures so
+// callers that already import render don't have to add a second import.
+func FormatValidatorFailures(failures []chainexec.ValidatorFailure) string {
+	return chainexec.FormatValidatorFailures(failures)
 }

--- a/internal/render/chain.go
+++ b/internal/render/chain.go
@@ -25,11 +25,29 @@ import (
 //	{{ .Selection.* }}    — chosen base + components
 //	{{ .Package.* }}      — package metadata (name, version, labels, ...)
 func resolveChainTemplate(pkg *api.Package, inputs *api.Inputs, sel *api.Selection, facts *api.Facts) (*api.FunctionChain, error) {
+	// Aggregate package-wide transformers + each selected component's
+	// transformers in declaration order. Components add transformers in
+	// the order they appear in installer.yaml.spec.components (not the
+	// order the wizard selected them), so re-rendering is deterministic.
+	groups := gatherGroups(pkg, sel, func(p *api.Package) []api.FunctionGroup { return p.Spec.Transformers },
+		func(c *api.Component) []api.FunctionGroup { return c.Transformers })
+	if len(groups) == 0 {
+		return &api.FunctionChain{
+			APIVersion: api.APIVersion,
+			Kind:       api.KindFunctionChain,
+			Metadata:   api.Metadata{Name: pkg.Metadata.Name + "-function-chain"},
+			Spec: api.FunctionChainSpec{
+				Package:        pkg.Metadata.Name,
+				PackageVersion: pkg.Metadata.Version,
+			},
+		}, nil
+	}
+
 	// Marshal the template to YAML, run text/template over the bytes, then
 	// re-parse. This lets the template author use {{ .Inputs.foo }} anywhere
 	// a string appears in the chain (function args, whereResource, even
 	// toolchain), without us having to recurse through every field.
-	srcBytes, err := yaml.Marshal(pkg.Spec.Transformers)
+	srcBytes, err := yaml.Marshal(groups)
 	if err != nil {
 		return nil, fmt.Errorf("marshal template: %w", err)
 	}
@@ -54,8 +72,8 @@ func resolveChainTemplate(pkg *api.Package, inputs *api.Inputs, sel *api.Selecti
 		return nil, fmt.Errorf("execute template: %w", err)
 	}
 
-	var groups []api.FunctionGroup
-	if err := yaml.Unmarshal(buf.Bytes(), &groups); err != nil {
+	var resolved []api.FunctionGroup
+	if err := yaml.Unmarshal(buf.Bytes(), &resolved); err != nil {
 		return nil, fmt.Errorf("re-parse resolved chain: %w\n----\n%s\n----", err, buf.String())
 	}
 
@@ -68,19 +86,46 @@ func resolveChainTemplate(pkg *api.Package, inputs *api.Inputs, sel *api.Selecti
 		Spec: api.FunctionChainSpec{
 			Package:        pkg.Metadata.Name,
 			PackageVersion: pkg.Metadata.Version,
-			Groups:         groups,
+			Groups:         resolved,
 		},
 	}, nil
+}
+
+// gatherGroups concatenates package-wide groups with each selected
+// component's groups in installer.yaml declaration order. The picker
+// functions let one helper handle both Transformers and Validators without
+// reflection.
+func gatherGroups(
+	pkg *api.Package,
+	sel *api.Selection,
+	fromPackage func(*api.Package) []api.FunctionGroup,
+	fromComponent func(*api.Component) []api.FunctionGroup,
+) []api.FunctionGroup {
+	selected := map[string]bool{}
+	for _, name := range sel.Spec.Components {
+		selected[name] = true
+	}
+	out := append([]api.FunctionGroup(nil), fromPackage(pkg)...)
+	for i := range pkg.Spec.Components {
+		c := &pkg.Spec.Components[i]
+		if !selected[c.Name] {
+			continue
+		}
+		out = append(out, fromComponent(c)...)
+	}
+	return out
 }
 
 // resolveValidatorTemplate is the parallel of resolveChainTemplate for the
 // package's spec.validators field. Returns the resolved FunctionGroup list
 // ready to feed chainexec.RunValidators.
 func resolveValidatorTemplate(pkg *api.Package, inputs *api.Inputs, sel *api.Selection, facts *api.Facts) ([]api.FunctionGroup, error) {
-	if len(pkg.Spec.Validators) == 0 {
+	groups := gatherGroups(pkg, sel, func(p *api.Package) []api.FunctionGroup { return p.Spec.Validators },
+		func(c *api.Component) []api.FunctionGroup { return c.Validators })
+	if len(groups) == 0 {
 		return nil, nil
 	}
-	srcBytes, err := yaml.Marshal(pkg.Spec.Validators)
+	srcBytes, err := yaml.Marshal(groups)
 	if err != nil {
 		return nil, fmt.Errorf("marshal validators: %w", err)
 	}
@@ -102,11 +147,11 @@ func resolveValidatorTemplate(pkg *api.Package, inputs *api.Inputs, sel *api.Sel
 	}); err != nil {
 		return nil, fmt.Errorf("execute validators template: %w", err)
 	}
-	var groups []api.FunctionGroup
-	if err := yaml.Unmarshal(buf.Bytes(), &groups); err != nil {
+	var resolved []api.FunctionGroup
+	if err := yaml.Unmarshal(buf.Bytes(), &resolved); err != nil {
 		return nil, fmt.Errorf("re-parse resolved validators: %w\n----\n%s\n----", err, buf.String())
 	}
-	return groups, nil
+	return resolved, nil
 }
 
 // RunValidators is the public entry point used by `installer vet`. Resolves

--- a/internal/render/component_chain_test.go
+++ b/internal/render/component_chain_test.go
@@ -1,0 +1,145 @@
+package render_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	ipkg "github.com/confighub/installer/internal/pkg"
+	"github.com/confighub/installer/internal/render"
+	"github.com/confighub/installer/internal/selection"
+	"github.com/confighub/installer/pkg/api"
+)
+
+// TestComponentScopedTransformers verifies that a component's own
+// spec.components[].transformers list only runs when the component is
+// selected, and that its groups append to (don't replace) the package-wide
+// transformers chain.
+//
+// The package below sets metadata.namespace via the package-wide chain. The
+// `annotate` component then layers a yq-i call that adds a marker
+// annotation. Selecting `annotate` should produce manifests with both the
+// namespace AND the annotation; omitting it should produce only the
+// namespace.
+func TestComponentScopedTransformers(t *testing.T) {
+	if _, err := exec.LookPath("kustomize"); err != nil {
+		t.Skip("kustomize not on PATH")
+	}
+
+	for _, tc := range []struct {
+		name              string
+		selectAnnotate    bool
+		expectAnnotation  bool
+	}{
+		{name: "annotate selected", selectAnnotate: true, expectAnnotation: true},
+		{name: "annotate not selected", selectAnnotate: false, expectAnnotation: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pkgDir := writeMixinPackage(t)
+			loaded, err := ipkg.Load(pkgDir)
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			selected := []string{}
+			if tc.selectAnnotate {
+				selected = []string{"annotate"}
+			}
+			sel, err := selection.Resolve(loaded.Package, "", selected)
+			if err != nil {
+				t.Fatalf("Resolve: %v", err)
+			}
+			inputs := mixinInputs("demo")
+
+			work := t.TempDir()
+			out := filepath.Join(work, "out")
+			res, err := render.Render(context.Background(), render.Options{
+				Loaded:            loaded,
+				Selection:         sel,
+				Inputs:            inputs,
+				TransformerBinary: installerBin,
+			}, out)
+			if err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+
+			cm := readManifest(t, res, "ConfigMap", "demo", "smoke")
+			if !strings.Contains(cm, "namespace: demo") {
+				t.Errorf("expected namespace: demo in:\n%s", cm)
+			}
+			hasAnnotation := strings.Contains(cm, "installer.test/marker: hello")
+			if hasAnnotation != tc.expectAnnotation {
+				t.Errorf("annotation present=%v, want %v.\n%s", hasAnnotation, tc.expectAnnotation, cm)
+			}
+		})
+	}
+}
+
+func writeMixinPackage(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "installer.yaml"), `apiVersion: installer.confighub.com/v1alpha1
+kind: Package
+metadata: {name: mixin, version: 0.1.0}
+spec:
+  bases:
+    - {name: default, path: bases/default, default: true}
+  components:
+    - name: annotate
+      path: components/annotate
+      transformers:
+        - toolchain: Kubernetes/YAML
+          whereResource: "ConfigHub.ResourceType = 'v1/ConfigMap'"
+          invocations:
+            - name: yq-i
+              args: ['.metadata.annotations."installer.test/marker" = "hello"']
+  transformers:
+    - toolchain: Kubernetes/YAML
+      invocations:
+        - {name: set-namespace, args: ["{{ .Namespace }}"]}
+`)
+	writeFile(t, filepath.Join(root, "bases/default/kustomization.yaml"), "resources:\n  - cm.yaml\n")
+	writeFile(t, filepath.Join(root, "bases/default/cm.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: smoke
+data:
+  k: v
+`)
+	writeFile(t, filepath.Join(root, "components/annotate/kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+commonAnnotations:
+  installer.test/component: annotate
+`)
+	return root
+}
+
+func mixinInputs(ns string) *api.Inputs {
+	return &api.Inputs{
+		APIVersion: api.APIVersion,
+		Kind:       api.KindInputs,
+		Spec: api.InputsSpec{
+			Namespace: ns,
+			Values:    map[string]any{},
+		},
+	}
+}
+
+// readManifest finds the rendered file matching kind/namespace/name and
+// returns its body as a string.
+func readManifest(t *testing.T, res *render.Result, kind, namespace, name string) string {
+	t.Helper()
+	for _, f := range res.Manifests {
+		if f.Kind == kind && f.Namespace == namespace && f.Name == name {
+			body, err := os.ReadFile(filepath.Join(res.OutDir, "manifests", f.Filename))
+			if err != nil {
+				t.Fatalf("read %s: %v", f.Filename, err)
+			}
+			return string(body)
+		}
+	}
+	t.Fatalf("no manifest %s/%s/%s in result", kind, namespace, name)
+	return ""
+}

--- a/internal/render/compose.go
+++ b/internal/render/compose.go
@@ -1,12 +1,16 @@
 // Package render takes a loaded package + Selection + Inputs and produces
 // rendered Kubernetes manifests by:
 //
-//  1. Synthesizing a top-level kustomization.yaml that references the chosen
-//     base and Components inside the package.
-//  2. Shelling out to `kustomize build` to render the kustomize tree.
-//  3. Resolving the package's FunctionChainTemplate against the Inputs (Go
-//     templates), running each group via the ConfigHub function executor
-//     SDK with its declared toolchain and whereResource.
+//  1. Synthesizing a top-level kustomization.yaml under out/compose/ that
+//     references the chosen base + Components and wires the ConfigHub
+//     transformers and validators as kustomize transformer / validator
+//     plugins.
+//  2. Resolving the package's Transformers + Validators against the
+//     Inputs (Go templates) and writing them to
+//     out/compose/{transformers,validators}.yaml as KRM function configs.
+//  3. Shelling out to `kustomize build --enable-exec --enable-alpha-plugins`,
+//     which invokes `installer transformer` (via a wrapper script in
+//     out/compose/) to run each function group in process.
 //  4. Splitting the resulting multi-doc YAML into per-resource files with
 //     deterministic naming, written to out/manifests/.
 //  5. Persisting the resolved FunctionChain alongside selection.yaml and
@@ -24,74 +28,175 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// composeKustomization writes a synthesized top-level kustomization.yaml into
-// a fresh temp directory, referencing the chosen Base and Components by
-// absolute path inside the loaded package. Returns the temp dir path; caller
-// is responsible for cleanup.
-func composeKustomization(loaded *ipkg.Loaded, sel *api.Selection) (string, error) {
-	pkg := loaded.Package
-	baseDir, err := basePathForName(pkg, sel.Spec.Base)
+// composeInputs is what composeKustomization needs to produce the on-disk
+// compose tree. All paths in Loaded must already be symlink-resolved upstream
+// (Render does this).
+type composeInputs struct {
+	Loaded            *ipkg.Loaded
+	Selection         *api.Selection
+	Chain             *api.FunctionChain // resolved; may have zero groups
+	Validators        []api.FunctionGroup
+	TransformerBinary string // absolute path to the installer binary
+}
+
+// composeKustomization writes a synthesized kustomization tree under
+// composeDir (created if missing, cleared if it already exists). The
+// kustomization references the chosen base + components by relative path,
+// wires transformers.yaml as a transformer and validators.yaml as a
+// validator (when each is non-empty), and writes a one-line
+// installer-transformer.sh wrapper script that execs the running installer
+// binary's transformer subcommand.
+//
+// composeDir is the only directory written; callers persist it under
+// <work-dir>/out/compose/ so `cd out/compose && kustomize build` reproduces
+// the render byte-for-byte.
+func composeKustomization(in composeInputs, composeDir string) error {
+	pkg := in.Loaded.Package
+	baseDir, err := basePathForName(pkg, in.Selection.Spec.Base)
 	if err != nil {
-		return "", err
+		return err
+	}
+
+	if err := os.RemoveAll(composeDir); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(composeDir, 0o755); err != nil {
+		return err
 	}
 
 	// kustomize rejects absolute paths in resources/components; compute
 	// relative paths from the compose dir to each referenced directory.
 	// Both paths must be symlink-resolved or kustomize's own EvalSymlinks
 	// step produces nonsense (notably on macOS, where /var → /private/var).
-	tmp, err := os.MkdirTemp("", "installer-compose-*")
+	composeReal, err := filepath.EvalSymlinks(composeDir)
 	if err != nil {
-		return "", err
+		return err
 	}
-	tmpReal, err := filepath.EvalSymlinks(tmp)
+	rootReal, err := filepath.EvalSymlinks(in.Loaded.Root)
 	if err != nil {
-		_ = os.RemoveAll(tmp)
-		return "", err
+		return err
 	}
-	rootReal, err := filepath.EvalSymlinks(loaded.Root)
-	if err != nil {
-		_ = os.RemoveAll(tmp)
-		return "", err
-	}
-
 	rel := func(target string) (string, error) {
-		return filepath.Rel(tmpReal, filepath.Join(rootReal, target))
+		return filepath.Rel(composeReal, filepath.Join(rootReal, target))
 	}
 
 	baseRel, err := rel(baseDir)
 	if err != nil {
-		_ = os.RemoveAll(tmp)
-		return "", err
+		return err
 	}
 	composed := composedKustomization{
 		APIVersion: "kustomize.config.k8s.io/v1beta1",
 		Kind:       "Kustomization",
 		Resources:  []string{baseRel},
 	}
-	for _, name := range sel.Spec.Components {
+	for _, name := range in.Selection.Spec.Components {
 		path, err := componentPathForName(pkg, name)
 		if err != nil {
-			_ = os.RemoveAll(tmp)
-			return "", err
+			return err
 		}
 		r, err := rel(path)
 		if err != nil {
-			_ = os.RemoveAll(tmp)
-			return "", err
+			return err
 		}
 		composed.Components = append(composed.Components, r)
 	}
 
+	// Write transformers.yaml + validators.yaml + the exec wrapper when needed,
+	// and link them into the top-level kustomization. Empty groups are
+	// elided so trivial packages don't pay for an exec subprocess they
+	// don't use.
+	needsWrapper := false
+	if in.Chain != nil && len(in.Chain.Spec.Groups) > 0 {
+		if err := writeKRMFunctionConfig(composeDir, "transformers.yaml", kindConfigHubTransformers,
+			pkg.Metadata.Name+"-transformers", in.Chain.Spec.Groups); err != nil {
+			return err
+		}
+		composed.Transformers = append(composed.Transformers, "transformers.yaml")
+		needsWrapper = true
+	}
+	if len(in.Validators) > 0 {
+		if err := writeKRMFunctionConfig(composeDir, "validators.yaml", kindConfigHubValidators,
+			pkg.Metadata.Name+"-validators", in.Validators); err != nil {
+			return err
+		}
+		composed.Validators = append(composed.Validators, "validators.yaml")
+		needsWrapper = true
+	}
+	if needsWrapper {
+		if err := writeTransformerWrapper(composeDir, in.TransformerBinary); err != nil {
+			return err
+		}
+	}
+
 	body, err := yaml.Marshal(composed)
 	if err != nil {
-		_ = os.RemoveAll(tmp)
-		return "", err
+		return err
 	}
-	if err := os.WriteFile(filepath.Join(tmp, "kustomization.yaml"), body, 0o644); err != nil {
-		_ = os.RemoveAll(tmp)
-		return "", err
+	// Lead with the exact incantation needed to reproduce this render — the
+	// two flags are mandatory for the exec transformer/validator to fire, and
+	// neither is the kustomize default. yaml.Marshal won't emit comments, so
+	// we prefix the header manually.
+	header := []byte("# Reproduce this render with:\n" +
+		"#   kustomize build --enable-exec --enable-alpha-plugins .\n")
+	return os.WriteFile(filepath.Join(composeDir, "kustomization.yaml"), append(header, body...), 0o644)
+}
+
+// krmFunctionConfig is the shape we emit into transformers.yaml / validators.yaml.
+// The config.kubernetes.io/function annotation tells kustomize which
+// executable to invoke for this transformer/validator; we always point at
+// ./installer-transformer.sh (relative to composeDir) so the kustomization is
+// self-contained.
+type krmFunctionConfig struct {
+	APIVersion string                `yaml:"apiVersion"`
+	Kind       string                `yaml:"kind"`
+	Metadata   krmFunctionConfigMeta `yaml:"metadata"`
+	Spec       struct {
+		Groups []api.FunctionGroup `yaml:"groups"`
+	} `yaml:"spec"`
+}
+
+type krmFunctionConfigMeta struct {
+	Name        string            `yaml:"name"`
+	Annotations map[string]string `yaml:"annotations"`
+}
+
+// kindConfigHubTransformers and kindConfigHubValidators are defined in
+// internal/cli/transformer.go; we redeclare here to avoid an import cycle
+// (cli imports render in some commands, so render can't import cli). They
+// parallel the kustomization.yaml sections they're meant to be listed under
+// — transformers: and validators: respectively.
+const (
+	kindConfigHubTransformers = "ConfigHubTransformers"
+	kindConfigHubValidators   = "ConfigHubValidators"
+)
+
+func writeKRMFunctionConfig(composeDir, filename, kind, name string, groups []api.FunctionGroup) error {
+	cfg := krmFunctionConfig{
+		APIVersion: api.APIVersion,
+		Kind:       kind,
+		Metadata: krmFunctionConfigMeta{
+			Name: name,
+			Annotations: map[string]string{
+				"config.kubernetes.io/function": "exec:\n  path: ./installer-transformer.sh\n",
+			},
+		},
 	}
-	return tmp, nil
+	cfg.Spec.Groups = groups
+	body, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", filename, err)
+	}
+	return os.WriteFile(filepath.Join(composeDir, filename), body, 0o644)
+}
+
+// writeTransformerWrapper writes a one-line shell wrapper that execs the
+// installer binary's transformer subcommand. The absolute path is baked in
+// at render time so `cd out/compose && kustomize build` reproduces without
+// any extra env setup; users can edit the wrapper to point elsewhere if the
+// binary moves.
+func writeTransformerWrapper(composeDir, installerBin string) error {
+	body := fmt.Sprintf("#!/bin/sh\nexec %q transformer\n", installerBin)
+	return os.WriteFile(filepath.Join(composeDir, "installer-transformer.sh"), []byte(body), 0o755)
 }
 
 func basePathForName(pkg *api.Package, name string) (string, error) {
@@ -113,8 +218,10 @@ func componentPathForName(pkg *api.Package, name string) (string, error) {
 }
 
 type composedKustomization struct {
-	APIVersion string   `yaml:"apiVersion"`
-	Kind       string   `yaml:"kind"`
-	Resources  []string `yaml:"resources,omitempty"`
-	Components []string `yaml:"components,omitempty"`
+	APIVersion   string   `yaml:"apiVersion"`
+	Kind         string   `yaml:"kind"`
+	Resources    []string `yaml:"resources,omitempty"`
+	Components   []string `yaml:"components,omitempty"`
+	Transformers []string `yaml:"transformers,omitempty"`
+	Validators   []string `yaml:"validators,omitempty"`
 }

--- a/internal/render/e2e_test.go
+++ b/internal/render/e2e_test.go
@@ -51,7 +51,7 @@ func TestEndToEnd_HelloApp(t *testing.T) {
 		t.Errorf("solver and wizard disagree on base")
 	}
 
-	result, err := render.Render(context.Background(), render.Options{
+	result, err := render.Render(context.Background(), render.Options{TransformerBinary: installerBin,
 		Loaded:    loaded,
 		Selection: sel,
 		Inputs:    inputs,
@@ -140,7 +140,7 @@ func TestEndToEnd_KubeRay(t *testing.T) {
 	}
 	sel, inputs := wres.Selection, wres.Inputs
 
-	result, err := render.Render(context.Background(), render.Options{
+	result, err := render.Render(context.Background(), render.Options{TransformerBinary: installerBin,
 		Loaded:    loaded,
 		Selection: sel,
 		Inputs:    inputs,
@@ -239,7 +239,7 @@ func TestEndToEnd_GAIE(t *testing.T) {
 	}
 	sel, inputs := wres.Selection, wres.Inputs
 
-	result, err := render.Render(context.Background(), render.Options{
+	result, err := render.Render(context.Background(), render.Options{TransformerBinary: installerBin,
 		Loaded:    loaded,
 		Selection: sel,
 		Inputs:    inputs,

--- a/internal/render/images.go
+++ b/internal/render/images.go
@@ -87,7 +87,7 @@ func requireImagesBlock(path string) error {
 		return fmt.Errorf(
 			"%s has no `images:` block; declare one to use --set-image, "+
 				"or have the package author declare image inputs and a "+
-				"set-container-image group in functionChainTemplate (see "+
+				"set-container-image group in transformers (see "+
 				"docs/principles.md Principle 5)", path)
 	}
 	return nil

--- a/internal/render/kustomize.go
+++ b/internal/render/kustomize.go
@@ -6,10 +6,11 @@ import (
 	"os/exec"
 )
 
-// runKustomize shells out to `kustomize build <dir>` and returns stdout.
-// The kustomize binary must be on PATH.
+// runKustomize shells out to `kustomize build` and returns stdout. The exec
+// flags are always passed; kustomize ignores them for kustomizations that
+// don't reference exec plugins.
 func runKustomize(dir string) ([]byte, error) {
-	cmd := exec.Command("kustomize", "build", dir)
+	cmd := exec.Command("kustomize", "build", "--enable-exec", "--enable-alpha-plugins", dir)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/render/multipkg.go
+++ b/internal/render/multipkg.go
@@ -49,6 +49,10 @@ type DepsOptions struct {
 	// Fetcher resolves a locked dep's ref+digest to a local package root.
 	// If nil, DefaultFetcher is used.
 	Fetcher Fetcher
+
+	// TransformerBinary is propagated to each per-dep Render call. Defaults
+	// to os.Executable() inside Render when empty.
+	TransformerBinary string
 }
 
 // DepResult records the outcome of one dependency render.
@@ -107,7 +111,12 @@ func RenderDependencies(ctx context.Context, opts DepsOptions) ([]DepResult, err
 		if err := os.MkdirAll(depOut, 0o755); err != nil {
 			return nil, err
 		}
-		res, err := Render(ctx, Options{Loaded: loaded, Selection: sel, Inputs: inputs}, depOut)
+		res, err := Render(ctx, Options{
+			Loaded:            loaded,
+			Selection:         sel,
+			Inputs:            inputs,
+			TransformerBinary: opts.TransformerBinary,
+		}, depOut)
 		if err != nil {
 			return nil, fmt.Errorf("render dep %s: %w", d.Name, err)
 		}

--- a/internal/render/multipkg_test.go
+++ b/internal/render/multipkg_test.go
@@ -20,7 +20,7 @@ metadata: {name: dep, version: 0.1.0}
 spec:
   bases:
     - {name: default, path: bases/default, default: true}
-  functionChainTemplate:
+  transformers:
     - toolchain: Kubernetes/YAML
       whereResource: ""
       invocations:
@@ -45,7 +45,7 @@ spec:
     - {name: default, path: bases/default, default: true}
   dependencies:
     - {name: dep-one, package: oci://test/dep, version: "^0.1.0"}
-  functionChainTemplate:
+  transformers:
     - toolchain: Kubernetes/YAML
       whereResource: ""
       invocations:
@@ -129,7 +129,7 @@ func TestRenderDependencies(t *testing.T) {
 		return writeDepPackage(t, destDir), nil
 	}
 
-	results, err := render.RenderDependencies(ctx, render.DepsOptions{
+	results, err := render.RenderDependencies(ctx, render.DepsOptions{TransformerBinary: installerBin,
 		Lock:         lock,
 		ParentInputs: parentInputs,
 		WorkDir:      work,
@@ -198,7 +198,7 @@ func TestRenderDependenciesNamespaceFallbackToParent(t *testing.T) {
 		},
 	}
 
-	results, err := render.RenderDependencies(ctx, render.DepsOptions{
+	results, err := render.RenderDependencies(ctx, render.DepsOptions{TransformerBinary: installerBin,
 		Lock:         lock,
 		ParentInputs: parentInputs,
 		WorkDir:      work,
@@ -245,7 +245,7 @@ func TestRenderDependenciesDeterministic(t *testing.T) {
 	}
 	run := func() map[string]string {
 		work := t.TempDir()
-		_, err := render.RenderDependencies(ctx, render.DepsOptions{
+		_, err := render.RenderDependencies(ctx, render.DepsOptions{TransformerBinary: installerBin,
 			Lock:         lock,
 			ParentInputs: parentInputs,
 			WorkDir:      work,

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -10,7 +10,8 @@ import (
 	"github.com/confighub/installer/pkg/api"
 )
 
-// Options controls Render. All fields are required except Facts.
+// Options controls Render. All fields are required except Facts and
+// TransformerBinary.
 type Options struct {
 	Loaded    *ipkg.Loaded
 	Selection *api.Selection
@@ -18,28 +19,39 @@ type Options struct {
 	// Facts is the parsed facts.yaml. Nil when the package has no collector
 	// or the wizard has not been re-run after one was added.
 	Facts *api.Facts
+	// TransformerBinary is the absolute path baked into the
+	// out/compose/installer-transformer wrapper script. Defaults to
+	// os.Executable() — the binary currently running Render. Tests inject a
+	// freshly-built installer binary so the go test binary (which doesn't
+	// implement the `transformer` subcommand) isn't invoked by kustomize.
+	TransformerBinary string
 }
 
 // Result is what Render produces.
 type Result struct {
 	// OutDir is the directory written to (out/manifests + out/secrets + out/spec
-	// underneath).
+	// + out/compose underneath).
 	OutDir string
 	// Manifests is the per-resource non-sensitive output, ordered by Slug.
 	Manifests []File
 	// Secrets is the per-resource sensitive output (Kubernetes Secrets),
 	// written to out/secrets/ and never uploaded as Units.
 	Secrets []File
-	// Chain is the resolved FunctionChain that was executed (also persisted to spec/).
+	// Chain is the resolved FunctionChain that was executed (also persisted
+	// to spec/ and to compose/chain.yaml).
 	Chain *api.FunctionChain
 }
 
-// Render reads the package + selection + inputs, drives kustomize, runs the
-// function chain, and writes per-resource files plus the spec docs to outDir.
+// Render reads the package + selection + inputs, drives kustomize (which
+// invokes `installer transformer` as an exec plugin to apply the function
+// chain and validators), and writes per-resource files plus the spec docs
+// to outDir.
 //
 // outDir is created if missing. Existing files in outDir/manifests are
 // overwritten; files not produced by this render are NOT removed (callers
-// who want a clean slate should remove manifests/ first).
+// who want a clean slate should remove manifests/ first). out/compose/ is
+// always cleared and rewritten so the on-disk kustomization tree reflects
+// the current render exactly.
 func Render(ctx context.Context, opts Options, outDir string) (*Result, error) {
 	if opts.Loaded == nil {
 		return nil, fmt.Errorf("Render: Loaded is required")
@@ -51,6 +63,15 @@ func Render(ctx context.Context, opts Options, outDir string) (*Result, error) {
 		return nil, fmt.Errorf("Render: Inputs is required")
 	}
 
+	transformerBin := opts.TransformerBinary
+	if transformerBin == "" {
+		exe, err := os.Executable()
+		if err != nil {
+			return nil, fmt.Errorf("locate installer binary: %w", err)
+		}
+		transformerBin = exe
+	}
+
 	// 0. Apply per-image overrides (if any) by running `kustomize edit
 	//    set image` against the chosen base's kustomization.yaml. The
 	//    chosen base must declare an `images:` block; render fails fast
@@ -59,59 +80,44 @@ func Render(ctx context.Context, opts Options, outDir string) (*Result, error) {
 		return nil, err
 	}
 
-	// 1. Compose the top-level kustomization in a temp dir, run kustomize build.
-	composeDir, err := composeKustomization(opts.Loaded, opts.Selection)
+	// 1. Resolve chain + validators against inputs + facts. These become
+	//    chain.yaml / validators.yaml in out/compose/, invoked by kustomize
+	//    via the exec plugin.
+	chain, err := resolveChainTemplate(opts.Loaded.Package, opts.Inputs, opts.Selection, opts.Facts)
 	if err != nil {
 		return nil, err
 	}
-	defer os.RemoveAll(composeDir)
+	validators, err := resolveValidatorTemplate(opts.Loaded.Package, opts.Inputs, opts.Selection, opts.Facts)
+	if err != nil {
+		return nil, err
+	}
+
+	// 2. Compose out/compose/ and run kustomize against it. Kustomize
+	//    invokes the wrapper, which execs `installer transformer`,
+	//    which runs each function group through chainexec in-process.
+	composeDir := filepath.Join(outDir, "compose")
+	if err := composeKustomization(composeInputs{
+		Loaded:            opts.Loaded,
+		Selection:         opts.Selection,
+		Chain:             chain,
+		Validators:        validators,
+		TransformerBinary: transformerBin,
+	}, composeDir); err != nil {
+		return nil, err
+	}
 
 	rendered, err := runKustomize(composeDir)
 	if err != nil {
 		return nil, err
 	}
 
-	// 2. Resolve the function chain template against the inputs and facts.
-	chain, err := resolveChainTemplate(opts.Loaded.Package, opts.Inputs, opts.Selection, opts.Facts)
+	// 3. Split into per-resource files with deterministic naming.
+	files, err := splitForUnits(rendered)
 	if err != nil {
 		return nil, err
 	}
 
-	// 3. Run the chain. Output of each group feeds the next.
-	mutated := rendered
-	if len(chain.Spec.Groups) > 0 {
-		mutated, err = runChain(ctx, chain, rendered)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// 3a. Run validators against the mutated output. Validators are
-	// templated against the same context as the function chain, so an
-	// author can pass {{ .Inputs.foo }} into a vet-cel expression. Any
-	// failing validator surfaces as a render error — render produces
-	// no manifests when validation fails.
-	if len(opts.Loaded.Package.Spec.Validators) > 0 {
-		validators, err := resolveValidatorTemplate(opts.Loaded.Package, opts.Inputs, opts.Selection, opts.Facts)
-		if err != nil {
-			return nil, err
-		}
-		failures, err := runValidators(ctx, validators, mutated)
-		if err != nil {
-			return nil, err
-		}
-		if len(failures) > 0 {
-			return nil, fmt.Errorf("validation failed:\n%s", FormatValidatorFailures(failures))
-		}
-	}
-
-	// 4. Split into per-resource files with deterministic naming.
-	files, err := splitForUnits(mutated)
-	if err != nil {
-		return nil, err
-	}
-
-	// 5. Split sensitive resources off into out/secrets/, write the rest to
+	// 4. Split sensitive resources off into out/secrets/, write the rest to
 	// out/manifests/.
 	var manifests, secrets []File
 	for _, f := range files {
@@ -167,8 +173,6 @@ func Render(ctx context.Context, opts Options, outDir string) (*Result, error) {
 	if err := writeYAML(filepath.Join(specDir, "function-chain.yaml"), chain); err != nil {
 		return nil, err
 	}
-	// The manifest index records only non-sensitive files; secrets are tracked
-	// separately and never uploaded.
 	if err := writeManifestIndex(filepath.Join(specDir, "manifest-index.yaml"), opts.Loaded.Package, manifests); err != nil {
 		return nil, err
 	}
@@ -198,10 +202,10 @@ func writeYAML(path string, v any) error {
 // upload is implemented, the index records kind/name/namespace and leaves
 // phase empty.
 type manifestIndex struct {
-	APIVersion string              `yaml:"apiVersion"`
-	Kind       string              `yaml:"kind"`
-	Metadata   api.Metadata        `yaml:"metadata"`
-	Spec       manifestIndexSpec   `yaml:"spec"`
+	APIVersion string            `yaml:"apiVersion"`
+	Kind       string            `yaml:"kind"`
+	Metadata   api.Metadata      `yaml:"metadata"`
+	Spec       manifestIndexSpec `yaml:"spec"`
 }
 
 type manifestIndexSpec struct {

--- a/internal/render/testmain_test.go
+++ b/internal/render/testmain_test.go
@@ -1,0 +1,42 @@
+package render_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// installerBin is the path to a freshly-built installer binary, set by
+// TestMain and consumed by Render-driven tests via Options.TransformerBinary.
+// We can't use the go-test binary directly because it doesn't implement the
+// `installer transformer` subcommand kustomize invokes through the wrapper
+// script in out/compose/.
+var installerBin string
+
+func TestMain(m *testing.M) {
+	code, err := buildAndRun(m)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Exit(code)
+}
+
+func buildAndRun(m *testing.M) (int, error) {
+	tmp, err := os.MkdirTemp("", "installer-bin-*")
+	if err != nil {
+		return 0, fmt.Errorf("mkdir: %w", err)
+	}
+	defer os.RemoveAll(tmp)
+	bin := filepath.Join(tmp, "installer")
+	cmd := exec.Command("go", "build", "-o", bin, "github.com/confighub/installer/cmd/installer")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return 0, fmt.Errorf("build installer: %w", err)
+	}
+	installerBin = bin
+	return m.Run(), nil
+}

--- a/internal/upload/appconfig.go
+++ b/internal/upload/appconfig.go
@@ -17,6 +17,7 @@ const (
 	annoToolchain = "installer.confighub.com/toolchain"
 	annoMode      = "installer.confighub.com/appconfig-mode"
 	annoSourceKey = "installer.confighub.com/appconfig-source-key"
+	annoMutable   = "installer.confighub.com/appconfig-mutable"
 
 	appConfigModeFile = "file"
 	appConfigModeEnv  = "env"
@@ -45,6 +46,12 @@ type AppConfigManifest struct {
 	// SourceKey is the data: key whose value is the raw file body
 	// (file mode only). Empty in env mode.
 	SourceKey string
+	// Mutable reflects appconfig-mutable: when true, the renderer Target
+	// gets RevisionHistoryLimit=0 so the rendered ConfigMap updates in
+	// place (stable name, hash-annotation-driven workload rolling). When
+	// false, RevisionHistoryLimit is left at the bridge default so each
+	// content change produces a new, immutable ConfigMap revision.
+	Mutable bool
 	// Content is the raw AppConfig file body. file mode reads
 	// data[SourceKey] verbatim; env mode emits a `.env`-shaped doc
 	// from data: in sorted key order.
@@ -92,6 +99,10 @@ func DetectAppConfigManifest(path string) (*AppConfigManifest, error) {
 			path, annoMode)
 	}
 	sourceKey := shape.Metadata.Annotations[annoSourceKey]
+	mutable, err := parseMutable(shape.Metadata.Annotations[annoMutable])
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
 
 	m := &AppConfigManifest{
 		ManifestPath:     path,
@@ -100,6 +111,7 @@ func DetectAppConfigManifest(path string) (*AppConfigManifest, error) {
 		Toolchain:        toolchain,
 		Mode:             mode,
 		SourceKey:        sourceKey,
+		Mutable:          mutable,
 	}
 	switch mode {
 	case appConfigModeFile:
@@ -147,16 +159,39 @@ func (m *AppConfigManifest) TargetSlug() string {
 //
 // AsKeyValue=true is set only when the carrier was generated from `envs:`
 // AND the toolchain is AppConfig/Env (the bridge silently ignores it for
-// other toolchains; we set it only where it's meaningful). The mutability
-// rule (RevisionHistoryLimit) is left at the bridge default for now —
-// authors can edit the Target post-upload if they need mutable mode. See
-// docs/transformer.md for the full mapping plan; a richer rule needs a
-// dedicated annotation since the rendered ConfigMap name alone doesn't
-// reliably tell us whether kustomize hashed it.
+// other toolchains; we set it only where it's meaningful).
+//
+// RevisionHistoryLimit=0 is set when the carrier is mutable (kustomize
+// did NOT append a hash suffix, indicating disableNameSuffixHash: true).
+// Mutable ConfigMaps update in place and rely on a hash annotation on
+// the workload to trigger rolling restarts; immutable ConfigMaps (the
+// kustomize default) roll on every content change, so we leave
+// RevisionHistoryLimit at the bridge default to retain a few revisions
+// in cub for rollback.
 func (m *AppConfigManifest) RendererOptions() []string {
 	var out []string
 	if m.Mode == appConfigModeEnv && m.Toolchain == "AppConfig/Env" {
 		out = append(out, "AsKeyValue=true")
 	}
+	if m.Mutable {
+		out = append(out, "RevisionHistoryLimit=0")
+	}
 	return out
+}
+
+// parseMutable parses the appconfig-mutable annotation value. Missing →
+// false (immutable, the kustomize default for configMapGenerator).
+// "true"/"false" → straightforward. Anything else is rejected so a
+// typo doesn't silently degrade to immutable.
+func parseMutable(v string) (bool, error) {
+	switch v {
+	case "":
+		return false, nil
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return false, fmt.Errorf("%s=%q must be \"true\" or \"false\"", annoMutable, v)
+	}
 }

--- a/internal/upload/appconfig.go
+++ b/internal/upload/appconfig.go
@@ -1,0 +1,162 @@
+package upload
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// AppConfig annotation keys — duplicated from internal/cli/appconfig.go to
+// avoid pulling the CLI package into upload (which would invert the
+// dependency direction). Keep the values in sync; both files document the
+// same author contract.
+const (
+	annoToolchain = "installer.confighub.com/toolchain"
+	annoMode      = "installer.confighub.com/appconfig-mode"
+	annoSourceKey = "installer.confighub.com/appconfig-source-key"
+
+	appConfigModeFile = "file"
+	appConfigModeEnv  = "env"
+)
+
+// AppConfigManifest describes one annotated ConfigMap discovered in a
+// rendered manifests directory. DetectAppConfigManifest fills it in;
+// callers use it to drive renderer-Target + AppConfig-Unit creation and
+// to know which files to skip in the normal Kubernetes/YAML upload path.
+type AppConfigManifest struct {
+	// ManifestPath is the absolute path to the rendered ConfigMap YAML.
+	// The file itself is not uploaded as a Kubernetes/YAML Unit — the
+	// renderer Target re-derives the ConfigMap at apply time.
+	ManifestPath string
+	// CarrierName is metadata.name of the rendered ConfigMap.
+	CarrierName string
+	// CarrierNamespace is metadata.namespace (may be empty for
+	// cluster-scope ConfigMaps, but the kustomize default sets it).
+	CarrierNamespace string
+	// Toolchain is the value of installer.confighub.com/toolchain on
+	// the ConfigMap (e.g., AppConfig/Properties, AppConfig/Env).
+	Toolchain string
+	// Mode is appconfig-mode (file|env). Set by the transformer's
+	// pre-pass; this code reads it verbatim.
+	Mode string
+	// SourceKey is the data: key whose value is the raw file body
+	// (file mode only). Empty in env mode.
+	SourceKey string
+	// Content is the raw AppConfig file body. file mode reads
+	// data[SourceKey] verbatim; env mode emits a `.env`-shaped doc
+	// from data: in sorted key order.
+	Content []byte
+}
+
+// DetectAppConfigManifest reads path as a YAML document and returns an
+// AppConfigManifest only when the document is a ConfigMap carrying
+// installer.confighub.com/toolchain (with mode + source-key already
+// injected by the transformer's pre-pass). Returns nil for every other
+// manifest type so callers can branch with `if appCfg != nil`.
+func DetectAppConfigManifest(path string) (*AppConfigManifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var shape struct {
+		APIVersion string `yaml:"apiVersion"`
+		Kind       string `yaml:"kind"`
+		Metadata   struct {
+			Name        string            `yaml:"name"`
+			Namespace   string            `yaml:"namespace"`
+			Annotations map[string]string `yaml:"annotations"`
+		} `yaml:"metadata"`
+		Data map[string]string `yaml:"data"`
+	}
+	if err := yaml.Unmarshal(data, &shape); err != nil {
+		// Not parseable as YAML — let the normal upload path surface that.
+		return nil, nil
+	}
+	if shape.Kind != "ConfigMap" {
+		return nil, nil
+	}
+	toolchain := shape.Metadata.Annotations[annoToolchain]
+	if toolchain == "" {
+		return nil, nil
+	}
+	if !strings.HasPrefix(toolchain, "AppConfig/") {
+		return nil, fmt.Errorf("%s: %s=%q must be an AppConfig/* toolchain",
+			path, annoToolchain, toolchain)
+	}
+	mode := shape.Metadata.Annotations[annoMode]
+	if mode == "" {
+		return nil, fmt.Errorf("%s: %s missing — the transformer should have injected it during render; re-run `installer render`",
+			path, annoMode)
+	}
+	sourceKey := shape.Metadata.Annotations[annoSourceKey]
+
+	m := &AppConfigManifest{
+		ManifestPath:     path,
+		CarrierName:      shape.Metadata.Name,
+		CarrierNamespace: shape.Metadata.Namespace,
+		Toolchain:        toolchain,
+		Mode:             mode,
+		SourceKey:        sourceKey,
+	}
+	switch mode {
+	case appConfigModeFile:
+		if sourceKey == "" {
+			return nil, fmt.Errorf("%s: file mode requires %s annotation", path, annoSourceKey)
+		}
+		body, ok := shape.Data[sourceKey]
+		if !ok {
+			return nil, fmt.Errorf("%s: %s=%q references missing data: key", path, annoSourceKey, sourceKey)
+		}
+		m.Content = []byte(body)
+	case appConfigModeEnv:
+		keys := make([]string, 0, len(shape.Data))
+		for k := range shape.Data {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		var b strings.Builder
+		for _, k := range keys {
+			fmt.Fprintf(&b, "%s=%s\n", k, shape.Data[k])
+		}
+		m.Content = []byte(b.String())
+	default:
+		return nil, fmt.Errorf("%s: %s=%q must be %q or %q", path, annoMode, mode, appConfigModeFile, appConfigModeEnv)
+	}
+	return m, nil
+}
+
+// UnitSlug returns the slug for the AppConfig Unit derived from the
+// carrier ConfigMap's name. We append a stable suffix so the slug never
+// collides with the (separate) Kubernetes Units rendered in the same
+// Space.
+func (m *AppConfigManifest) UnitSlug() string {
+	return m.CarrierName + "-appconfig"
+}
+
+// TargetSlug returns the slug for the ConfigMapRenderer Target. One Target
+// per AppConfig Unit, named for symmetry with UnitSlug.
+func (m *AppConfigManifest) TargetSlug() string {
+	return m.CarrierName + "-renderer"
+}
+
+// RendererOptions returns the `--option K=V` flags appropriate for this
+// AppConfig manifest's ConfigMapRenderer Target.
+//
+// AsKeyValue=true is set only when the carrier was generated from `envs:`
+// AND the toolchain is AppConfig/Env (the bridge silently ignores it for
+// other toolchains; we set it only where it's meaningful). The mutability
+// rule (RevisionHistoryLimit) is left at the bridge default for now —
+// authors can edit the Target post-upload if they need mutable mode. See
+// docs/transformer.md for the full mapping plan; a richer rule needs a
+// dedicated annotation since the rendered ConfigMap name alone doesn't
+// reliably tell us whether kustomize hashed it.
+func (m *AppConfigManifest) RendererOptions() []string {
+	var out []string
+	if m.Mode == appConfigModeEnv && m.Toolchain == "AppConfig/Env" {
+		out = append(out, "AsKeyValue=true")
+	}
+	return out
+}

--- a/internal/upload/appconfig_test.go
+++ b/internal/upload/appconfig_test.go
@@ -57,6 +57,75 @@ data:
 	}
 }
 
+// TestDetectAppConfigManifest_MutableTriggersRevisionHistoryLimit
+// verifies that appconfig-mutable=true on the rendered ConfigMap maps
+// to RevisionHistoryLimit=0 on the renderer Target.
+func TestDetectAppConfigManifest_MutableTriggersRevisionHistoryLimit(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cm.yaml")
+	writeFile(t, path, `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+  annotations:
+    installer.confighub.com/toolchain: AppConfig/Properties
+    installer.confighub.com/appconfig-mode: file
+    installer.confighub.com/appconfig-source-key: application.properties
+    installer.confighub.com/appconfig-mutable: "true"
+data:
+  application.properties: x=1
+`)
+	got, err := DetectAppConfigManifest(path)
+	if err != nil {
+		t.Fatalf("DetectAppConfigManifest: %v", err)
+	}
+	if !got.Mutable {
+		t.Errorf("Mutable: want true, got false")
+	}
+	opts := got.RendererOptions()
+	hasRev := false
+	for _, o := range opts {
+		if o == "RevisionHistoryLimit=0" {
+			hasRev = true
+		}
+	}
+	if !hasRev {
+		t.Errorf("mutable=true should include RevisionHistoryLimit=0; got %v", opts)
+	}
+}
+
+// TestDetectAppConfigManifest_ImmutableSkipsRevisionHistoryLimit
+// verifies that the immutable case (the kustomize default) leaves
+// RevisionHistoryLimit unset so the bridge default applies.
+func TestDetectAppConfigManifest_ImmutableSkipsRevisionHistoryLimit(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cm.yaml")
+	writeFile(t, path, `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config-798k5k7g9f
+  annotations:
+    installer.confighub.com/toolchain: AppConfig/Properties
+    installer.confighub.com/appconfig-mode: file
+    installer.confighub.com/appconfig-source-key: application.properties
+    installer.confighub.com/appconfig-mutable: "false"
+data:
+  application.properties: x=1
+`)
+	got, err := DetectAppConfigManifest(path)
+	if err != nil {
+		t.Fatalf("DetectAppConfigManifest: %v", err)
+	}
+	if got.Mutable {
+		t.Errorf("Mutable: want false, got true")
+	}
+	for _, o := range got.RendererOptions() {
+		if strings.HasPrefix(o, "RevisionHistoryLimit") {
+			t.Errorf("immutable case must not set RevisionHistoryLimit; got %v", got.RendererOptions())
+		}
+	}
+}
+
 // TestDetectAppConfigManifest_EnvKeyValueOption verifies env-mode +
 // AppConfig/Env triggers the AsKeyValue=true Target option, and the
 // content is reconstructed as a deterministic .env-shaped doc.

--- a/internal/upload/appconfig_test.go
+++ b/internal/upload/appconfig_test.go
@@ -1,0 +1,171 @@
+package upload
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDetectAppConfigManifest_FileMode verifies the detector picks up a
+// rendered ConfigMap with the file-mode annotations the transformer's
+// pre-pass injects, and extracts the raw file body verbatim.
+func TestDetectAppConfigManifest_FileMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cm.yaml")
+	writeFile(t, path, `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+  namespace: demo
+  annotations:
+    installer.confighub.com/toolchain: AppConfig/Properties
+    installer.confighub.com/appconfig-mode: file
+    installer.confighub.com/appconfig-source-key: application.properties
+data:
+  application.properties: |
+    a=1
+    b=2
+`)
+	got, err := DetectAppConfigManifest(path)
+	if err != nil {
+		t.Fatalf("DetectAppConfigManifest: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected detection, got nil")
+	}
+	if got.Toolchain != "AppConfig/Properties" {
+		t.Errorf("Toolchain: want AppConfig/Properties, got %q", got.Toolchain)
+	}
+	if got.Mode != "file" {
+		t.Errorf("Mode: want file, got %q", got.Mode)
+	}
+	if got.SourceKey != "application.properties" {
+		t.Errorf("SourceKey: want application.properties, got %q", got.SourceKey)
+	}
+	wantContent := "a=1\nb=2\n"
+	if string(got.Content) != wantContent {
+		t.Errorf("Content: want %q, got %q", wantContent, string(got.Content))
+	}
+	if got.UnitSlug() != "app-config-appconfig" {
+		t.Errorf("UnitSlug: want app-config-appconfig, got %q", got.UnitSlug())
+	}
+	if got.TargetSlug() != "app-config-renderer" {
+		t.Errorf("TargetSlug: want app-config-renderer, got %q", got.TargetSlug())
+	}
+	if len(got.RendererOptions()) != 0 {
+		t.Errorf("file-mode non-Env toolchain should not set AsKeyValue, got %v", got.RendererOptions())
+	}
+}
+
+// TestDetectAppConfigManifest_EnvKeyValueOption verifies env-mode +
+// AppConfig/Env triggers the AsKeyValue=true Target option, and the
+// content is reconstructed as a deterministic .env-shaped doc.
+func TestDetectAppConfigManifest_EnvKeyValueOption(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cm.yaml")
+	writeFile(t, path, `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-env
+  annotations:
+    installer.confighub.com/toolchain: AppConfig/Env
+    installer.confighub.com/appconfig-mode: env
+data:
+  FOO: bar
+  BAZ: qux
+`)
+	got, err := DetectAppConfigManifest(path)
+	if err != nil {
+		t.Fatalf("DetectAppConfigManifest: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected detection, got nil")
+	}
+	if got.Mode != "env" {
+		t.Errorf("Mode: want env, got %q", got.Mode)
+	}
+	opts := got.RendererOptions()
+	if len(opts) != 1 || opts[0] != "AsKeyValue=true" {
+		t.Errorf("RendererOptions: want [AsKeyValue=true], got %v", opts)
+	}
+	// Env content is rendered with sorted keys for determinism: BAZ before FOO.
+	wantContent := "BAZ=qux\nFOO=bar\n"
+	if string(got.Content) != wantContent {
+		t.Errorf("Content: want %q, got %q", wantContent, string(got.Content))
+	}
+}
+
+// TestDetectAppConfigManifest_SkipsUnannotated returns nil for ConfigMaps
+// that don't carry the toolchain annotation. The normal Kubernetes/YAML
+// upload path handles those.
+func TestDetectAppConfigManifest_SkipsUnannotated(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cm.yaml")
+	writeFile(t, path, `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: plain
+data:
+  foo: bar
+`)
+	got, err := DetectAppConfigManifest(path)
+	if err != nil {
+		t.Fatalf("DetectAppConfigManifest: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected no detection for un-annotated ConfigMap, got %+v", got)
+	}
+}
+
+// TestDetectAppConfigManifest_SkipsNonConfigMap returns nil for non-ConfigMap
+// resources even if they happen to carry an installer annotation (shouldn't
+// happen in practice, but we don't want to fail loudly on it).
+func TestDetectAppConfigManifest_SkipsNonConfigMap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "deployment.yaml")
+	writeFile(t, path, `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: smoke
+  annotations:
+    installer.confighub.com/toolchain: AppConfig/Properties
+spec:
+  replicas: 1
+`)
+	got, err := DetectAppConfigManifest(path)
+	if err != nil {
+		t.Fatalf("DetectAppConfigManifest: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected no detection for Deployment, got %+v", got)
+	}
+}
+
+// TestDetectAppConfigManifest_RejectsMissingMode catches the case where
+// the upload step runs against output from an older installer that didn't
+// inject the mode annotation. Error message should point at re-rendering.
+func TestDetectAppConfigManifest_RejectsMissingMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cm.yaml")
+	writeFile(t, path, `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app
+  annotations:
+    installer.confighub.com/toolchain: AppConfig/Properties
+data:
+  app.properties: x=1
+`)
+	_, err := DetectAppConfigManifest(path)
+	if err == nil {
+		t.Fatal("expected error for missing appconfig-mode annotation")
+	}
+	if !strings.Contains(err.Error(), "appconfig-mode") {
+		t.Errorf("error should name the missing annotation: %v", err)
+	}
+	if !strings.Contains(err.Error(), "installer render") {
+		t.Errorf("error should suggest re-rendering: %v", err)
+	}
+}
+
+// writeFile (defined in upload_test.go, same package) is reused here.

--- a/packages/kubernetes-resources/installer.yaml
+++ b/packages/kubernetes-resources/installer.yaml
@@ -18,7 +18,7 @@ spec:
         templates so operators don't author Kubernetes YAML from
         scratch.
 
-  functionChainTemplate:
+  transformers:
     # 1. Set the namespace on every namespaced resource. The
     #    Namespace resource itself gets renamed by `set-namespace`.
     - toolchain: Kubernetes/YAML

--- a/packages/worker/installer.yaml
+++ b/packages/worker/installer.yaml
@@ -69,7 +69,7 @@ spec:
       mount paths, probes) — together they document everything an AI agent or
       human operator needs to author a working Deployment.
 
-  functionChainTemplate:
+  transformers:
     # 1. Name the Namespace and the ClusterRoleBinding (cluster-scoped, so
     #    they don't get a metadata.namespace from set-namespace below).
     - toolchain: Kubernetes/YAML

--- a/packages/worker/validation/README.md
+++ b/packages/worker/validation/README.md
@@ -24,5 +24,5 @@ docker run --rm "$IMAGE" docgen runtime > runtime.yaml
 ```
 
 The same three commands work against any tag — pin to the tag this package's
-`functionChainTemplate` is wired against (defaulted by `cub worker get-image`
+`transformers` is wired against (defaulted by `cub worker get-image`
 to match the server version).

--- a/pkg/api/package.go
+++ b/pkg/api/package.go
@@ -147,6 +147,19 @@ type Component struct {
 	ValidForBases []string `yaml:"validForBases,omitempty" json:"validForBases,omitempty"`
 	// ExternalRequires scoped to this Component.
 	ExternalRequires []ExternalRequire `yaml:"externalRequires,omitempty" json:"externalRequires,omitempty"`
+	// Transformers is an optional component-scoped mixin: function groups
+	// that only run when this component is selected. Appended to the
+	// package-wide PackageSpec.Transformers in declaration order so the
+	// resolved chain still runs in a single in-process executor pass.
+	// Authored exactly like the package-wide list — same toolchain /
+	// whereResource / invocations shape, same restricted Go template
+	// surface ({{ .Namespace }}, {{ .Inputs.* }}, {{ .Selection.* }},
+	// {{ .Facts.* }}, {{ .Package.* }}).
+	Transformers []FunctionGroup `yaml:"transformers,omitempty" json:"transformers,omitempty"`
+	// Validators is the analogous component-scoped validator list. Appended
+	// to PackageSpec.Validators when this component is selected; same
+	// "Mutating=false only" contract.
+	Validators []FunctionGroup `yaml:"validators,omitempty" json:"validators,omitempty"`
 }
 
 // ExternalRequireKind enumerates the typed precondition categories observed

--- a/pkg/api/package.go
+++ b/pkg/api/package.go
@@ -44,13 +44,13 @@ type PackageSpec struct {
 	ExternalManifests []ExternalManifest `yaml:"externalManifests,omitempty" json:"externalManifests,omitempty"`
 
 	// Inputs declares the wizard prompts. Inputs are referenced by Go template
-	// expressions in FunctionChainTemplate (e.g., "{{ .Inputs.namespace }}").
+	// expressions in Transformers (e.g., "{{ .Inputs.namespace }}").
 	Inputs []Input `yaml:"inputs,omitempty" json:"inputs,omitempty"`
 
 	// Collector is an executable bundled in the package that the wizard runs
 	// to discover install-time facts (server URL, image tag, worker IDs, etc.)
 	// and to produce sensitive material as .env.secret files consumed by
-	// kustomize secretGenerator. See FunctionChainTemplate for how facts are
+	// kustomize secretGenerator. See Transformers for how facts are
 	// referenced.
 	Collector *Collector `yaml:"collector,omitempty" json:"collector,omitempty"`
 
@@ -66,15 +66,19 @@ type PackageSpec struct {
 	// empty WhereResource matches everything else.
 	Phases []Phase `yaml:"phases,omitempty" json:"phases,omitempty"`
 
-	// FunctionChainTemplate is a list of function invocation groups. At render
-	// time it is resolved with the wizard answers (Go templates), then each
-	// group is executed by funcimpl.NewStandardExecutor with its own toolchain
-	// and whereResource filter, output of each group feeding the next.
-	FunctionChainTemplate []FunctionGroup `yaml:"functionChainTemplate,omitempty" json:"functionChainTemplate,omitempty"`
+	// Transformers is a list of function-invocation groups that mutate the
+	// rendered output. At render time it is resolved with the wizard answers
+	// (Go templates), serialized to out/compose/transformers.yaml as a
+	// ConfigHubTransformers KRM function config, and run by `installer
+	// transformer` (which kustomize invokes as an exec plugin via the
+	// out/compose/installer-transformer.sh wrapper). Each group runs through
+	// funcimpl.NewStandardExecutor with its own toolchain and whereResource
+	// filter, output of each group feeding the next.
+	Transformers []FunctionGroup `yaml:"transformers,omitempty" json:"transformers,omitempty"`
 
 	// Validators is a list of validating-function invocation groups, run
 	// at the end of render against the mutated output. Same shape as
-	// FunctionChainTemplate, but every named function must be a
+	// Transformers, but every named function must be a
 	// Validating function (Mutating=false). Validators do not modify
 	// the rendered manifests; they fail render if any validator
 	// returns Passed=false.

--- a/pkg/api/parse_test.go
+++ b/pkg/api/parse_test.go
@@ -28,7 +28,7 @@ spec:
     - name: namespace
       type: string
       default: test
-  functionChainTemplate:
+  transformers:
     - toolchain: Kubernetes/YAML
       whereResource: ""
       invocations:
@@ -53,9 +53,9 @@ func TestParsePackage(t *testing.T) {
 	if !p.Spec.Components[0].Default || p.Spec.Components[1].Default {
 		t.Errorf("default flag mismatch: %+v", p.Spec.Components)
 	}
-	if len(p.Spec.FunctionChainTemplate) != 1 ||
-		p.Spec.FunctionChainTemplate[0].Toolchain != "Kubernetes/YAML" {
-		t.Errorf("function chain mismatch: %+v", p.Spec.FunctionChainTemplate)
+	if len(p.Spec.Transformers) != 1 ||
+		p.Spec.Transformers[0].Toolchain != "Kubernetes/YAML" {
+		t.Errorf("function chain mismatch: %+v", p.Spec.Transformers)
 	}
 }
 
@@ -143,7 +143,7 @@ spec:
   replaces:
     - {package: oci://ghcr.io/foo/old-name, version: "< 2.0.0"}
   bundleExamples: false
-  functionChainTemplate:
+  transformers:
     - toolchain: Kubernetes/YAML
       whereResource: ""
       invocations:


### PR DESCRIPTION
## Summary

- Fold the ConfigHub function chain into kustomize as a real
  transformer exec plugin instead of a separate post-\`kustomize
  build\` step. \`installer transformer\` is a first-class
  subcommand readable on its own that any kustomization can invoke;
  \`installer render\` writes a durable \`out/compose/\` and runs
  \`kustomize build --enable-exec --enable-alpha-plugins\`.
- Rename \`installer.yaml.spec.functionChainTemplate\` to
  \`spec.transformers\` (and the Go field) to match the
  kustomization.yaml section the resolved chain lands in. Components
  gain optional \`transformers:\` / \`validators:\` mixins.
- Land AppConfig support end-to-end. Authors tag a
  \`configMapGenerator\` with
  \`installer.confighub.com/toolchain: AppConfig/<type>\`; the
  transformer infers and injects \`appconfig-mode\`,
  \`appconfig-source-key\`, and \`appconfig-mutable\` annotations,
  round-trips the raw config body through \`AppConfig/*\` function
  groups, and the upload step splits the carrier into a four-piece
  bundle: ConfigMapRenderer Target, AppConfig Unit, placeholder
  Kubernetes/YAML ConfigMap Unit, and a live-state MergeUnits link.

Design + rationale: \`docs/transformer.md\`. User-facing docs
(README, author-guide, author-tutorial, consumer-guide) refreshed
to match.

## Test plan

- [ ] \`go test ./...\` green (verified locally)
- [ ] \`installer wizard examples/hello-app\` + \`installer render\` produces \`out/compose/{kustomization,transformers}.yaml\` and \`installer-transformer.sh\`
- [ ] \`cd out/compose && kustomize build --enable-exec --enable-alpha-plugins .\` reproduces the same manifests
- [ ] \`installer transformer\` works standalone: pipe a \`ResourceList\` with a \`ConfigHubTransformers\` functionConfig and verify the items round-trip with the chain applied
- [ ] kuberay example (two transformer groups) renders correctly: namespace set, image set
- [ ] Component-scoped mixin: selecting a component pulls in its \`transformers:\`, omitting it doesn't
- [ ] AppConfig round-trip: \`AppConfig/Properties\` function mutates the carrier ConfigMap's \`data[<source-key>]\`
- [ ] AppConfig upload (against a live cub + worker) creates Target + AppConfig Unit + placeholder Unit + live-merge link

## Phased plan reference

| Phase | Status | Commit |
| --- | --- | --- |
| 1 chainexec lift | ✅ | d385eec |
| 2 \`installer transformer\` subcommand | ✅ | d385eec |
| 3 kustomize-driven render | ✅ | d385eec |
| 4 durable \`out/compose/\` | ✅ | d385eec |
| 5 component-scoped mixins | ✅ | ef79fe8 |
| 6 AppConfig author contract | ✅ | ef79fe8 |
| 7 AppConfig transformer round-trip | ✅ | ef79fe8 |
| 8 AppConfig upload split | ✅ | a44de5f |
| 8b mutability inference | ✅ | b7c0f64 |
| docs refresh | ✅ | 9558829 |

## Known deferred items (documented in \`docs/transformer.md\`)

- Carrier-level \`whereResource\` filtering for AppConfig groups (currently matches all ConfigMaps with the right toolchain annotation).
- \`{{ .Namespace }}\` templating inside \`kustomization.yaml\` files (requires a pre-pass that mirrors resolved copies into \`out/compose/\` to keep package files read-only).
- \`manifest-index.yaml\` schema extension for AppConfig provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)