### PR TITLE
upload: align AppConfig ConfigMap names; rename binary to 'install'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+# Makefile for the installer CLI.
+#
+# The output binary is `bin/install` because the cub plugin protocol
+# names the plugin after its entrypoint basename: invoking it via cub
+# reads as `cub install ...`, matching the standalone form.
+
+GO     ?= go
+BIN    ?= bin/install
+PKG    ?= ./cmd/installer
+
+.PHONY: all build install test vet fmt clean
+
+all: build
+
+build: $(BIN)
+
+$(BIN): $(shell find . -name '*.go' -not -path './bin/*')
+	$(GO) build -o $(BIN) $(PKG)
+
+# Alias: `make install` builds the binary (it does NOT install it on
+# PATH — name matches the binary, not the verb).
+install: build
+
+test:
+	$(GO) test ./...
+
+vet:
+	$(GO) vet ./...
+
+fmt:
+	$(GO) fmt ./...
+
+clean:
+	rm -f bin/install bin/installer

--- a/README.md
+++ b/README.md
@@ -81,10 +81,13 @@ Stubbed: `installer preflight` — cluster-side constraint checks.
 ## Build
 
 ```bash
-go build -o bin/installer ./cmd/installer
+make build       # writes bin/install
 ```
 
-`installer` shells out to `kustomize` for `kustomize build`. Install it from
+The binary is named `install` so the cub plugin protocol exposes it as
+`cub install ...` (cub names plugins after the entrypoint basename in
+`cub-plugin.yaml`). `install` shells out to `kustomize` for
+`kustomize build`. Install it from
 [kubernetes-sigs/kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/)
 or `brew install kustomize`.
 
@@ -94,11 +97,11 @@ End to end against the included example, no ConfigHub server required:
 
 ```bash
 # 1. Inspect what's in the package.
-bin/installer doc ./examples/hello-app
+bin/install doc ./examples/hello-app
 
 # 2. Wizard: pick base + components, supply inputs. Writes
 #    /tmp/hello/out/spec/{selection,inputs}.yaml.
-bin/installer wizard ./examples/hello-app \
+bin/install wizard ./examples/hello-app \
   --work-dir /tmp/hello \
   --non-interactive \
   --select monitoring --select ingress \
@@ -107,22 +110,22 @@ bin/installer wizard ./examples/hello-app \
 # 3. Render: composes a kustomization in out/compose/ with the ConfigHub
 #    function chain wired in as a kustomize transformer plugin, runs
 #    `kustomize build`, writes one file per resource to out/manifests/.
-bin/installer render /tmp/hello
+bin/install render /tmp/hello
 
 # 4. Upload to ConfigHub. Records the destination Space(s) in
 #    out/spec/upload.yaml so subsequent plan / update / upgrade
 #    re-enter the same Space without operator re-typing.
-bin/installer upload /tmp/hello --space my-greeter
+bin/install upload /tmp/hello --space my-greeter
 
 # 5. Day-2: edit a rendered file, see what update would do, apply.
 $EDITOR /tmp/hello/out/manifests/deployment-demo-hello-app.yaml
-bin/installer plan /tmp/hello              # read-only diff vs ConfigHub
-bin/installer update /tmp/hello --yes      # apply inside a ChangeSet
+bin/install plan /tmp/hello              # read-only diff vs ConfigHub
+bin/install update /tmp/hello --yes      # apply inside a ChangeSet
 
 # 6. Upgrade: re-pull, re-render, plan, then apply atomically.
-bin/installer upgrade /tmp/hello ./examples/hello-app \
+bin/install upgrade /tmp/hello ./examples/hello-app \
   --set-image nginxdemos/hello=nginxdemos/hello:plain-text-v2
-bin/installer upgrade-apply /tmp/hello     # promote .upgrade/ + run update
+bin/install upgrade-apply /tmp/hello     # promote .upgrade/ + run update
 ```
 
 The wizard's `--select` is closed under each component's `requires:` list, so
@@ -219,7 +222,7 @@ when the component is selected.
 ## Plugin install
 
 The binary doubles as a `cub` plugin. After publishing a release that includes
-a platform binary at the path `bin/installer`, install with:
+a platform binary at the path `bin/install`, install with:
 
 ```bash
 cub plugin install confighub/installer

--- a/cub-plugin.yaml
+++ b/cub-plugin.yaml
@@ -1,1 +1,1 @@
-entrypoint: bin/installer
+entrypoint: bin/install

--- a/docs/author-tutorial.md
+++ b/docs/author-tutorial.md
@@ -20,7 +20,7 @@ For the doctrine the installer is anchored to, see
 
 ## Prerequisites
 
-- `installer` binary on PATH (or invoke `bin/installer` from a clone).
+- `install` binary on PATH (or invoke `bin/install` from a clone).
 - `kustomize` on PATH.
 - `cub` on PATH and signed in (`cub auth login`).
 - The `kubernetes-resources` package bootstrapped in your

--- a/docs/transformer.md
+++ b/docs/transformer.md
@@ -347,9 +347,14 @@ write-back; failures become `ResourceList.results`.
 At upload, ConfigMaps with `installer.confighub.com/toolchain` are
 split into four ConfigHub objects:
 
-- **AppConfig Unit** (slug `<carrier-name>-appconfig`). Toolchain
-  from the annotation. Data = the extracted raw file body. Day-2
-  source of truth in the native format.
+- **AppConfig Unit** (slug = `<carrier-name>`, matching the
+  kustomize-generated ConfigMap name). Toolchain from the annotation.
+  Data = the extracted raw file body. Day-2 source of truth in the
+  native format. The ConfigMapRenderer bridge uses the Unit slug as
+  the rendered ConfigMap's `metadata.name`, so the slug deliberately
+  has no suffix — workloads can reference the carrier by its
+  kustomize-generated name (e.g. `envFrom.configMapRef.name`) and the
+  rendered ConfigMap will match.
 - **ConfigMapRenderer Target** (slug `<carrier-name>-renderer`).
   Provider `ConfigMapRenderer`, toolchain from the annotation,
   livestate-type `Kubernetes/YAML`. Attached to the AppConfig Unit
@@ -372,14 +377,17 @@ split into four ConfigHub objects:
   link inference at the end of `uploadOnePackage` then reads to wire
   workload references (envFrom, volumes, etc.) into the placeholder.
 - **Placeholder Kubernetes/YAML ConfigMap Unit** (slug =
-  `<carrier-name>`, matching the kustomize-generated name).
-  Body is empty at creation; populated by the live-merge link below
-  using the live state from the just-applied AppConfig Unit. Inherits
-  the upload-wide `--target` flag (typically a Kubernetes namespace
-  target) so it applies into the same place as every other rendered
-  manifest. Other workload Units in the Space reference the carrier
-  by name, so existing intra-Space link inference
-  (`internal/upload/links.go`) wires them into this placeholder.
+  `<carrier-name>-rendered`). Body is empty at creation; populated by
+  the live-merge link below using the live state from the
+  just-applied AppConfig Unit. Inherits the upload-wide `--target`
+  flag (typically a Kubernetes namespace target) so it applies into
+  the same place as every other rendered manifest. The `-rendered`
+  suffix avoids colliding with the AppConfig Unit (which owns the
+  bare carrier name). Workloads still resolve to the rendered
+  ConfigMap by `metadata.name` (= `<carrier-name>`, set by the bridge
+  from the AppConfig Unit's slug), so intra-Space link inference
+  (`internal/upload/links.go`) wires them into this placeholder via
+  the merged content.
 - **Live-merge link** (server-assigned slug via `-`).
   `--use-live-state --auto-update --update-type MergeUnits`. Pulls
   the rendered ConfigMap from the AppConfig Unit's live state into

--- a/examples/gaie/README.md
+++ b/examples/gaie/README.md
@@ -37,13 +37,13 @@ package that templates the chart at install time.
 ## Quick start
 
 ```bash
-bin/installer wizard ./examples/gaie \
+bin/install wizard ./examples/gaie \
   --work-dir /tmp/gaie \
   --non-interactive \
   --select sample-pool \
   --input namespace=inference
 
-bin/installer render /tmp/gaie
+bin/install render /tmp/gaie
 ls /tmp/gaie/out/manifests/
 ```
 

--- a/examples/kuberay/README.md
+++ b/examples/kuberay/README.md
@@ -40,12 +40,12 @@ push to Docker Hub). Fork the package to point at a private mirror.
 ## Quick start
 
 ```bash
-bin/installer wizard ./examples/kuberay \
+bin/install wizard ./examples/kuberay \
   --work-dir /tmp/kuberay \
   --non-interactive \
   --input namespace=kuberay-system
 
-bin/installer render /tmp/kuberay
+bin/install render /tmp/kuberay
 ls /tmp/kuberay/out/manifests/
 ```
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -135,8 +135,8 @@ resources: []
 			fmt.Printf("  - %s/\n", filepath.Join(dir, "validation"))
 			fmt.Println()
 			fmt.Println("Next: drop your kustomize resources under bases/default/, then run")
-			fmt.Printf("  installer wizard %s --work-dir /tmp/dev --non-interactive --namespace demo\n", dir)
-			fmt.Printf("  installer render /tmp/dev\n")
+			fmt.Printf("  %s wizard %s --work-dir /tmp/dev --non-interactive --namespace demo\n", InvocationName(), dir)
+			fmt.Printf("  %s render /tmp/dev\n", InvocationName())
 			return nil
 		},
 	}

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -210,8 +210,8 @@ func newNewCmd() *cobra.Command {
 			}
 			fmt.Println()
 			fmt.Println("Next: re-render to verify the new resource:")
-			fmt.Printf("  installer wizard %s --work-dir /tmp/dev --non-interactive --namespace demo\n", abs)
-			fmt.Printf("  installer render /tmp/dev\n")
+			fmt.Printf("  %s wizard %s --work-dir /tmp/dev --non-interactive --namespace demo\n", InvocationName(), abs)
+			fmt.Printf("  %s render /tmp/dev\n", InvocationName())
 			return nil
 		},
 	}

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -127,7 +127,7 @@ identical bytes. Re-render after editing selection.yaml or inputs.yaml.`,
 				}
 			}
 
-			fmt.Printf("Next: installer upload %s --space <slug>\n", workDir)
+			fmt.Printf("Next: %s upload %s --space <slug>\n", InvocationName(), workDir)
 			return nil
 		},
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -16,6 +16,23 @@ func invokedAsPlugin() bool {
 	return os.Getenv("CUB_PLUGIN") == "1"
 }
 
+// InvocationName is the command name to print in user-facing follow-up
+// instructions ("Next: ... upload <dir>"). It returns "cub install" when
+// the binary was launched via the cub plugin protocol so the operator
+// can copy-paste the suggestion back into their shell; otherwise it
+// returns os.Args[0] verbatim (e.g. "bin/install", "install",
+// "/usr/local/bin/install") so the suggestion matches what they
+// actually typed. Falls back to "installer" if os.Args is empty.
+func InvocationName() string {
+	if invokedAsPlugin() {
+		return "cub install"
+	}
+	if len(os.Args) > 0 && os.Args[0] != "" {
+		return os.Args[0]
+	}
+	return "installer"
+}
+
 // NewRoot builds the root cobra command with all subcommands attached.
 func NewRoot() *cobra.Command {
 	root := &cobra.Command{

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -169,11 +169,11 @@ re-render.`,
 
 			if apply {
 				fmt.Println()
-				fmt.Println("--apply: chaining `installer upgrade-apply`")
+				fmt.Printf("--apply: chaining `%s upgrade-apply`\n", InvocationName())
 				priorPkg := prior.PriorPackage
 				return runUpgradeApply(ctx, workDir, loaded.Package, yes, priorPkg)
 			}
-			fmt.Printf("\nNext: installer upgrade-apply %s   (or rerun with --apply)\n", workDir)
+			fmt.Printf("\nNext: %s upgrade-apply %s   (or rerun with --apply)\n", InvocationName(), workDir)
 			return nil
 		},
 	}

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -494,11 +494,14 @@ func uploadAppConfigManifest(pkg upload.Package, appCfg *upload.AppConfigManifes
 		return fmt.Errorf("cub unit apply %s in %s: %w", appCfg.UnitSlug(), pkg.SpaceSlug, err)
 	}
 
-	// 5. Create the placeholder ConfigMap Unit whose slug matches the
-	//    carrier name. Empty body — populated by the live-merge link
-	//    below. Other workload Units in the same Space reference the
-	//    carrier by name; intra-Space link inference wires them into this
-	//    placeholder so the runtime ConfigMap name flows through.
+	// 5. Create the placeholder ConfigMap Unit. Its slug carries a
+	//    "-rendered" suffix so it doesn't collide with the AppConfig
+	//    Unit (which owns the carrier's name so the bridge stamps that
+	//    name onto the rendered ConfigMap). Body is empty at creation;
+	//    populated by the live-merge link below. Other workload Units
+	//    reference the ConfigMap by metadata.name (which equals
+	//    UnitSlug() after the merge); intra-Space link inference wires
+	//    them into this placeholder via the merged content.
 	placeholderArgs := []string{"unit", "create"}
 	if allowExists {
 		placeholderArgs = append(placeholderArgs, "--allow-exists")
@@ -517,12 +520,12 @@ func uploadAppConfigManifest(pkg upload.Package, appCfg *upload.AppConfigManifes
 	for _, l := range labels {
 		placeholderArgs = append(placeholderArgs, "--label", l)
 	}
-	placeholderArgs = append(placeholderArgs, appCfg.CarrierName)
+	placeholderArgs = append(placeholderArgs, appCfg.PlaceholderSlug())
 	pcmd := exec.Command("cub", placeholderArgs...)
 	pcmd.Stdout = os.Stdout
 	pcmd.Stderr = os.Stderr
 	if err := pcmd.Run(); err != nil {
-		return fmt.Errorf("cub unit create %s in %s: %w", appCfg.CarrierName, pkg.SpaceSlug, err)
+		return fmt.Errorf("cub unit create %s in %s: %w", appCfg.PlaceholderSlug(), pkg.SpaceSlug, err)
 	}
 
 	// 6. Live-state MergeUnits link from placeholder → AppConfig Unit.
@@ -540,13 +543,13 @@ func uploadAppConfigManifest(pkg upload.Package, appCfg *upload.AppConfigManifes
 		"--space", pkg.SpaceSlug,
 		"--use-live-state", "--auto-update", "--update-type", "MergeUnits",
 		"--label", componentLabel,
-		"-", appCfg.CarrierName, appCfg.UnitSlug(),
+		"-", appCfg.PlaceholderSlug(), appCfg.UnitSlug(),
 	)
 	lcmd := exec.Command("cub", linkArgs...)
 	lcmd.Stdout = os.Stdout
 	lcmd.Stderr = os.Stderr
 	if err := lcmd.Run(); err != nil {
-		return fmt.Errorf("cub link create %s → %s in %s: %w", appCfg.CarrierName, appCfg.UnitSlug(), pkg.SpaceSlug, err)
+		return fmt.Errorf("cub link create %s → %s in %s: %w", appCfg.PlaceholderSlug(), appCfg.UnitSlug(), pkg.SpaceSlug, err)
 	}
 
 	// 7. Stamp the correct namespace onto the placeholder Unit's now-
@@ -563,12 +566,12 @@ func uploadAppConfigManifest(pkg upload.Package, appCfg *upload.AppConfigManifes
 		fcmd := exec.Command("cub", "function", "do", "--quiet",
 			"--space", pkg.SpaceSlug,
 			"--toolchain", "Kubernetes/YAML",
-			"--unit", appCfg.CarrierName,
+			"--unit", appCfg.PlaceholderSlug(),
 			"set-namespace", namespace)
 		fcmd.Stdout = os.Stdout
 		fcmd.Stderr = os.Stderr
 		if err := fcmd.Run(); err != nil {
-			return fmt.Errorf("cub function do set-namespace on %s in %s: %w", appCfg.CarrierName, pkg.SpaceSlug, err)
+			return fmt.Errorf("cub function do set-namespace on %s in %s: %w", appCfg.PlaceholderSlug(), pkg.SpaceSlug, err)
 		}
 	}
 	return nil

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -129,7 +129,7 @@ Pass --non-interactive to script the wizard with --base, --components,
 			}
 			fmt.Printf("Base: %s; components: %v\n", res.Selection.Spec.Base, res.Selection.Spec.Components)
 			fmt.Printf("Namespace: %s\n", raw.Namespace)
-			fmt.Printf("Next: installer render %s\n", absWork)
+			fmt.Printf("Next: %s render %s\n", InvocationName(), absWork)
 			return nil
 		},
 	}

--- a/internal/upload/appconfig.go
+++ b/internal/upload/appconfig.go
@@ -140,12 +140,23 @@ func DetectAppConfigManifest(path string) (*AppConfigManifest, error) {
 	return m, nil
 }
 
-// UnitSlug returns the slug for the AppConfig Unit derived from the
-// carrier ConfigMap's name. We append a stable suffix so the slug never
-// collides with the (separate) Kubernetes Units rendered in the same
-// Space.
+// UnitSlug returns the slug for the AppConfig Unit. It matches the
+// carrier ConfigMap's name with no suffix because the ConfigMapRenderer
+// bridge uses the Unit slug as the rendered ConfigMap's metadata.name —
+// so the Unit slug must equal the name workloads use (envFrom,
+// configMapRef, etc.) for refs to resolve at apply time.
 func (m *AppConfigManifest) UnitSlug() string {
-	return m.CarrierName + "-appconfig"
+	return m.CarrierName
+}
+
+// PlaceholderSlug returns the slug for the placeholder Kubernetes/YAML
+// ConfigMap Unit that the live-merge link populates from the AppConfig
+// Unit's live state. It carries a "-rendered" suffix so it doesn't
+// collide with UnitSlug in the same Space; the slug is not user-facing
+// (workloads still resolve by the ConfigMap's metadata.name, which
+// equals UnitSlug after the merge).
+func (m *AppConfigManifest) PlaceholderSlug() string {
+	return m.CarrierName + "-rendered"
 }
 
 // TargetSlug returns the slug for the ConfigMapRenderer Target. One Target

--- a/internal/upload/appconfig_test.go
+++ b/internal/upload/appconfig_test.go
@@ -46,8 +46,11 @@ data:
 	if string(got.Content) != wantContent {
 		t.Errorf("Content: want %q, got %q", wantContent, string(got.Content))
 	}
-	if got.UnitSlug() != "app-config-appconfig" {
-		t.Errorf("UnitSlug: want app-config-appconfig, got %q", got.UnitSlug())
+	if got.UnitSlug() != "app-config" {
+		t.Errorf("UnitSlug: want app-config, got %q", got.UnitSlug())
+	}
+	if got.PlaceholderSlug() != "app-config-rendered" {
+		t.Errorf("PlaceholderSlug: want app-config-rendered, got %q", got.PlaceholderSlug())
 	}
 	if got.TargetSlug() != "app-config-renderer" {
 		t.Errorf("TargetSlug: want app-config-renderer, got %q", got.TargetSlug())

--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -24,9 +24,17 @@ import (
 	"text/template"
 	"time"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/confighub/installer/internal/cubctx"
 	"github.com/confighub/installer/pkg/api"
 )
+
+// localConfigAnnotation is the kubernetes.io annotation that marks a KRM
+// resource as installer-/tool-only so kustomize, kpt, and the ConfigHub
+// bridges skip applying it to the cluster. See
+// https://kubernetes.io/docs/reference/labels-annotations-taints/#config-kubernetes-io-local-config
+const localConfigAnnotation = "config.kubernetes.io/local-config"
 
 // Package is one unit-of-upload — the parent or a locked dep.
 type Package struct {
@@ -223,13 +231,106 @@ func BuildInstallerRecord(pkg Package) ([]byte, error) {
 		trimmed := bytes.TrimSpace(data)
 		trimmed = bytes.TrimPrefix(trimmed, []byte("---\n"))
 		trimmed = bytes.TrimSpace(trimmed)
+		// Mark every doc as local-config so a stray `cub unit apply`
+		// (or kubectl/kustomize) treats the installer-record Unit as
+		// tooling state, not a workload to push to the cluster.
+		marked, err := addLocalConfigAnnotation(trimmed)
+		if err != nil {
+			return nil, fmt.Errorf("annotate %s: %w", p, err)
+		}
 		if i > 0 {
 			buf.WriteString("---\n")
 		}
-		buf.Write(trimmed)
+		buf.Write(marked)
 		buf.WriteByte('\n')
 	}
 	return buf.Bytes(), nil
+}
+
+// addLocalConfigAnnotation sets metadata.annotations[localConfigAnnotation]
+// = "true" on a single YAML doc and returns the re-emitted bytes. The
+// re-emit goes through yaml.v3 so it preserves comments and node order
+// where possible. Returns the input unchanged if the doc isn't a mapping
+// (an empty stream or a non-KRM-shaped doc has nowhere to attach the
+// annotation, and there's nothing to apply in that case either).
+func addLocalConfigAnnotation(doc []byte) ([]byte, error) {
+	var node yaml.Node
+	if err := yaml.Unmarshal(doc, &node); err != nil {
+		return nil, fmt.Errorf("parse: %w", err)
+	}
+	root := documentRoot(&node)
+	if root == nil || root.Kind != yaml.MappingNode {
+		return doc, nil
+	}
+	metadata := mappingValue(root, "metadata")
+	if metadata == nil {
+		metadata = &yaml.Node{Kind: yaml.MappingNode}
+		setMappingValue(root, "metadata", metadata)
+	}
+	annotations := mappingValue(metadata, "annotations")
+	if annotations == nil {
+		annotations = &yaml.Node{Kind: yaml.MappingNode}
+		setMappingValue(metadata, "annotations", annotations)
+	}
+	setMappingScalar(annotations, localConfigAnnotation, "true")
+	out, err := yaml.Marshal(&node)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+	return bytes.TrimRight(out, "\n"), nil
+}
+
+// documentRoot returns the inner mapping node of a top-level yaml.Node
+// returned by yaml.Unmarshal (which always wraps the document in a
+// DocumentNode). Returns nil if the stream is empty.
+func documentRoot(n *yaml.Node) *yaml.Node {
+	if n == nil {
+		return nil
+	}
+	if n.Kind == yaml.DocumentNode {
+		if len(n.Content) == 0 {
+			return nil
+		}
+		return n.Content[0]
+	}
+	return n
+}
+
+// mappingValue returns the value node for key inside a MappingNode, or nil
+// if absent. Mapping nodes store key/value pairs as alternating entries in
+// Content.
+func mappingValue(m *yaml.Node, key string) *yaml.Node {
+	if m == nil || m.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			return m.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// setMappingValue replaces or appends a key/value pair on m.
+func setMappingValue(m *yaml.Node, key string, value *yaml.Node) {
+	if m == nil || m.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			m.Content[i+1] = value
+			return
+		}
+	}
+	m.Content = append(m.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: key},
+		value,
+	)
+}
+
+// setMappingScalar sets a scalar string value under key on m.
+func setMappingScalar(m *yaml.Node, key, value string) {
+	setMappingValue(m, key, &yaml.Node{Kind: yaml.ScalarNode, Value: value})
 }
 
 // RefreshInstallerRecord rebuilds the installer-record Unit body from

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -173,6 +173,44 @@ func TestBuildInstallerRecord(t *testing.T) {
 	}
 }
 
+// TestBuildInstallerRecord_LocalConfigAnnotation verifies every doc in
+// the multi-doc body carries config.kubernetes.io/local-config: "true"
+// so a stray `cub unit apply` (or kubectl/kustomize) skips applying
+// the installer-record Unit's contents to the cluster.
+func TestBuildInstallerRecord_LocalConfigAnnotation(t *testing.T) {
+	work := t.TempDir()
+	pkgDir := filepath.Join(work, "package")
+	specDir := filepath.Join(work, "out", "spec")
+	writeFile(t, filepath.Join(pkgDir, "installer.yaml"), minimalParentYAML)
+	// Spec doc with no annotations: section should be added.
+	writeFile(t, filepath.Join(specDir, "selection.yaml"), `apiVersion: installer.confighub.com/v1alpha1
+kind: Selection
+metadata: {name: x}
+`)
+	// Spec doc with a pre-existing unrelated annotation: should keep it
+	// AND gain local-config.
+	writeFile(t, filepath.Join(specDir, "inputs.yaml"), `apiVersion: installer.confighub.com/v1alpha1
+kind: Inputs
+metadata:
+  name: y
+  annotations:
+    example.com/keep-me: "1"
+`)
+
+	body, err := BuildInstallerRecord(Package{PackageDir: pkgDir, SpecDir: specDir})
+	if err != nil {
+		t.Fatalf("BuildInstallerRecord: %v", err)
+	}
+	got := string(body)
+	count := strings.Count(got, "config.kubernetes.io/local-config")
+	if count != 3 {
+		t.Errorf("expected local-config annotation on all 3 docs, got %d occurrences:\n%s", count, got)
+	}
+	if !strings.Contains(got, "example.com/keep-me") {
+		t.Errorf("pre-existing unrelated annotation was dropped:\n%s", got)
+	}
+}
+
 func TestSplitInstallerRecord(t *testing.T) {
 	work := t.TempDir()
 	pkgDir := filepath.Join(work, "package")

--- a/packages/worker/bases/default/deployment.yaml
+++ b/packages/worker/bases/default/deployment.yaml
@@ -28,6 +28,6 @@ spec:
                   fieldPath: metadata.namespace
           envFrom:
             - configMapRef:
-                name: confighub-worker-env-appconfig
+                name: confighub-worker-env
             - secretRef:
                 name: confighub-worker-secret

--- a/test/e2e/package-and-deps.sh
+++ b/test/e2e/package-and-deps.sh
@@ -57,8 +57,8 @@ trap cleanup EXIT
 
 # 1. Build.
 log "build installer"
-( cd "$REPO_ROOT" && go build -o bin/installer ./cmd/installer )
-BIN="$REPO_ROOT/bin/installer"
+( cd "$REPO_ROOT" && go build -o bin/install ./cmd/installer )
+BIN="$REPO_ROOT/bin/install"
 
 # 2. Registry.
 log "start registry:2 on :$REGISTRY_PORT"


### PR DESCRIPTION
## Summary

- **AppConfig Unit slug = carrier name (no `-appconfig` suffix).** The ConfigMapRenderer bridge uses the Unit slug as the rendered ConfigMap's `metadata.name`, so the suffix was leaking into the rendered ConfigMap and breaking any workload (e.g. the worker's `envFrom.configMapRef`) that referenced the carrier by its kustomize-generated name. The placeholder Unit now carries a `-rendered` suffix to avoid the slug collision; workloads still resolve by `metadata.name`. Worker package `deployment.yaml` reverted to reference `confighub-worker-env`.
- **Installer-record docs gain `config.kubernetes.io/local-config: "true"`** so a stray `cub unit apply` (or kubectl/kustomize) treats the installer-record Unit as tooling state and doesn't try to push the `installer.yaml`/spec docs to the cluster. ([local-config reference](https://kubernetes.io/docs/reference/labels-annotations-taints/#config-kubernetes-io-local-config))
- **Binary renamed `bin/installer` → `bin/install`**, built via a new `Makefile`. The cub plugin protocol names the plugin after its entrypoint basename, so this matches the `cub install ...` invocation form. `cub-plugin.yaml`, the e2e script, and user-facing docs follow.
- **\"Next: …\" messages use the actual invocation name.** New `InvocationName()` helper returns `os.Args[0]` standalone or `cub install` under `CUB_PLUGIN=1`, so copy-pasted suggestions match how the operator invoked the tool.

## Test plan

- [x] `go test ./...` (all packages pass; new `TestBuildInstallerRecord_LocalConfigAnnotation` and updated `appconfig_test.go` assertions)
- [x] `make build` produces `bin/install`
- [ ] Re-run the worker install end-to-end (`bin/install wizard packages/worker …` → render → upload → apply) and confirm the rendered ConfigMap is `confighub-worker-env` and the Deployment finds it
- [ ] Confirm `cub unit apply` on the installer-record Unit no-ops (or whatever the local-config semantics are)

🤖 Generated with [Claude Code](https://claude.com/claude-code)