### PR TITLE
Render AppConfig ConfigMaps via render-configmap function instead of the ConfigMapRenderer bridge

### DIFF
--- a/docs/author-guide.md
+++ b/docs/author-guide.md
@@ -692,8 +692,8 @@ native format (a real `.properties`, `.toml`, `.env`, etc. file in
 your package tree) so per-format ConfigHub functions can mutate it
 correctly, ConfigHub can validate against a schema, and the upload
 step can split the rendered output into an AppConfig Unit + a
-ConfigMapRenderer Target so day-2 edits stay in the source format
-too.
+`render-configmap` Invocation so day-2 edits stay in the source
+format too.
 
 ### Author contract
 
@@ -754,16 +754,17 @@ toolchain annotation and:
 
 At upload time, an annotated ConfigMap becomes a four-piece bundle:
 an AppConfig Unit (toolchain from the annotation, data = the
-extracted raw file), a ConfigMapRenderer Target attached to it, a
-placeholder Kubernetes/YAML ConfigMap Unit whose slug matches the
-kustomize-generated name (so other workloads in the Space link to
-it by name via the existing intra-Space inference), and a live-state
-`MergeUnits` link from the placeholder to the AppConfig Unit so the
-runtime ConfigMap name flows through to the workload reference at
-apply time.
+extracted raw file), a `render-configmap` Invocation, a placeholder
+Kubernetes/YAML ConfigMap Unit whose slug matches the
+kustomize-generated name (so other workloads in the Space link to it
+by name via the existing intra-Space inference), and an `Upsert` link
+from the placeholder to the AppConfig Unit with the Invocation as its
+TransformInvocation. On resolution the function renders the ConfigMap
+into the placeholder so the runtime ConfigMap name flows through to
+the workload reference at apply time.
 
-The worker the renderer Target uses is `<space>/server-worker` by
-default; override with `install upload --appconfig-worker <slug>`.
+Rendering runs as a built-in function on the server — no bridge
+worker, Target, or apply step is involved.
 
 ### disableNameSuffixHash
 

--- a/docs/consumer-guide.md
+++ b/docs/consumer-guide.md
@@ -146,12 +146,11 @@ install upload --space-pattern '{{.PackageName}}-prod'
 If the package ships application-config files (a `configMapGenerator`
 tagged with `installer.confighub.com/toolchain`, e.g.
 `AppConfig/Properties` or `AppConfig/Env`), `install upload` also
-creates a `ConfigMapRenderer` Target plus a separate AppConfig Unit
-holding the raw config body. The renderer Target needs a worker; the
-installer auto-creates a server-side worker named `renderer-worker` in
-the destination Space (idempotent — re-uploading is safe). Override
-with `install upload --space ... --appconfig-worker <slug>` if
-you'd rather point at an existing worker.
+creates a separate AppConfig Unit holding the raw config body, a
+`render-configmap` Invocation, and a placeholder Kubernetes/YAML Unit
+wired by an Upsert link that renders the ConfigMap into the
+placeholder. No bridge worker is required — rendering runs as a
+built-in function on the server.
 
 ## Where to make changes
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -230,10 +230,11 @@ work-dir has been uploaded before:
 
 - **First upload** — `out/spec/upload.yaml` does not exist. Creates
   Spaces (idempotent), creates one Unit per rendered manifest plus the
-  untargeted `installer-record` Unit, creates ConfigMapRenderer
-  Targets + AppConfig Units for any AppConfig-tagged manifests,
-  creates cross-Space `installer-record → installer-record` links for
-  dependencies, runs intra-Space NeedsProvides link inference. Writes
+  untargeted `installer-record` Unit, creates an AppConfig Unit +
+  `render-configmap` Invocation + placeholder Unit + Upsert link for
+  any AppConfig-tagged manifests, creates cross-Space
+  `installer-record → installer-record` links for dependencies, runs
+  intra-Space NeedsProvides link inference. Writes
   `out/spec/upload.yaml` at the end.
 - **Reconcile** — `out/spec/upload.yaml` exists. Re-computes the same
   plan `install plan` would produce, opens one ChangeSet per Space,

--- a/docs/transformer.md
+++ b/docs/transformer.md
@@ -33,9 +33,9 @@ chain can operate on it from inside the kustomize pipeline.
   ConfigMap → AppConfig content boundary in-process, mutates, and
   writes back.
 - At upload, materialize annotated ConfigMaps into the right
-  ConfigHub triple: AppConfig Unit + ConfigMapRenderer Target +
-  Kubernetes/YAML Unit, linked via existing intra-Space link
-  inference.
+  ConfigHub objects: AppConfig Unit + render-configmap Invocation +
+  Kubernetes/YAML placeholder Unit, wired by an Upsert link and the
+  existing intra-Space link inference.
 
 ## Non-goals
 
@@ -297,8 +297,8 @@ downstream consumers (upload, drift) see one canonical contract:
   (versioned ConfigMaps, each content change rolls a new one);
   unmatched → mutable (stable name, hash annotation on the
   consuming workload triggers restarts). The upload step reads
-  this to set `RevisionHistoryLimit=0` on the renderer Target in
-  the mutable case.
+  this to pass `--immutable=false` to the render-configmap
+  Invocation in the mutable case.
 
 Authors don't write the mode, source-key, or mutable annotations
 themselves; the transformer infers and injects them. Authors who
@@ -350,53 +350,49 @@ split into four ConfigHub objects:
 - **AppConfig Unit** (slug = `<carrier-name>`, matching the
   kustomize-generated ConfigMap name). Toolchain from the annotation.
   Data = the extracted raw file body. Day-2 source of truth in the
-  native format. The ConfigMapRenderer bridge uses the Unit slug as
-  the rendered ConfigMap's `metadata.name`, so the slug deliberately
-  has no suffix — workloads can reference the carrier by its
-  kustomize-generated name (e.g. `envFrom.configMapRef.name`) and the
-  rendered ConfigMap will match.
-- **ConfigMapRenderer Target** (slug `<carrier-name>-renderer`).
-  Provider `ConfigMapRenderer`, toolchain from the annotation,
-  livestate-type `Kubernetes/YAML`. Attached to the AppConfig Unit
-  so applying it renders a ConfigMap in the cluster. Worker is
-  `<space>/<--appconfig-worker>` (default `server-worker`). Options:
-  - `AsKeyValue=true` iff mode=env AND toolchain=AppConfig/Env. The
-    bridge ignores it for non-Env toolchains; we set it only where
-    it's meaningful.
-  - `RevisionHistoryLimit=0` iff `appconfig-mutable=true` (the
-    transformer pre-pass infers this from kustomize's hash-suffix
-    convention; see "Author contract" above). Mutable ConfigMaps
-    update in place; immutable ones (the kustomize default) leave
-    `RevisionHistoryLimit` at the bridge default so cub retains
-    a few revisions for rollback.
-- **Apply the AppConfig Unit** (`cub unit apply --wait`) right after
-  creating it. The renderer Target's worker produces the rendered
-  ConfigMap as the AppConfig Unit's live state. Doing the apply
-  before the link is created (next step) means the link's initial
-  MergeUnits pulls real content into the placeholder's Data — which
-  link inference at the end of `uploadOnePackage` then reads to wire
-  workload references (envFrom, volumes, etc.) into the placeholder.
+  native format. No target — it is a pure data source. The
+  `render-configmap` function uses the Unit slug as the rendered
+  ConfigMap's `metadata.name` (`<slug>-<hash>` in immutable mode,
+  `<slug>` in mutable mode), so the slug deliberately has no suffix —
+  workloads can reference the carrier by its kustomize-generated name
+  (e.g. `envFrom.configMapRef.name`) and the rendered ConfigMap will
+  match.
+- **render-configmap Invocation** (slug `<carrier-name>-render`).
+  Toolchain from the annotation. This is the `TransformInvocation`
+  the Upsert link runs to render the AppConfig Unit's data into a
+  Kubernetes ConfigMap. Function arguments:
+  - `--as-key-value=true` iff mode=env AND toolchain=AppConfig/Env.
+    The function ignores it for non-Env toolchains; we set it only
+    where it's meaningful.
+  - `--immutable=false` iff `appconfig-mutable=true` (the transformer
+    pre-pass infers this from kustomize's hash-suffix convention; see
+    "Author contract" above), otherwise `--immutable=true`. Mutable
+    ConfigMaps update in place with a stable name; immutable ones (the
+    kustomize default) get hashed names and accumulate as revisions
+    (bound via a separate `prune-configmaps` trigger if desired).
 - **Placeholder Kubernetes/YAML ConfigMap Unit** (slug =
   `<carrier-name>-rendered`). Body is empty at creation; populated by
-  the live-merge link below using the live state from the
-  just-applied AppConfig Unit. Inherits the upload-wide `--target`
-  flag (typically a Kubernetes namespace target) so it applies into
-  the same place as every other rendered manifest. The `-rendered`
-  suffix avoids colliding with the AppConfig Unit (which owns the
-  bare carrier name). Workloads still resolve to the rendered
-  ConfigMap by `metadata.name` (= `<carrier-name>`, set by the bridge
-  from the AppConfig Unit's slug), so intra-Space link inference
+  the Upsert link below. Inherits the upload-wide `--target` flag
+  (typically a Kubernetes namespace target) so it applies into the
+  same place as every other rendered manifest. The `-rendered` suffix
+  avoids colliding with the AppConfig Unit (which owns the bare
+  carrier name). Workloads still resolve to the rendered ConfigMap by
+  `metadata.name` (= `<carrier-name>`, set by render-configmap from
+  the AppConfig Unit's slug), so intra-Space link inference
   (`internal/upload/links.go`) wires them into this placeholder via
-  the merged content.
-- **Live-merge link** (server-assigned slug via `-`).
-  `--use-live-state --auto-update --update-type MergeUnits`. Pulls
-  the rendered ConfigMap from the AppConfig Unit's live state into
-  the placeholder's Data so the runtime ConfigMap name (with its
-  hash suffix) flows through to the workload's
-  `volumeMounts` / `envFrom` reference.
+  the rendered content.
+- **Upsert link** (server-assigned slug via `-`).
+  `--update-type Upsert --auto-update --transform-invocation
+  <space>/<carrier-name>-render`. On resolution the
+  `render-configmap` function renders the AppConfig Unit's data into a
+  Kubernetes ConfigMap and upserts it into the placeholder's Data — no
+  bridge, no worker, no apply — so the runtime ConfigMap name flows
+  through to the workload's `volumeMounts` / `envFrom` reference.
+  `--auto-update` keeps the placeholder in sync as the AppConfig Unit
+  changes.
 - **`cub function do set-namespace`** on the placeholder Unit, using
-  the wizard's `Inputs.Spec.Namespace`. The ConfigMapRenderer bridge
-  stamps `metadata.namespace=confighubplaceholder` on its live state
+  the wizard's `Inputs.Spec.Namespace`. `render-configmap` stamps
+  `metadata.namespace=confighubplaceholder` on the rendered ConfigMap
   (the placeholder is meant to be resolved by a namespace link at
   apply time), but the intra-Space link inference matches by
   `metadata.namespace` and a placeholder value never resolves. Stamping
@@ -412,9 +408,9 @@ auto-inferred link to the placeholder Unit even with the namespace
 fix above. Tracked separately.
 
 The rendered ConfigMap YAML in `out/manifests/` is NOT uploaded as a
-Unit — the renderer Target re-derives the ConfigMap from the
-AppConfig Unit's content at apply time, and the placeholder + link
-pair handles the namespace/reference wiring.
+Unit — the render-configmap Invocation re-derives the ConfigMap from
+the AppConfig Unit's content via the Upsert link, and the placeholder
++ link pair handles the namespace/reference wiring.
 
 The `manifest-index.yaml` schema can later gain fields recording the
 AppConfig source-key and toolchain so `update` / `upgrade` can
@@ -500,11 +496,11 @@ We test all of these against AppConfig-bearing ConfigMaps:
    `AppConfig/*` extract from `data:`, invoke, write back. Both
    mutating and validating paths supported.
 7. **AppConfig upload split. ✅** Detected ConfigMaps become a
-   four-piece bundle: renderer Target, AppConfig Unit, placeholder
-   Kubernetes/YAML ConfigMap Unit (slug matches the carrier name so
-   intra-Space link inference works), and a live-state MergeUnits
-   link from placeholder → AppConfig Unit. Behind
-   `--appconfig-worker` (default `server-worker`).
+   four-piece bundle: render-configmap Invocation, AppConfig Unit,
+   placeholder Kubernetes/YAML ConfigMap Unit (slug matches the
+   carrier name so intra-Space link inference works), and an Upsert
+   link from placeholder → AppConfig Unit with the Invocation as its
+   TransformInvocation. No bridge worker required.
 8. **Cleanup.** Remove the AppConfig roadmap bullet from
    README.md once 5–7 land.
 

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -29,7 +29,6 @@ func newUploadCmd() *cobra.Command {
 		target        string
 		annotations   []string
 		labels        []string
-		appCfgWorker  string
 		retry         bool
 		yes           bool
 		changeSetSlug string
@@ -43,10 +42,12 @@ presence of <work-dir>/out/spec/upload.yaml (written by the first upload):
 
 First upload (no upload.yaml):
   Creates Space(s), one Unit per rendered manifest, plus the untargeted
-  installer-record Unit. ConfigMapRenderer Targets + AppConfig Unit pairs
-  for AppConfig-annotated ConfigMaps. Cross-Space links between parent
-  and dependency installer-record Units. Intra-Space NeedsProvides link
-  inference runs per Space at the end. Writes upload.yaml on success.
+  installer-record Unit. For AppConfig-annotated ConfigMaps: an AppConfig
+  Unit + a render-configmap Invocation + a placeholder Kubernetes/YAML
+  Unit, wired by an Upsert link that renders the ConfigMap into the
+  placeholder. Cross-Space links between parent and dependency
+  installer-record Units. Intra-Space NeedsProvides link inference runs
+  per Space at the end. Writes upload.yaml on success.
 
 Reconcile (upload.yaml exists):
   Re-computes the same plan install plan would produce. Opens one
@@ -179,7 +180,7 @@ ConfigHub.`,
 			}
 
 			for _, pkg := range packages {
-				if err := uploadOnePackage(pkg, target, annotations, labels, appCfgWorker, retry); err != nil {
+				if err := uploadOnePackage(pkg, target, annotations, labels, retry); err != nil {
 					return err
 				}
 			}
@@ -207,8 +208,7 @@ ConfigHub.`,
 	cmd.Flags().StringSliceVar(&annotations, "annotation", nil, "annotation key=value to set on every rendered Unit (repeatable)")
 	cmd.Flags().StringSliceVar(&labels, "label", nil, "label key=value to set on every rendered Unit (repeatable)")
 	cmd.Flags().StringVar(&workDir, "work-dir", ".", "working directory")
-	cmd.Flags().StringVar(&appCfgWorker, "appconfig-worker", "renderer-worker", "worker slug (Space-relative) attached to ConfigMapRenderer Targets for AppConfig-annotated ConfigMaps; auto-created as a server-side worker in the destination Space if missing")
-	cmd.Flags().BoolVar(&retry, "retry", false, "first upload only: tolerate Units, Targets, and Links that already exist so a partially-failed first upload can be retried. Space and renderer-worker auto-create are always idempotent — this flag only affects content. Ignored on reconcile (reconcile is always idempotent).")
+	cmd.Flags().BoolVar(&retry, "retry", false, "first upload only: tolerate Units, Invocations, and Links that already exist so a partially-failed first upload can be retried. Space auto-create is always idempotent — this flag only affects content. Ignored on reconcile (reconcile is always idempotent).")
 	cmd.Flags().BoolVar(&yes, "yes", false, "reconcile only: skip confirmation for deletes (required when stdin is not a TTY and the plan contains deletes)")
 	cmd.Flags().StringVar(&changeSetSlug, "changeset", "", "reconcile only: ChangeSet slug to open per Space (default: installer-update-<timestamp>)")
 	return cmd
@@ -304,10 +304,10 @@ func refreshInstallerRecordHook(packages []upload.Package) diff.PackageRefresher
 
 // uploadOnePackage creates pkg.SpaceSlug if missing, uploads each rendered
 // manifest as a Unit (with --target/--annotation/--label applied), splits
-// AppConfig-annotated ConfigMaps into AppConfig Unit + ConfigMapRenderer
-// Target pairs, creates the untargeted installer-record Unit, and runs
-// the intra-Space link inference.
-func uploadOnePackage(pkg upload.Package, target string, annotations, labels []string, appCfgWorker string, retry bool) error {
+// AppConfig-annotated ConfigMaps into AppConfig Unit + render-configmap
+// Invocation + placeholder + Upsert link, creates the untargeted
+// installer-record Unit, and runs the intra-Space link inference.
+func uploadOnePackage(pkg upload.Package, target string, annotations, labels []string, retry bool) error {
 	fmt.Printf("== %s@%s → Space %s ==\n", pkg.Name, pkg.Version, pkg.SpaceSlug)
 
 	if err := ensureSpace(pkg.SpaceSlug); err != nil {
@@ -315,9 +315,9 @@ func uploadOnePackage(pkg upload.Package, target string, annotations, labels []s
 	}
 
 	// Read the wizard's namespace from out/spec/inputs.yaml. AppConfig
-	// placeholders need it post-merge: the ConfigMapRenderer bridge stamps
-	// metadata.namespace=confighubplaceholder onto its live state (it
-	// expects a namespace link to fill that in at apply time), but our
+	// placeholders need it post-render: render-configmap stamps
+	// metadata.namespace=confighubplaceholder onto the rendered ConfigMap
+	// (it expects a namespace link to fill that in at apply time), but our
 	// intra-Space link inference matches by namespace and a placeholder
 	// value never resolves. set-namespace on the placeholder Unit lets
 	// the inference wire the Deployment → ConfigMap link.
@@ -334,17 +334,6 @@ func uploadOnePackage(pkg upload.Package, target string, annotations, labels []s
 		return fmt.Errorf("read %s: %w", pkg.ManifestsDir, err)
 	}
 
-	// Pre-scan for AppConfig-annotated ConfigMaps. If any exist, we need
-	// a server-side worker in the destination Space to render them — auto
-	// create it the same way we auto-create the Space, so a fresh
-	// installation has every dependency in place without operator
-	// pre-staging. Idempotent via --allow-exists.
-	type manifestEntry struct {
-		path   string
-		base   string
-		appCfg *upload.AppConfigManifest
-	}
-	var manifests []manifestEntry
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
@@ -354,34 +343,18 @@ func uploadOnePackage(pkg upload.Package, target string, annotations, labels []s
 		if err != nil {
 			return err
 		}
-		manifests = append(manifests, manifestEntry{path: path, base: e.Name(), appCfg: appCfg})
-	}
-	hasAppConfig := false
-	for _, m := range manifests {
-		if m.appCfg != nil {
-			hasAppConfig = true
-			break
-		}
-	}
-	if hasAppConfig {
-		if err := ensureRendererWorker(pkg.SpaceSlug, appCfgWorker); err != nil {
-			return err
-		}
-	}
-
-	for _, m := range manifests {
-		if m.appCfg != nil {
-			if err := uploadAppConfigManifest(pkg, m.appCfg, appCfgWorker, target, componentLabel, namespace, annotations, labels, retry); err != nil {
+		if appCfg != nil {
+			if err := uploadAppConfigManifest(pkg, appCfg, target, componentLabel, namespace, annotations, labels, retry); err != nil {
 				return err
 			}
 			continue
 		}
-		slug := trimExt(m.base)
+		slug := trimExt(e.Name())
 		cubArgs := []string{"unit", "create"}
 		if retry {
 			cubArgs = append(cubArgs, "--allow-exists")
 		}
-		cubArgs = append(cubArgs, "--space", pkg.SpaceSlug, "--merge-external-source", m.base, "--label", componentLabel)
+		cubArgs = append(cubArgs, "--space", pkg.SpaceSlug, "--merge-external-source", e.Name(), "--label", componentLabel)
 		if target != "" {
 			cubArgs = append(cubArgs, "--target", target)
 		}
@@ -391,7 +364,7 @@ func uploadOnePackage(pkg upload.Package, target string, annotations, labels []s
 		for _, l := range labels {
 			cubArgs = append(cubArgs, "--label", l)
 		}
-		cubArgs = append(cubArgs, slug, m.path)
+		cubArgs = append(cubArgs, slug, path)
 		ccmd := exec.Command("cub", cubArgs...)
 		ccmd.Stdout = os.Stdout
 		ccmd.Stderr = os.Stderr
@@ -507,31 +480,35 @@ func reportSecretsNotUploaded(pkg upload.Package, secrets []renderedSecret) {
 // uploadAppConfigManifest materializes the AppConfig bundle in pkg's
 // Space:
 //
-//  1. ConfigMapRenderer Target — one per carrier ConfigMap.
-//  2. AppConfig Unit — Data is the extracted raw file body, target is
-//     the renderer. This is the day-2 source of truth in the native
-//     format (.properties, .env, etc.).
-//  3. cub unit apply --wait against the AppConfig Unit — the
-//     ConfigMapRenderer worker produces the rendered ConfigMap as live
-//     state. Doing this before creating the link below means the link's
-//     initial MergeUnits pulls real content into the placeholder, so
-//     the link inference at the end of uploadOnePackage can read the
-//     placeholder's rendered metadata.name to wire workload references.
-//  4. Placeholder Kubernetes/YAML ConfigMap Unit — same slug as the
-//     carrier so other Units in the Space link to it by name via
-//     intra-Space link inference. Body is empty at creation; populated
-//     when the live-merge link below fires.
-//  5. Live-state MergeUnits link placeholder → AppConfig Unit.
+//  1. render-configmap Invocation — one per carrier ConfigMap. Its
+//     toolchain matches the AppConfig Unit; its args encode immutable /
+//     as-key-value mode.
+//  2. AppConfig Unit — Data is the extracted raw file body. No target;
+//     it is a pure data source. This is the day-2 source of truth in the
+//     native format (.properties, .env, etc.).
+//  3. Placeholder Kubernetes/YAML ConfigMap Unit — carries a "-rendered"
+//     suffix so it doesn't collide with the AppConfig Unit (which owns
+//     the carrier's name, equal to the rendered ConfigMap's
+//     metadata.name). Body is empty at creation; populated by the Upsert
+//     link below. Other workload Units reference the ConfigMap by
+//     metadata.name; intra-Space link inference wires them into this
+//     placeholder via the rendered content.
+//  4. Upsert link placeholder → AppConfig Unit, with the render-configmap
+//     Invocation as its TransformInvocation. On resolution the function
+//     renders the AppConfig Unit's Data into a Kubernetes ConfigMap and
+//     upserts it into the placeholder's Data. --auto-update keeps it in
+//     sync as the AppConfig Unit changes. No bridge, no worker, no apply.
+//  5. set-namespace on the placeholder so intra-Space link inference can
+//     match it (the rendered ConfigMap carries a namespace placeholder).
 //
 // The placeholder Unit inherits the upload-wide `target` flag (typically a
 // Kubernetes namespace target) so it applies into the same place as every
-// other rendered manifest. The renderer Target itself is attached only to
-// the AppConfig Unit.
+// other rendered manifest.
 //
-// Idempotent via --allow-exists on the Target, Units, and link; re-running
-// upload after re-rendering refreshes the AppConfig Unit body via the
-// --merge-external-source mechanism the regular path uses.
-func uploadAppConfigManifest(pkg upload.Package, appCfg *upload.AppConfigManifest, worker, target, componentLabel, namespace string, annotations, labels []string, retry bool) error {
+// Idempotent via --allow-exists on the Invocation, Units, and link;
+// re-running upload after re-rendering refreshes the AppConfig Unit body
+// via the --merge-external-source mechanism the regular path uses.
+func uploadAppConfigManifest(pkg upload.Package, appCfg *upload.AppConfigManifest, target, componentLabel, namespace string, annotations, labels []string, retry bool) error {
 	fmt.Printf("AppConfig: %s (toolchain=%s, mode=%s)\n", appCfg.CarrierName, appCfg.Toolchain, appCfg.Mode)
 
 	// 1. Stage the extracted raw config in a temp file so cub unit
@@ -547,31 +524,28 @@ func uploadAppConfigManifest(pkg upload.Package, appCfg *upload.AppConfigManifes
 	}
 	tmp.Close()
 
-	// 2. Create the ConfigMapRenderer Target. The worker arg is required
-	//    by `cub target create` and is Space-relative by convention.
-	workerRef := pkg.SpaceSlug + "/" + worker
-	targetArgs := []string{"target", "create"}
+	// 2. Create the render-configmap Invocation. The "--" separator tells
+	//    cub the following tokens are function arguments, not invocation
+	//    flags.
+	invArgs := []string{"invocation", "create"}
 	if retry {
-		targetArgs = append(targetArgs, "--allow-exists")
+		invArgs = append(invArgs, "--allow-exists")
 	}
-	targetArgs = append(targetArgs,
+	invArgs = append(invArgs,
 		"--space", pkg.SpaceSlug,
-		appCfg.TargetSlug(), "", workerRef,
-		"--provider", "ConfigMapRenderer",
-		"--toolchain", appCfg.Toolchain,
-		"--livestate-type", "Kubernetes/YAML",
+		"--label", componentLabel,
+		appCfg.InvocationSlug(), appCfg.Toolchain,
+		"--", "render-configmap",
 	)
-	if opts := appCfg.RendererOptions(); opts != "" {
-		targetArgs = append(targetArgs, "--option", opts)
-	}
-	tcmd := exec.Command("cub", targetArgs...)
-	tcmd.Stdout = os.Stdout
-	tcmd.Stderr = os.Stderr
-	if err := tcmd.Run(); err != nil {
-		return fmt.Errorf("cub target create %s in %s: %w", appCfg.TargetSlug(), pkg.SpaceSlug, err)
+	invArgs = append(invArgs, appCfg.RenderConfigMapArgs()...)
+	icmd := exec.Command("cub", invArgs...)
+	icmd.Stdout = os.Stdout
+	icmd.Stderr = os.Stderr
+	if err := icmd.Run(); err != nil {
+		return fmt.Errorf("cub invocation create %s in %s: %w", appCfg.InvocationSlug(), pkg.SpaceSlug, err)
 	}
 
-	// 3. Create the AppConfig Unit pointing at that Target.
+	// 3. Create the AppConfig Unit (no target — pure data source).
 	unitArgs := []string{"unit", "create"}
 	if retry {
 		unitArgs = append(unitArgs, "--allow-exists")
@@ -579,7 +553,6 @@ func uploadAppConfigManifest(pkg upload.Package, appCfg *upload.AppConfigManifes
 	unitArgs = append(unitArgs,
 		"--space", pkg.SpaceSlug,
 		"--toolchain", appCfg.Toolchain,
-		"--target", appCfg.TargetSlug(),
 		"--merge-external-source", filepath.Base(appCfg.ManifestPath),
 		"--label", componentLabel,
 	)
@@ -597,30 +570,8 @@ func uploadAppConfigManifest(pkg upload.Package, appCfg *upload.AppConfigManifes
 		return fmt.Errorf("cub unit create %s in %s: %w", appCfg.UnitSlug(), pkg.SpaceSlug, err)
 	}
 
-	// 4. Apply the AppConfig Unit so the ConfigMapRenderer worker produces
-	//    a rendered ConfigMap as its live state. The live-merge link in
-	//    step 6 pulls from that live state to populate the placeholder's
-	//    Data; without this apply the placeholder stays empty, and the
-	//    intra-Space link inference run at the end of uploadOnePackage
-	//    can't see the rendered ConfigMap's metadata.name to wire up
-	//    workload references (Deployment envFrom, volumes, etc.).
-	acmd := exec.Command("cub", "unit", "apply",
-		"--space", pkg.SpaceSlug, "--wait", "--quiet",
-		appCfg.UnitSlug())
-	acmd.Stdout = os.Stdout
-	acmd.Stderr = os.Stderr
-	if err := acmd.Run(); err != nil {
-		return fmt.Errorf("cub unit apply %s in %s: %w", appCfg.UnitSlug(), pkg.SpaceSlug, err)
-	}
-
-	// 5. Create the placeholder ConfigMap Unit. Its slug carries a
-	//    "-rendered" suffix so it doesn't collide with the AppConfig
-	//    Unit (which owns the carrier's name so the bridge stamps that
-	//    name onto the rendered ConfigMap). Body is empty at creation;
-	//    populated by the live-merge link below. Other workload Units
-	//    reference the ConfigMap by metadata.name (which equals
-	//    UnitSlug() after the merge); intra-Space link inference wires
-	//    them into this placeholder via the merged content.
+	// 4. Create the placeholder ConfigMap Unit. Body is empty at creation;
+	//    populated by the Upsert link below.
 	placeholderArgs := []string{"unit", "create"}
 	if retry {
 		placeholderArgs = append(placeholderArgs, "--allow-exists")
@@ -647,12 +598,11 @@ func uploadAppConfigManifest(pkg upload.Package, appCfg *upload.AppConfigManifes
 		return fmt.Errorf("cub unit create %s in %s: %w", appCfg.PlaceholderSlug(), pkg.SpaceSlug, err)
 	}
 
-	// 6. Live-state MergeUnits link from placeholder → AppConfig Unit.
-	//    --use-live-state pulls the rendered ConfigMap from the
-	//    AppConfig Unit's live state (populated by step 4's apply) into
-	//    the placeholder's Data; --auto-update keeps it in sync as the
-	//    AppConfig Unit is re-applied. --update-type MergeUnits is the
-	//    rendering link. Slug "-" tells the server to assign one.
+	// 5. Upsert link placeholder → AppConfig Unit. On resolution the
+	//    TransformInvocation (render-configmap) renders the AppConfig
+	//    Unit's Data into a Kubernetes ConfigMap and upserts it into the
+	//    placeholder's Data; --auto-update keeps it in sync as the
+	//    AppConfig Unit changes. Slug "-" tells the server to assign one.
 	linkArgs := []string{"link", "create"}
 	if retry {
 		linkArgs = append(linkArgs, "--allow-exists")
@@ -660,7 +610,8 @@ func uploadAppConfigManifest(pkg upload.Package, appCfg *upload.AppConfigManifes
 	linkArgs = append(linkArgs,
 		"--wait",
 		"--space", pkg.SpaceSlug,
-		"--use-live-state", "--auto-update", "--update-type", "MergeUnits",
+		"--update-type", "Upsert", "--auto-update",
+		"--transform-invocation", pkg.SpaceSlug+"/"+appCfg.InvocationSlug(),
 		"--label", componentLabel,
 		"-", appCfg.PlaceholderSlug(), appCfg.UnitSlug(),
 	)
@@ -671,11 +622,10 @@ func uploadAppConfigManifest(pkg upload.Package, appCfg *upload.AppConfigManifes
 		return fmt.Errorf("cub link create %s → %s in %s: %w", appCfg.PlaceholderSlug(), appCfg.UnitSlug(), pkg.SpaceSlug, err)
 	}
 
-	// 7. Stamp the correct namespace onto the placeholder Unit's now-
-	//    populated Data. The ConfigMapRenderer bridge writes
-	//    metadata.namespace=confighubplaceholder to the live state it
-	//    produces — the placeholder is meant to be filled in later via a
-	//    namespace link at apply time. But link inference (the
+	// 6. Stamp the correct namespace onto the placeholder Unit's now-
+	//    populated Data. render-configmap writes
+	//    metadata.namespace=confighubplaceholder (it expects a namespace
+	//    link to fill that in at apply time). But link inference (the
 	//    intra-Space pass below) matches by metadata.namespace, and a
 	//    placeholder value never resolves, so Deployments referencing
 	//    the carrier by name don't link to the placeholder Unit. Setting
@@ -720,24 +670,6 @@ func ensureSpace(slug string) error {
 	ccmd.Stderr = os.Stderr
 	if err := ccmd.Run(); err != nil {
 		return fmt.Errorf("cub space create %s: %w", slug, err)
-	}
-	return nil
-}
-
-// ensureRendererWorker creates a server-side worker (the cub server hosts
-// it, no separately-deployed bridge worker required) in the destination
-// Space if missing. ConfigMapRenderer Targets that materialize AppConfig
-// Units reference this worker; we auto-create it so a fresh install
-// doesn't require operators to pre-stage anything beyond their cub login.
-// Idempotent via --allow-exists.
-func ensureRendererWorker(spaceSlug, workerSlug string) error {
-	ccmd := exec.Command("cub", "worker", "create",
-		"--space", spaceSlug,
-		"--allow-exists", "--quiet", "--is-server-worker",
-		workerSlug)
-	ccmd.Stderr = os.Stderr
-	if err := ccmd.Run(); err != nil {
-		return fmt.Errorf("cub worker create %s in %s: %w", workerSlug, spaceSlug, err)
 	}
 	return nil
 }

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -143,7 +143,7 @@ func computeOne(ctx context.Context, pkg upload.Package) (SpacePlan, error) {
 	for _, slug := range sortedKeys(rendered) {
 		item := rendered[slug]
 		// Placeholder Units exist in cub but their body is maintained
-		// by the live-merge link from upload's AppConfig pathway.
+		// by the Upsert link from upload's AppConfig pathway.
 		// They have no separate local source — registering them in
 		// the rendered set keeps them out of delete candidates;
 		// add/update is a no-op.
@@ -192,7 +192,7 @@ func computeOne(ctx context.Context, pkg upload.Package) (SpacePlan, error) {
 //     from AppCfg.Content via merge-external-source, with Base
 //     matching the carrier filename upload used as the source name.
 //   - Placeholder ConfigMap Unit (toolchain Kubernetes/YAML; body
-//     empty at create, populated via live-merge link from the
+//     empty at create, populated via the Upsert link from the
 //     AppConfig Unit) — IsPlaceholder=true; never directly updated
 //     and never a delete candidate while the AppConfig manifest is
 //     present.

--- a/internal/upload/appconfig.go
+++ b/internal/upload/appconfig.go
@@ -21,6 +21,10 @@ const (
 
 	appConfigModeFile = "file"
 	appConfigModeEnv  = "env"
+
+	// AppConfigToolchainEnv is the only AppConfig toolchain where the
+	// as-key-value rendering option is meaningful (envFrom injection).
+	AppConfigToolchainEnv = "AppConfig/Env"
 )
 
 // AppConfigManifest describes one annotated ConfigMap discovered in a
@@ -46,11 +50,12 @@ type AppConfigManifest struct {
 	// SourceKey is the data: key whose value is the raw file body
 	// (file mode only). Empty in env mode.
 	SourceKey string
-	// Mutable reflects appconfig-mutable: when true, the renderer Target
-	// gets RevisionHistoryLimit=0 so the rendered ConfigMap updates in
-	// place (stable name, hash-annotation-driven workload rolling). When
-	// false, RevisionHistoryLimit is left at the bridge default so each
-	// content change produces a new, immutable ConfigMap revision.
+	// Mutable reflects appconfig-mutable: when true, the render-configmap
+	// Invocation is created with `--immutable=false`, producing a single
+	// mutable ConfigMap with a stable name (updates in place; workloads
+	// roll via the hash annotation on the pod template). When false (the
+	// kustomize default for configMapGenerator), `--immutable=true`
+	// produces immutable ConfigMaps with hashed names.
 	Mutable bool
 	// Content is the raw AppConfig file body. file mode reads
 	// data[SourceKey] verbatim; env mode emits a `.env`-shaped doc
@@ -141,59 +146,50 @@ func DetectAppConfigManifest(path string) (*AppConfigManifest, error) {
 }
 
 // UnitSlug returns the slug for the AppConfig Unit. It matches the
-// carrier ConfigMap's name with no suffix because the ConfigMapRenderer
-// bridge uses the Unit slug as the rendered ConfigMap's metadata.name —
-// so the Unit slug must equal the name workloads use (envFrom,
+// carrier ConfigMap's name with no suffix because the rendered ConfigMap
+// uses the Unit slug as its metadata.name (the render-configmap function
+// emits `<UnitSlug>-<hash>` in immutable mode and `<UnitSlug>` in mutable
+// mode), so the Unit slug must equal the name workloads use (envFrom,
 // configMapRef, etc.) for refs to resolve at apply time.
 func (m *AppConfigManifest) UnitSlug() string {
 	return m.CarrierName
 }
 
 // PlaceholderSlug returns the slug for the placeholder Kubernetes/YAML
-// ConfigMap Unit that the live-merge link populates from the AppConfig
-// Unit's live state. It carries a "-rendered" suffix so it doesn't
-// collide with UnitSlug in the same Space; the slug is not user-facing
-// (workloads still resolve by the ConfigMap's metadata.name, which
-// equals UnitSlug after the merge).
+// ConfigMap Unit that the Upsert link populates with the rendered
+// ConfigMap. It carries a "-rendered" suffix so it doesn't collide with
+// UnitSlug in the same Space; the slug is not user-facing (workloads
+// still resolve by the ConfigMap's metadata.name, which equals UnitSlug
+// after the render).
 func (m *AppConfigManifest) PlaceholderSlug() string {
 	return m.CarrierName + "-rendered"
 }
 
-// TargetSlug returns the slug for the ConfigMapRenderer Target. One Target
-// per AppConfig Unit, named for symmetry with UnitSlug.
-func (m *AppConfigManifest) TargetSlug() string {
-	return m.CarrierName + "-renderer"
+// InvocationSlug returns the slug for the render-configmap Invocation
+// that the Upsert link references as its TransformInvocation. One
+// Invocation per AppConfig Unit, named for symmetry with UnitSlug.
+func (m *AppConfigManifest) InvocationSlug() string {
+	return m.CarrierName + "-render"
 }
 
-// RendererOptions returns the value for a single `--option K=V` flag
-// appropriate for this AppConfig manifest's ConfigMapRenderer Target.
-// Multiple bridge options for one ConfigType are semicolon-joined in a
-// single flag value — cub's `cub target create --option` is position-
-// aligned (each --option flag corresponds to a ConfigType slot), so
-// repeating --option N times would tell cub we want N ConfigTypes,
-// which fails validation when only one --provider/--toolchain/--livestate-type
-// triple is supplied. Returns "" when no options apply.
+// RenderConfigMapArgs returns the function-argument tokens to pass to
+// `cub invocation create … -- render-configmap …`. Each token already
+// includes its `--<name>=<value>` form so the caller can append them
+// directly to its arg list.
 //
-// AsKeyValue=true is set only when the carrier was generated from `envs:`
-// AND the toolchain is AppConfig/Env (the bridge silently ignores it for
-// other toolchains; we set it only where it's meaningful).
-//
-// RevisionHistoryLimit=0 is set when the carrier is mutable (kustomize
-// did NOT append a hash suffix, indicating disableNameSuffixHash: true).
-// Mutable ConfigMaps update in place and rely on a hash annotation on
-// the workload to trigger rolling restarts; immutable ConfigMaps (the
-// kustomize default) roll on every content change, so we leave
-// RevisionHistoryLimit at the bridge default to retain a few revisions
-// in cub for rollback.
-func (m *AppConfigManifest) RendererOptions() string {
-	var parts []string
-	if m.Mode == appConfigModeEnv && m.Toolchain == "AppConfig/Env" {
-		parts = append(parts, "AsKeyValue=true")
+//   - --immutable=true  (kustomize default for configMapGenerator)
+//     or --immutable=false when the carrier was generated with
+//     disableNameSuffixHash: true.
+//   - --as-key-value=true only when the carrier was generated from
+//     `envs:` AND the toolchain is AppConfig/Env. The function silently
+//     ignores it for other toolchains; we set it only where it's
+//     meaningful.
+func (m *AppConfigManifest) RenderConfigMapArgs() []string {
+	args := []string{fmt.Sprintf("--immutable=%t", !m.Mutable)}
+	if m.Mode == appConfigModeEnv && m.Toolchain == AppConfigToolchainEnv {
+		args = append(args, "--as-key-value=true")
 	}
-	if m.Mutable {
-		parts = append(parts, "RevisionHistoryLimit=0")
-	}
-	return strings.Join(parts, ";")
+	return args
 }
 
 // parseMutable parses the appconfig-mutable annotation value. Missing →

--- a/internal/upload/appconfig_test.go
+++ b/internal/upload/appconfig_test.go
@@ -52,18 +52,21 @@ data:
 	if got.PlaceholderSlug() != "app-config-rendered" {
 		t.Errorf("PlaceholderSlug: want app-config-rendered, got %q", got.PlaceholderSlug())
 	}
-	if got.TargetSlug() != "app-config-renderer" {
-		t.Errorf("TargetSlug: want app-config-renderer, got %q", got.TargetSlug())
+	if got.InvocationSlug() != "app-config-render" {
+		t.Errorf("InvocationSlug: want app-config-render, got %q", got.InvocationSlug())
 	}
-	if len(got.RendererOptions()) != 0 {
-		t.Errorf("file-mode non-Env toolchain should not set AsKeyValue, got %v", got.RendererOptions())
+	args := got.RenderConfigMapArgs()
+	// Mutable defaults to false, so the render-configmap arg should be --immutable=true,
+	// and a Properties-mode-file carrier should not set --as-key-value.
+	if len(args) != 1 || args[0] != "--immutable=true" {
+		t.Errorf("RenderConfigMapArgs: want [\"--immutable=true\"], got %v", args)
 	}
 }
 
-// TestDetectAppConfigManifest_MutableTriggersRevisionHistoryLimit
-// verifies that appconfig-mutable=true on the rendered ConfigMap maps
-// to RevisionHistoryLimit=0 on the renderer Target.
-func TestDetectAppConfigManifest_MutableTriggersRevisionHistoryLimit(t *testing.T) {
+// TestDetectAppConfigManifest_MutableMapsToFunctionArg verifies that
+// appconfig-mutable=true on the rendered ConfigMap maps to
+// --immutable=false on the render-configmap Invocation.
+func TestDetectAppConfigManifest_MutableMapsToFunctionArg(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "cm.yaml")
 	writeFile(t, path, `apiVersion: v1
@@ -85,16 +88,15 @@ data:
 	if !got.Mutable {
 		t.Errorf("Mutable: want true, got false")
 	}
-	opts := got.RendererOptions()
-	if !strings.Contains(opts, "RevisionHistoryLimit=0") {
-		t.Errorf("mutable=true should include RevisionHistoryLimit=0; got %q", opts)
+	args := got.RenderConfigMapArgs()
+	if len(args) == 0 || args[0] != "--immutable=false" {
+		t.Errorf("mutable=true should produce --immutable=false; got %v", args)
 	}
 }
 
-// TestDetectAppConfigManifest_ImmutableSkipsRevisionHistoryLimit
-// verifies that the immutable case (the kustomize default) leaves
-// RevisionHistoryLimit unset so the bridge default applies.
-func TestDetectAppConfigManifest_ImmutableSkipsRevisionHistoryLimit(t *testing.T) {
+// TestDetectAppConfigManifest_ImmutableMapsToFunctionArg verifies that
+// the immutable case (the kustomize default) maps to --immutable=true.
+func TestDetectAppConfigManifest_ImmutableMapsToFunctionArg(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "cm.yaml")
 	writeFile(t, path, `apiVersion: v1
@@ -116,8 +118,9 @@ data:
 	if got.Mutable {
 		t.Errorf("Mutable: want false, got true")
 	}
-	if strings.Contains(got.RendererOptions(), "RevisionHistoryLimit") {
-		t.Errorf("immutable case must not set RevisionHistoryLimit; got %q", got.RendererOptions())
+	args := got.RenderConfigMapArgs()
+	if len(args) == 0 || args[0] != "--immutable=true" {
+		t.Errorf("immutable case should produce --immutable=true; got %v", args)
 	}
 }
 
@@ -148,8 +151,15 @@ data:
 	if got.Mode != "env" {
 		t.Errorf("Mode: want env, got %q", got.Mode)
 	}
-	if opts := got.RendererOptions(); opts != "AsKeyValue=true" {
-		t.Errorf("RendererOptions: want \"AsKeyValue=true\", got %q", opts)
+	args := got.RenderConfigMapArgs()
+	wantArgs := []string{"--immutable=true", "--as-key-value=true"}
+	if len(args) != len(wantArgs) {
+		t.Fatalf("RenderConfigMapArgs: want %v, got %v", wantArgs, args)
+	}
+	for i, want := range wantArgs {
+		if args[i] != want {
+			t.Errorf("RenderConfigMapArgs[%d]: want %q, got %q", i, want, args[i])
+		}
 	}
 	// Env content is rendered with sorted keys for determinism: BAZ before FOO.
 	wantContent := "BAZ=qux\nFOO=bar\n"

--- a/test/e2e/upload-reconcile.sh
+++ b/test/e2e/upload-reconcile.sh
@@ -3,8 +3,8 @@
 # upload-reconcile.sh — end-to-end smoke for `install upload` against a
 # live ConfigHub server, driven by the worker package so the test
 # exercises BOTH the standard Unit pathway and the AppConfig pathway
-# (ConfigMapRenderer Target + AppConfig Unit + placeholder + live-state
-# MergeUnits link).
+# (render-configmap Invocation + AppConfig Unit + placeholder + Upsert
+# link).
 #
 # Flow:
 #
@@ -13,9 +13,9 @@
 #                    via `install render` (bypasses setup's collector,
 #                    which would overwrite facts back to :latest)
 #   upload         — first upload: creates Space + Units + installer-
-#                    record + AppConfig trio (Target/AppConfig Unit/
-#                    placeholder) + cross-Unit links + auto-creates
-#                    renderer-worker
+#                    record + AppConfig set (render-configmap Invocation/
+#                    AppConfig Unit/placeholder + Upsert link) + cross-Unit
+#                    links
 #   plan (clean)   — No changes
 #   edit + plan    — surfaces the edited slug
 #   reconcile      — applies inside a ChangeSet
@@ -98,7 +98,7 @@ cleanup_msg() {
   printf '\n----- inspection state preserved -----\n'
   printf 'Space:    %s\n' "$SPACE"
   printf 'Work-dir: %s\n' "$WORK_TMP"
-  printf '\nClean up the Space (and everything in it — Units, Targets, Links,\nthe BridgeWorker entity, the renderer-worker, ChangeSets) with:\n  cub space delete --recursive %s\n' "$SPACE"
+  printf '\nClean up the Space (and everything in it — Units, Invocations, Links,\nthe BridgeWorker entity, ChangeSets) with:\n  cub space delete --recursive %s\n' "$SPACE"
   if [[ "$KEEP_WD" = "1" ]]; then
     printf 'Clean up the work-dir with:\n  rm -rf %s\n' "$WORK_TMP"
   fi
@@ -198,8 +198,8 @@ grep -q "image: $PINNED_IMAGE" "$DEP_FILE" \
 note "rendered Deployment now references $PINNED_IMAGE"
 
 # The AppConfig ConfigMap (confighub-worker-env) should be present in
-# rendered manifests — upload will split it into a renderer Target +
-# AppConfig Unit + placeholder.
+# rendered manifests — upload will split it into a render-configmap
+# Invocation + AppConfig Unit + placeholder.
 appcfg_cm=$(grep -l "installer.confighub.com/toolchain: AppConfig/Env" "$WORK_TMP/out/manifests"/*.yaml | head -1)
 [[ -n "$appcfg_cm" ]] || fail "expected at least one AppConfig-tagged ConfigMap among rendered manifests"
 note "AppConfig carrier ConfigMap: $(basename "$appcfg_cm")"
@@ -222,19 +222,22 @@ note "Units in $SPACE after first upload: $unit_count"
 cub unit list --space "$SPACE" 2>/dev/null | awk '{print $1}' | grep -qx "installer-record" \
   || fail "first upload did not create installer-record Unit in $SPACE"
 
-# 6b. AppConfig-pathway assertions: one ConfigMapRenderer Target, one
-# *-rendered placeholder Unit, and the auto-created renderer-worker.
-target_count=$(cub target list --space "$SPACE" 2>/dev/null | awk 'NR>1 && /-renderer/' | wc -l | tr -d ' ')
-[[ "$target_count" -ge 1 ]] || fail "expected at least one ConfigMapRenderer Target in $SPACE (got $target_count)"
-note "ConfigMapRenderer Targets:"
-cub target list --space "$SPACE" 2>/dev/null | awk 'NR>1 {print "      "$1}' || true
+# 6b. AppConfig-pathway assertions: one render-configmap Invocation and
+# one *-rendered placeholder Unit. No bridge Target and no renderer
+# worker — the rendering happens via the render-configmap function on an
+# Upsert link.
+invocation_count=$(cub invocation list --space "$SPACE" 2>/dev/null | awk 'NR>1 && /-render/' | wc -l | tr -d ' ')
+[[ "$invocation_count" -ge 1 ]] || fail "expected at least one render-configmap Invocation in $SPACE (got $invocation_count)"
+note "render-configmap Invocations:"
+cub invocation list --space "$SPACE" 2>/dev/null | awk 'NR>1 {print "      "$1}' || true
 
 placeholder_count=$(cub unit list --space "$SPACE" 2>/dev/null | awk 'NR>1 && /-rendered/' | wc -l | tr -d ' ')
 [[ "$placeholder_count" -ge 1 ]] || fail "expected at least one *-rendered placeholder Unit in $SPACE"
 
-cub worker list --space "$SPACE" 2>/dev/null | awk '{print $1}' | grep -qx "renderer-worker" \
-  || fail "upload should auto-create the renderer-worker server-side worker in $SPACE"
-note "renderer-worker auto-created OK"
+# The placeholder should hold a rendered ConfigMap (the Upsert link ran).
+cub unit data --space "$SPACE" confighub-worker-env-rendered 2>/dev/null | grep -q "kind: ConfigMap" \
+  || fail "placeholder confighub-worker-env-rendered should contain a rendered ConfigMap"
+note "rendered ConfigMap present in placeholder Unit"
 
 link_count=$(cub link list --space "$SPACE" 2>/dev/null | awk 'NR>1' | wc -l | tr -d ' ')
 [[ "$link_count" -ge 1 ]] || fail "expected at least one intra-Space link in $SPACE"
@@ -278,7 +281,7 @@ grep -q "^Plan: 0 to add, 1 to change, 0 to delete\\.$" "$WORK_TMP/plan-appcfg.l
 grep -q "~ confighub-worker-env\b" "$WORK_TMP/plan-appcfg.log" \
   || fail "plan after AppConfig edit should name the AppConfig Unit slug confighub-worker-env (see $WORK_TMP/plan-appcfg.log)"
 if grep -q "~ confighub-worker-env-rendered" "$WORK_TMP/plan-appcfg.log"; then
-  fail "plan should NOT name the *-rendered placeholder (it's maintained by the live-merge link, not by reconcile)"
+  fail "plan should NOT name the *-rendered placeholder (it's maintained by the Upsert link, not by reconcile)"
 fi
 
 run upload-appcfg "$BIN" upload --work-dir "$WORK_TMP" --yes || fail "upload after AppConfig edit failed (see $WORK_TMP/upload-appcfg.log)"


### PR DESCRIPTION
## Summary

`install upload` now renders AppConfig-annotated ConfigMaps using the new `render-configmap` function on an **Upsert** link, instead of the `ConfigMapRenderer` bridge. No bridge worker, Target, or apply step is involved anymore.

This depends on the server-side `render-configmap` / Upsert support (confighubai/confighub#4428, merged).

## What the installer does differently

**Before** — an AppConfig-annotated ConfigMap split into:
- AppConfig Unit targeted at a `ConfigMapRenderer` Target
- `cub unit apply` to produce the rendered ConfigMap as live state
- placeholder Kubernetes/YAML Unit
- live-state `MergeUnits` link
- an auto-created server-side `renderer-worker`

**After** — it splits into:
- AppConfig Unit (no target — pure data source)
- `render-configmap` Invocation (slug `<carrier>-render`)
- placeholder Kubernetes/YAML Unit
- `Upsert` link with the Invocation as its `TransformInvocation`

On resolution the function renders the ConfigMap directly into the placeholder. No worker to auto-create, no Target, no apply.

Mode mapping moves from bridge Target options to function arguments:

| Carrier property | Old (Target option) | New (function arg) |
|---|---|---|
| mutable | `RevisionHistoryLimit=0` | `--immutable=false` |
| env-mode AppConfig/Env | `AsKeyValue=true` | `--as-key-value=true` |

The `--appconfig-worker` flag is removed (nothing to point a worker at).

> No backward compatibility for the bridge pathway — an install previously uploaded with the ConfigMapRenderer bridge would need to be re-uploaded. The `cub-worker` binary still supports the `ConfigMapRenderer` provider type; only the installer's use of it is dropped.

## Changes

- `internal/upload/appconfig.go` — drop `TargetSlug` / `RendererOptions`; add `InvocationSlug` and `RenderConfigMapArgs`.
- `internal/cli/upload.go` — rewrite `uploadAppConfigManifest`; remove `--appconfig-worker`, `ensureRendererWorker`, the worker pre-scan, and the apply step.
- `internal/diff/diff.go` — comment updates (Upsert vs live-merge).
- docs — `transformer.md`, `lifecycle.md`, `consumer-guide.md`, `author-guide.md`.
- `test/e2e/upload-reconcile.sh` — assert a `render-configmap` Invocation and a rendered ConfigMap in the placeholder instead of a Target + renderer-worker; fix a BSD-awk word-boundary incompatibility.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (unit suite, incl. `internal/upload` and `internal/cli`)
- [x] `test/e2e/upload-reconcile.sh` against a live local server — `=== OK ===`, including the AppConfig round-trip, reconcile, and ChangeSet flow. Resulting Space has an empty Target list (no ConfigMapRenderer Target) and a `KeyValue`-rendered ConfigMap in the placeholder Unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)