### PR TITLE
upload: report unmatched references after link inference

### DIFF
--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 
 	"github.com/confighub/installer/internal/deps"
 	ipkg "github.com/confighub/installer/internal/pkg"
@@ -283,7 +284,105 @@ func uploadOnePackage(pkg upload.Package, target string, annotations, labels []s
 	if err := createInstallerRecordUnit(pkg, allowExists); err != nil {
 		return err
 	}
-	return upload.ReconcileLinks(context.Background(), pkg.SpaceSlug, pkg.Name)
+	renderedSecrets := loadRenderedSecretsFromDir(pkg.SecretsDir)
+	skipUnmatched := skipKeysForRenderedSecrets(renderedSecrets)
+	if err := upload.ReconcileLinks(context.Background(), pkg.SpaceSlug, pkg.Name, skipUnmatched); err != nil {
+		return err
+	}
+	reportSecretsNotUploaded(pkg, renderedSecrets)
+	return nil
+}
+
+// renderedSecret describes one rendered Secret manifest in pkg.SecretsDir.
+// We parse the file enough to print kind/name/namespace in the reminder
+// AND to skip the matching entry in ReconcileLinks' unmatched-references
+// list — otherwise the operator sees the same Secret called out twice.
+type renderedSecret struct {
+	Filename  string
+	Type      string // apiVersion/Kind, e.g. v1/Secret
+	Name      string
+	Namespace string
+}
+
+// loadRenderedSecretsFromDir scans pkg.SecretsDir and returns one entry
+// per .yaml/.yml file. Best-effort: a missing dir, an unparseable file,
+// or a doc that doesn't look like a Kubernetes resource is just skipped.
+// The dir may legitimately not exist when no Secrets were rendered.
+func loadRenderedSecretsFromDir(secretsDir string) []renderedSecret {
+	if secretsDir == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(secretsDir)
+	if err != nil {
+		return nil
+	}
+	var out []renderedSecret
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		n := e.Name()
+		if !strings.HasSuffix(n, ".yaml") && !strings.HasSuffix(n, ".yml") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(secretsDir, n))
+		if err != nil {
+			continue
+		}
+		var doc struct {
+			APIVersion string `yaml:"apiVersion"`
+			Kind       string `yaml:"kind"`
+			Metadata   struct {
+				Name      string `yaml:"name"`
+				Namespace string `yaml:"namespace"`
+			} `yaml:"metadata"`
+		}
+		if err := yaml.Unmarshal(data, &doc); err != nil {
+			continue
+		}
+		if doc.Kind == "" || doc.Metadata.Name == "" {
+			continue
+		}
+		out = append(out, renderedSecret{
+			Filename:  n,
+			Type:      doc.APIVersion + "/" + doc.Kind,
+			Name:      doc.Metadata.Name,
+			Namespace: doc.Metadata.Namespace,
+		})
+	}
+	return out
+}
+
+func skipKeysForRenderedSecrets(secrets []renderedSecret) map[string]struct{} {
+	if len(secrets) == 0 {
+		return nil
+	}
+	keys := make(map[string]struct{}, len(secrets))
+	for _, s := range secrets {
+		keys[upload.UnmatchedKey(s.Type, s.Name)] = struct{}{}
+	}
+	return keys
+}
+
+// reportSecretsNotUploaded surfaces any rendered Secrets that landed in
+// pkg.SecretsDir. The installer renders them (so the operator can inspect
+// and apply them out-of-band) but never uploads them as Units — they
+// don't belong in ConfigHub today.
+func reportSecretsNotUploaded(pkg upload.Package, secrets []renderedSecret) {
+	if len(secrets) == 0 {
+		return
+	}
+	fmt.Println()
+	fmt.Printf("Note: %d rendered Secret(s) in %s were NOT uploaded to ConfigHub.\n", len(secrets), pkg.SecretsDir)
+	fmt.Println("Apply them out-of-band (e.g., `kubectl apply -f`) or stage them however your")
+	fmt.Println("environment manages secrets:")
+	for _, s := range secrets {
+		fullName := s.Name
+		if s.Namespace != "" {
+			fullName = s.Namespace + "/" + s.Name
+		}
+		fmt.Printf("  - %s %q (%s)\n", s.Type, fullName, s.Filename)
+	}
 }
 
 // uploadAppConfigManifest materializes the AppConfig bundle in pkg's

--- a/internal/diff/apply.go
+++ b/internal/diff/apply.go
@@ -149,7 +149,9 @@ func Apply(ctx context.Context, plan Plan, opts ApplyOptions) (ApplyResult, erro
 			res.Deleted += deleted
 		}
 		// Re-run link inference now that the Unit set has changed.
-		if err := upload.ReconcileLinks(ctx, sp.SpaceSlug, sp.Package); err != nil {
+		// No skip set here — `installer update` doesn't have the
+		// installer's rendered out/secrets/ context in hand.
+		if err := upload.ReconcileLinks(ctx, sp.SpaceSlug, sp.Package, nil); err != nil {
 			return res, err
 		}
 		if opts.PostSpaceHook != nil {

--- a/internal/upload/links.go
+++ b/internal/upload/links.go
@@ -23,10 +23,19 @@ import (
 // Each new link is labeled Component=<component> so it can be
 // filtered alongside the package's units.
 //
+// skipUnmatched suppresses entries from the unmatched-references
+// reminder for resources the caller already accounts for elsewhere
+// (e.g., rendered Secrets the operator will apply out-of-band). Keys
+// are produced by UnmatchedKey(targetType, targetName). Pass nil to
+// report every unmatched reference. Built-in Kubernetes ClusterRoles
+// are always filtered out — they pre-exist in every cluster and
+// would otherwise dominate the reminder for any package that ships a
+// RoleBinding.
+//
 // Used by `installer upload` (after the per-package Unit creation
 // loop) and by `installer update` (after Apply mutates the Unit set).
 // The two paths share an implementation so behavior cannot drift.
-func ReconcileLinks(ctx context.Context, space, component string) error {
+func ReconcileLinks(ctx context.Context, space, component string, skipUnmatched map[string]struct{}) error {
 	resources, err := loadResources(ctx, space)
 	if err != nil {
 		return err
@@ -43,7 +52,7 @@ func ReconcileLinks(ctx context.Context, space, component string) error {
 	if err != nil {
 		return err
 	}
-	edges := planLinks(resources, refs, labels, crds)
+	edges, unmatched := planLinks(resources, refs, labels, crds)
 
 	existing, err := loadExistingIntraSpaceLinks(ctx, space)
 	if err != nil {
@@ -65,7 +74,58 @@ func ReconcileLinks(ctx context.Context, space, component string) error {
 	if created == 0 && len(edges) == 0 {
 		fmt.Println("No links to create.")
 	}
+	reportUnmatchedReferences(unmatched, skipUnmatched)
 	return nil
+}
+
+// UnmatchedKey produces the canonical key for the skipUnmatched set
+// passed to ReconcileLinks. The shape matches what reportUnmatchedReferences
+// computes per row internally.
+func UnmatchedKey(targetType, targetName string) string {
+	return targetType + "\x00" + targetName
+}
+
+// reportUnmatchedReferences prints a non-fatal reminder for references in
+// uploaded workload Units that didn't match any Unit in the Space. Most
+// common reason: the referenced resource lives in the cluster but isn't
+// managed by ConfigHub (e.g., a Secret created out-of-band, a Namespace
+// owned by the platform team, a ServiceAccount provided by a base
+// install). The installer can't verify those from here — we don't assume
+// the operator running `installer upload` has cluster access — so we
+// surface the list for the operator to confirm rather than failing.
+//
+// Two classes of references are always suppressed:
+//   - Built-in Kubernetes ClusterRoles (cluster-admin/admin/edit/view
+//     and anything under the system: prefix) — they pre-exist in every
+//     cluster and would otherwise dominate the reminder for packages
+//     that ship a RoleBinding.
+//   - Anything whose UnmatchedKey is in skipUnmatched, which the caller
+//     uses to suppress targets it already mentions in a separate
+//     reminder (e.g., rendered-but-not-uploaded Secrets that the
+//     operator will apply out-of-band).
+func reportUnmatchedReferences(unmatched []UnmatchedReference, skipUnmatched map[string]struct{}) {
+	var visible []UnmatchedReference
+	for _, u := range unmatched {
+		if u.TargetType == "rbac.authorization.k8s.io/v1/ClusterRole" && IsBuiltInClusterRole(u.TargetName) {
+			continue
+		}
+		if _, ok := skipUnmatched[UnmatchedKey(u.TargetType, u.TargetName)]; ok {
+			continue
+		}
+		visible = append(visible, u)
+	}
+	if len(visible) == 0 {
+		return
+	}
+	fmt.Println()
+	fmt.Println("Note: the following references didn't resolve to any Unit in this Space.")
+	fmt.Println("That's expected when the referenced resource lives in the cluster but")
+	fmt.Println("isn't managed by ConfigHub (e.g., a Secret created out-of-band, a")
+	fmt.Println("Namespace owned by the platform team). Verify each against your cluster")
+	fmt.Println("before applying.")
+	for _, u := range visible {
+		fmt.Printf("  - %s -> %s %q\n", u.FromUnit, u.TargetType, u.TargetName)
+	}
 }
 
 // LinkEdge is one inferred edge between two Units in the same Space.
@@ -76,6 +136,17 @@ type LinkEdge struct {
 	ToUnit   string
 	// Reason is human-readable; surfaced in upload/update logs.
 	Reason string
+}
+
+// UnmatchedReference is a `get-references` result that didn't match any
+// Unit in the Space — workload Unit FromUnit references a resource of
+// type TargetType named TargetName, but no Unit holds that target.
+// Typically a sign that the target lives in the cluster (out-of-band
+// Secret, platform-team Namespace, etc.) rather than a bug.
+type UnmatchedReference struct {
+	FromUnit   string
+	TargetType string
+	TargetName string
 }
 
 func createLink(ctx context.Context, space, component string, e LinkEdge) error {
@@ -296,7 +367,7 @@ func planLinks(
 	refs map[string][]referenceEntry,
 	labels map[string]*workloadLabels,
 	crds map[string]string,
-) []LinkEdge {
+) ([]LinkEdge, []UnmatchedReference) {
 	seen := map[string]LinkEdge{}
 	add := func(from, to, reason string) {
 		if from == to || from == "" || to == "" {
@@ -308,10 +379,28 @@ func planLinks(
 		}
 		seen[key] = LinkEdge{FromUnit: from, ToUnit: to, Reason: reason}
 	}
+	// Dedup unmatched refs on (fromUnit, targetType, targetName) so a
+	// reference that's repeated across paths (e.g., a Secret named in
+	// envFrom AND volumes) doesn't get reported twice.
+	unmatchedSeen := map[string]struct{}{}
+	var unmatched []UnmatchedReference
 	for fromUnit, entries := range refs {
 		for _, r := range entries {
 			k := resourceLookupKey(r.targetType, r.targetName)
-			for _, toUnit := range resources.unitsByTypeName[k] {
+			matches := resources.unitsByTypeName[k]
+			if len(matches) == 0 {
+				key := fromUnit + "\x00" + string(r.targetType) + "\x00" + string(r.targetName)
+				if _, dup := unmatchedSeen[key]; !dup {
+					unmatchedSeen[key] = struct{}{}
+					unmatched = append(unmatched, UnmatchedReference{
+						FromUnit:   fromUnit,
+						TargetType: string(r.targetType),
+						TargetName: string(r.targetName),
+					})
+				}
+				continue
+			}
+			for _, toUnit := range matches {
 				add(fromUnit, toUnit, "reference:"+string(r.targetType))
 			}
 		}
@@ -358,7 +447,16 @@ func planLinks(
 		}
 		return out[i].Reason < out[j].Reason
 	})
-	return out
+	sort.Slice(unmatched, func(i, j int) bool {
+		if unmatched[i].FromUnit != unmatched[j].FromUnit {
+			return unmatched[i].FromUnit < unmatched[j].FromUnit
+		}
+		if unmatched[i].TargetType != unmatched[j].TargetType {
+			return unmatched[i].TargetType < unmatched[j].TargetType
+		}
+		return unmatched[i].TargetName < unmatched[j].TargetName
+	})
+	return out, unmatched
 }
 
 func anySelectorMatches(selectors, templates []map[string]string) bool {

--- a/internal/upload/links_test.go
+++ b/internal/upload/links_test.go
@@ -1,0 +1,106 @@
+package upload
+
+import (
+	"sort"
+	"testing"
+
+	fapi "github.com/confighub/sdk/core/function/api"
+)
+
+// TestPlanLinks_ResolvedAndUnmatched exercises the two outputs of
+// planLinks together. The Deployment Unit references two resources by
+// name: a ConfigMap that exists as a Unit in the Space (matched) and a
+// Secret that doesn't (unmatched — typically a cluster-side Secret the
+// installer doesn't manage). Matched refs produce a LinkEdge; unmatched
+// refs land in the second return so the caller can surface them as a
+// non-fatal reminder.
+func TestPlanLinks_ResolvedAndUnmatched(t *testing.T) {
+	resources := &resourceIndex{
+		resourcesByUnit: map[string][]fapi.Resource{
+			"dep-unit": {{ResourceInfo: fapi.ResourceInfo{ResourceType: "apps/v1/Deployment", ResourceNameWithoutScope: "app"}}},
+			"cm-unit":  {{ResourceInfo: fapi.ResourceInfo{ResourceType: "v1/ConfigMap", ResourceNameWithoutScope: "app-config"}}},
+		},
+		unitsByTypeName: map[string][]string{
+			resourceLookupKey("apps/v1/Deployment", "app"):  {"dep-unit"},
+			resourceLookupKey("v1/ConfigMap", "app-config"): {"cm-unit"},
+		},
+	}
+	refs := map[string][]referenceEntry{
+		"dep-unit": {
+			{targetType: "v1/ConfigMap", targetName: "app-config"},                  // resolves → edge
+			{targetType: "v1/Secret", targetName: "app-secret"},                     // unmanaged → unmatched
+		},
+	}
+
+	edges, unmatched := planLinks(resources, refs, nil, nil)
+
+	if len(edges) != 1 {
+		t.Fatalf("edges: want 1, got %d (%+v)", len(edges), edges)
+	}
+	if edges[0].FromUnit != "dep-unit" || edges[0].ToUnit != "cm-unit" || edges[0].Reason != "reference:v1/ConfigMap" {
+		t.Errorf("edge: want dep-unit->cm-unit (reference:v1/ConfigMap), got %+v", edges[0])
+	}
+
+	if len(unmatched) != 1 {
+		t.Fatalf("unmatched: want 1, got %d (%+v)", len(unmatched), unmatched)
+	}
+	if unmatched[0] != (UnmatchedReference{FromUnit: "dep-unit", TargetType: "v1/Secret", TargetName: "app-secret"}) {
+		t.Errorf("unmatched: want dep-unit -> v1/Secret app-secret, got %+v", unmatched[0])
+	}
+}
+
+// TestPlanLinks_UnmatchedDeduped ensures a reference repeated across
+// multiple paths within the same workload Unit (e.g., the same Secret
+// named in both envFrom and volumes) is reported once, not twice.
+func TestPlanLinks_UnmatchedDeduped(t *testing.T) {
+	resources := &resourceIndex{
+		resourcesByUnit: map[string][]fapi.Resource{
+			"dep-unit": {{ResourceInfo: fapi.ResourceInfo{ResourceType: "apps/v1/Deployment", ResourceNameWithoutScope: "app"}}},
+		},
+		unitsByTypeName: map[string][]string{},
+	}
+	refs := map[string][]referenceEntry{
+		"dep-unit": {
+			{targetType: "v1/Secret", targetName: "shared"},
+			{targetType: "v1/Secret", targetName: "shared"}, // same target, different path
+		},
+	}
+	_, unmatched := planLinks(resources, refs, nil, nil)
+	if len(unmatched) != 1 {
+		t.Fatalf("unmatched: want 1 (deduped), got %d (%+v)", len(unmatched), unmatched)
+	}
+}
+
+// TestPlanLinks_UnmatchedSorted asserts deterministic output ordering so
+// tests + user-facing logs are stable.
+func TestPlanLinks_UnmatchedSorted(t *testing.T) {
+	resources := &resourceIndex{unitsByTypeName: map[string][]string{}}
+	refs := map[string][]referenceEntry{
+		"unit-b": {{targetType: "v1/Secret", targetName: "x"}},
+		"unit-a": {
+			{targetType: "v1/Secret", targetName: "z"},
+			{targetType: "v1/ConfigMap", targetName: "y"},
+		},
+	}
+	_, unmatched := planLinks(resources, refs, nil, nil)
+	got := make([]string, 0, len(unmatched))
+	for _, u := range unmatched {
+		got = append(got, u.FromUnit+":"+u.TargetType+"/"+u.TargetName)
+	}
+	want := []string{
+		"unit-a:v1/ConfigMap/y",
+		"unit-a:v1/Secret/z",
+		"unit-b:v1/Secret/x",
+	}
+	if !sort.StringsAreSorted(got) {
+		t.Errorf("unmatched not sorted: %v", got)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("want %d entries, got %d (%v)", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("entry %d: want %q, got %q", i, want[i], got[i])
+		}
+	}
+}

--- a/internal/upload/rbac_builtins.go
+++ b/internal/upload/rbac_builtins.go
@@ -1,0 +1,33 @@
+package upload
+
+import "strings"
+
+// builtInClusterRoles is the four user-facing default ClusterRoles
+// Kubernetes ships in every cluster
+// (https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
+// They're not represented as Units in any ConfigHub Space because they
+// pre-exist; references to them from package-provided RoleBindings /
+// ClusterRoleBindings would otherwise show up as unmatched in the link
+// inference reminder.
+var builtInClusterRoles = map[string]struct{}{
+	"cluster-admin": {},
+	"admin":         {},
+	"edit":          {},
+	"view":          {},
+}
+
+// IsBuiltInClusterRole reports whether name is a Kubernetes built-in
+// ClusterRole — either one of the four user-facing roles (cluster-admin,
+// admin, edit, view) or any role under the `system:` prefix Kubernetes
+// reserves for its core-component roles (system:node, system:kube-*,
+// system:controller:*, etc.). See
+// https://kubernetes.io/docs/reference/access-authn-authz/rbac/.
+//
+// Duplicated here pending the next SDK release; once a canonical copy
+// lives in k8skit, drop this file and import from there.
+func IsBuiltInClusterRole(name string) bool {
+	if _, ok := builtInClusterRoles[name]; ok {
+		return true
+	}
+	return strings.HasPrefix(name, "system:")
+}

--- a/internal/upload/rbac_builtins_test.go
+++ b/internal/upload/rbac_builtins_test.go
@@ -1,0 +1,39 @@
+package upload
+
+import "testing"
+
+func TestIsBuiltInClusterRole(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		want bool
+	}{
+		// Four user-facing default roles from the Kubernetes RBAC docs.
+		{"cluster-admin", true},
+		{"admin", true},
+		{"edit", true},
+		{"view", true},
+
+		// Core-component roles live under the `system:` prefix.
+		{"system:node", true},
+		{"system:kube-controller-manager", true},
+		{"system:controller:deployment-controller", true},
+		{"system:auth-delegator", true},
+
+		// User-defined roles are not filtered.
+		{"my-team-admin", false},
+		{"app-reader", false},
+		{"", false},
+
+		// Looks like a system prefix but isn't (no colon) — not a built-in.
+		{"systemic-role", false},
+
+		// Case-sensitive: the canonical `system:` prefix is lowercase.
+		{"System:node", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsBuiltInClusterRole(tc.name); got != tc.want {
+				t.Errorf("IsBuiltInClusterRole(%q) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/packages/worker/bases/default/deployment.yaml
+++ b/packages/worker/bases/default/deployment.yaml
@@ -28,6 +28,6 @@ spec:
                   fieldPath: metadata.namespace
           envFrom:
             - configMapRef:
-                name: confighub-worker-env
+                name: confighub-worker-env-appconfig
             - secretRef:
                 name: confighub-worker-secret


### PR DESCRIPTION
## Summary

After \`ReconcileLinks\` runs the intra-Space link inference,
\`installer upload\` now prints a non-fatal reminder listing every
\`get-references\` entry that didn't resolve to a Unit in the Space.
Typical reason: the referenced resource lives in the cluster but
isn't managed by ConfigHub (out-of-band Secret, platform-team
Namespace, etc.). The installer doesn't assume the operator has
cluster access, so the list is surfaced for them to verify rather
than treated as an error.

Two classes of unmatched references are suppressed:

- **Built-in Kubernetes ClusterRoles.** \`cluster-admin\` / \`admin\` /
  \`edit\` / \`view\` and anything under the \`system:\` prefix
  pre-exist in every cluster and would otherwise dominate the
  reminder for any package shipping a RoleBinding. A local
  \`IsBuiltInClusterRole\` helper handles this for now; pending the
  next SDK release the canonical version will live in k8skit and the
  installer can drop its local copy.
- **Rendered-but-not-uploaded Secrets.** \`installer upload\` already
  prints its own "N rendered Secret(s) ... were NOT uploaded"
  reminder; having those targets in the unmatched list too is just
  noise. \`uploadOnePackage\` now parses \`out/secrets/\` once
  (apiVersion / Kind / name) and passes a skip set into
  \`ReconcileLinks\` via a new \`skipUnmatched\` parameter. The
  secrets-not-uploaded reminder also gained kind/name/namespace
  alongside the filename so operators see what they're meant to
  apply.

Also fixes \`packages/worker/bases/default/deployment.yaml\` to
reference the AppConfig Unit's slug
(\`confighub-worker-env-appconfig\`) in \`envFrom.configMapRef.name\`
rather than the placeholder ConfigMap Unit's slug — the rendered
ConfigMap in the cluster derives its name from the AppConfig Unit,
and the workload reference has to match for \`get-references\`-driven
link inference to wire the Deployment to the right Unit.

## Test plan

- [x] \`go test ./...\` — green
- [x] New tests: three \`TestPlanLinks_*\` covering resolved-vs-unmatched
  split, dedup across paths, deterministic ordering;
  \`TestIsBuiltInClusterRole\` covering the four user-facing roles,
  \`system:\` prefix, user-defined names, edge cases (empty,
  near-miss, case-sensitive).
- [x] Live worker upload — \`cluster-admin\` reference filtered out,
  \`v1/Secret confighub-worker-secret\` reference suppressed because
  the file is listed in the secrets-not-uploaded reminder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)