### PR TITLE
install upload: empty (don't delete) reconciled-away Units; add kpt post-install guide

### DIFF
--- a/docs/consumer-guide.md
+++ b/docs/consumer-guide.md
@@ -265,7 +265,7 @@ install upload --yes
 # ChangeSet: statusboard-prod/installer-update-20260514-…
 # Successfully updated unit deployment-statusboard-statusboard …
 #
-# Applied: 0 created, 1 updated, 0 deleted.
+# Applied: 0 created, 1 updated, 0 emptied.
 # Updates revertable via:
 #   cub unit update --patch --space statusboard-prod \
 #       --restore Before:ChangeSet:installer-update-20260514-… \
@@ -275,8 +275,15 @@ install upload --yes
 The ChangeSet name is printed and the precise revert command is
 written to stdout — copy/paste it later if you need to roll back.
 
-`--yes` is required when stdin isn't a TTY and the plan contains
-deletes; otherwise upload prompts per delete.
+`--yes` is required when stdin isn't a TTY and the plan empties Units
+(those that dropped out of the rendered output); otherwise upload
+prompts before emptying. Upload never runs `cub unit delete`: a Unit
+that left the render is **emptied** rather than deleted. Emptying is a
+`--merge-external-source` 3-way merge that drops only the installer-
+contributed resources, so the Unit record, target binding, and any
+post-install edits survive, and applying the emptied Unit later removes
+its deployed resources. Units guarded by a DestroyGate are refused —
+clear the gate first if you really intend to tear them down.
 
 A re-run on a converged work-dir is a no-op (no ChangeSet opened):
 
@@ -294,8 +301,11 @@ To revert a reconcile upload, run the printed `cub unit update --patch
 - **Creates** from that upload are not reverted automatically — to
   undo a create, delete the Unit (`cub unit delete --space S
   <slug>`).
-- **Deletes** from that upload are not reverted automatically —
-  re-render and re-run `install upload` to re-create.
+- **Empties** from that upload (Units that dropped out of the render)
+  are not part of the ChangeSet, but the prior Data is preserved in the
+  Unit's revision history — restore it with `cub unit update --restore`
+  against the pre-empty revision, or re-render and re-run `install
+  upload` to repopulate it.
 
 If you need to roll back a multi-Unit change, this is where having
 the Component label pays off:

--- a/docs/consumer-guide.md
+++ b/docs/consumer-guide.md
@@ -214,6 +214,13 @@ This is the right layer for changes that don't warrant a re-render
 — ad-hoc fixes, exploratory tuning, anything where you want the
 change tracked in cub's revision history rather than your work-dir.
 
+Post-install mutations can also be made with [kpt](https://kpt.dev)
+instead of ConfigHub — a git-based configuration-as-data tool whose
+package merge preserves your edits across re-renders the same way
+`--merge-external-source` does. This is an alternative to `install
+upload` + `cub unit apply` for kpt users, or for trying post-install
+changes without ConfigHub first. See the [kpt guide](./kpt-guide.md).
+
 ### What NOT to do
 
 - **Don't edit the package source tree** (`./package/`). The next

--- a/docs/kpt-guide.md
+++ b/docs/kpt-guide.md
@@ -1,0 +1,172 @@
+# Post-install changes with kpt
+
+The installer renders fully-materialized Kubernetes manifests to
+`out/manifests/`. The recommended day-2 path is to upload them to
+ConfigHub and reconcile with `install upload` + `cub unit apply`:
+ConfigHub's `--merge-external-source` preserves your post-install edits
+across re-renders (see [Post-install ConfigHub
+mutations](./consumer-guide.md#3-post-install-confighub-mutations)).
+
+[kpt](https://kpt.dev) is an open-source alternative for the same job,
+using git instead of ConfigHub. This guide is for two audiences:
+
+- you already use kpt and want to manage the rendered output with it;
+- you want to make post-install changes **without** standing up
+  ConfigHub first — an alternative to `install upload` and `cub unit
+  apply`.
+
+## What kpt gives you
+
+kpt is a configuration-as-data tool that stores configuration in git.
+The unit of distribution is a **package** — a directory of YAML with a
+`Kptfile`. Fetching a package (`kpt pkg get`) clones it and records its
+upstream; pulling a new version (`kpt pkg update`) does a structured,
+schema-aware **3-way merge** (`resource-merge`) between the new upstream,
+the original upstream, and your local edits.
+
+That merge is the whole point here: it's the git-based analogue of
+ConfigHub's `--merge-external-source`. You keep your post-install edits
+in a separate clone, and when you re-render the base for an upgrade, kpt
+reconciles the new render with your edits.
+
+See the kpt package operations reference:
+<https://kpt.dev/book/03-packages/>.
+
+## The model
+
+Three pieces, all in one git repo (your work-dir):
+
+- **Base package** — `out/manifests/`, turned into a kpt package with a
+  `Kptfile`. Every `install render` rewrites it. This is the upstream.
+- **Post-install clone** — `out/post-install/manifests/`, a kpt clone of
+  the base. **You make your edits here**, never in the base.
+- **Upgrade** — re-render the base, commit, then `kpt pkg update` in the
+  clone merges the new render with your edits.
+
+Because your edits live in a separate clone, re-rendering the base never
+touches them; kpt merges the two on update.
+
+## Setup (local — no remote needed)
+
+`kpt pkg update` only needs the upstream's **committed** state — it
+git-fetches into a temp dir and merges. It never reads your working tree
+and doesn't need a *remote*, so the work-dir can be its own upstream. You
+only commit; you never push.
+
+```bash
+# In the work-dir — the directory holding package/ and out/.
+cd my-workdir
+git init -b main
+git add . && git commit -m "Initial render"
+
+# Turn the rendered manifests into a kpt package.
+cd out/manifests
+kpt pkg init .                 # writes Kptfile (+ README.md, package-context.yaml)
+cd ../..
+git add . && git commit -m "kpt: init base package in out/manifests"
+
+# Clone the base into out/post-install/manifests. The destination dir
+# (post-install) must exist; kpt nests the package — named "manifests" —
+# inside it. The ".git" in the path tells kpt where the repo ends and
+# the package path begins (otherwise: "ambiguous repo/dir").
+cd out
+mkdir -p post-install
+kpt pkg get "$(git -C .. rev-parse --show-toplevel)/.git/out/manifests" post-install
+cd ..
+git add . && git commit -m "kpt: clone base into out/post-install"
+```
+
+`out/.gitignore` (written by the installer) keeps `out/secrets/` out of
+git; the base package is `out/manifests/` only, which never contains
+rendered Secrets.
+
+## Make post-install changes
+
+Edit files under `out/post-install/manifests/` — by hand or with
+`kpt fn eval` — and commit:
+
+```bash
+$EDITOR out/post-install/manifests/deployment-*.yaml   # e.g. scale, annotate
+git add . && git commit -m "post-install: scale to 2 replicas"
+```
+
+Apply them to the cluster with `kpt live` — the kpt-native apply, which
+tracks an inventory of what it applied so it can prune resources you've
+since removed and report reconcile status (this is what replaces `cub
+unit apply`):
+
+```bash
+kpt live init out/post-install/manifests    # once — records an inventory in the Kptfile
+kpt live apply out/post-install/manifests   # apply, prune, and wait for status
+```
+
+(`kubectl apply -f out/post-install/manifests/` also works, but without
+the inventory it won't prune deleted resources.) See
+<https://kpt.dev/book/06-apply/>.
+
+## Upgrade: re-render, then merge
+
+```bash
+# 1. Re-render the base (new package version, new inputs, image bump…).
+#    --clean prunes resources dropped by the upgrade while PRESERVING the
+#    base package's Kptfile, so out/manifests stays a valid kpt package.
+install setup --pull <new-ref> --work-dir my-workdir --clean
+#    (or, to re-render in place without re-pulling: install render --clean)
+git add . && git commit -m "render <pkg>@<new-version>"
+
+# 2. Merge the new render into your post-install clone.
+cd out/post-install/manifests
+kpt pkg update .               # strategy: resource-merge (3-way)
+cd -
+# Resolve any conflicts kpt reports, then commit the merged result.
+git add . && git commit -m "post-install: merge <pkg>@<new-version>"
+```
+
+The merged clone has **both** the upgrade's changes and your post-install
+edits. Re-apply it to the cluster as above.
+
+## Versioning with tags
+
+kpt tracks the upstream by git ref, so tag each rendered version and pull
+the clone to a specific tag:
+
+```bash
+git tag v0.1.0                                  # at each rendered base version
+kpt pkg update out/post-install/manifests@v0.1.0
+```
+
+kpt does **not** enforce semver on the tag, so you can append an extra
+segment to version post-install iterations independently of the base —
+e.g. tag your post-install commits `v0.1.0.1`, `v0.1.0.2` while the base
+stays at `v0.1.0`.
+
+## Portable / shared setup: a real git remote
+
+The local setup records an absolute path as the package's upstream
+(`upstream.repo: /abs/path/to/my-workdir/`), which only resolves on that
+machine. To share the workflow — push the work-dir to a real remote and
+let teammates run updates — point the upstream at the remote URL instead:
+
+```bash
+git remote add origin https://github.com/you/your-repo
+git push -u origin main
+
+cd out
+mkdir -p post-install
+# <pkg-dir> is the work-dir's path within the repo, if any.
+kpt pkg get https://github.com/you/your-repo/<pkg-dir>/out/manifests post-install
+```
+
+Now the clone's `Kptfile` records the remote URL and `kpt pkg update`
+fetches from it — so the upgrade loop becomes re-render → commit →
+**push** → update. That extra push is the cost of portability; the
+local setup avoids it.
+
+## See also
+
+- kpt docs: <https://kpt.dev>
+- kpt package operations (`init` / `get` / `update`):
+  <https://kpt.dev/book/03-packages/>
+- kpt apply (`kpt live`): <https://kpt.dev/book/06-apply/>
+- The integrated ConfigHub alternative: [Post-install ConfigHub
+  mutations](./consumer-guide.md#3-post-install-confighub-mutations)

--- a/docs/lifecycle-plan.md
+++ b/docs/lifecycle-plan.md
@@ -107,9 +107,14 @@ Goal: execute the Phase B plan inside a ChangeSet.
     for adds.
   - `cub unit update --merge-external-source --changeset <slug> ...`
     for updates (no `--dry-run`).
-  - `cub unit delete` for deletes; gated on `opts.Yes` or interactive
-    confirm-each. Stale links are auto-removed by ConfigHub on Unit
-    delete — no installer-side cleanup.
+  - `cub unit update --merge-external-source` with empty content for
+    Units that dropped out of the render — **empty**, never `cub unit
+    delete` (deleting would orphan deployed resources, discard
+    post-install edits, and fail on DeleteGates). The merge drops only
+    installer-contributed resources, preserving post-install edits.
+    Gated on `opts.Yes` or interactive confirm-each, and refused for
+    Units carrying a DestroyGate. Stale links are auto-removed by
+    ConfigHub when the Data no longer references them.
 - New: `internal/cli/update.go` — `install update <work-dir> [--yes]
   [--changeset <slug>]`. Default ChangeSet slug:
   `installer-update-<RFC3339-timestamp>`. Plan output names the

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -239,10 +239,17 @@ work-dir has been uploaded before:
 - **Reconcile** — `out/spec/upload.yaml` exists. Re-computes the same
   plan `install plan` would produce, opens one ChangeSet per Space,
   runs `cub unit update --merge-external-source --changeset <slug>` for
-  updates, `cub unit create` for adds, `cub unit delete` for deletes
-  (gated on `--yes` or interactive confirmation). Refreshes the
-  `installer-record` Unit so subsequent setups re-enter from
-  up-to-date state.
+  updates, `cub unit create` for adds, and for Units that dropped out of
+  the rendered output, `cub unit update --merge-external-source` with
+  empty content to **empty** them (gated on `--yes` or interactive
+  confirmation). Emptying — never `cub unit delete` — is a 3-way merge
+  against the last installer push, so it removes only the installer-
+  contributed resources and preserves the Unit record, its target
+  binding, and any post-install edits, leaving prior Data in revision
+  history; applying the emptied Unit later removes its deployed
+  resources through the normal deploy path. Units guarded by a
+  DestroyGate are refused. Refreshes the `installer-record` Unit so
+  subsequent setups re-enter from up-to-date state.
 
 The two modes share most of the implementation; the detection rule is
 purely "is this the first time we're talking to ConfigHub for this
@@ -260,8 +267,9 @@ Flags:
   retried without erroring on the entries that did succeed. (Replaces
   the previous `--allow-exists` flag — same behavior, clearer name.)
   Ignored on reconcile (reconcile is always idempotent).
-- `--yes` — skip per-delete confirmation on reconcile (required when
-  stdin is not a TTY and the plan contains deletes).
+- `--yes` — skip the empty-Units confirmation on reconcile (required
+  when stdin is not a TTY and the plan empties Units that dropped out of
+  the rendered output).
 - `--changeset` — explicit ChangeSet slug on reconcile. Default:
   `installer-update-<RFC3339-timestamp>`.
 

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -59,10 +59,7 @@ identical bytes. Re-render after editing selection.yaml or inputs.yaml.`,
 			}
 
 			if clean {
-				if err := os.RemoveAll(manifestsDir); err != nil {
-					return err
-				}
-				if err := os.RemoveAll(filepath.Join(outDir, "secrets")); err != nil {
+				if err := render.CleanRenderedOutput(outDir); err != nil {
 					return err
 				}
 			}
@@ -127,7 +124,7 @@ identical bytes. Re-render after editing selection.yaml or inputs.yaml.`,
 		},
 	}
 	cmd.Flags().StringVar(&workDir, "work-dir", ".", "working directory (reads ./package + ./out/spec, writes ./out/manifests)")
-	cmd.Flags().BoolVar(&clean, "clean", false, "remove out/manifests/ and out/secrets/ before rendering")
+	cmd.Flags().BoolVar(&clean, "clean", false, "remove previously rendered out/manifests/ (preserving any kpt Kptfile) and out/secrets/ before rendering")
 	return cmd
 }
 

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -341,10 +341,7 @@ func runRenderInWorkDir(ctx context.Context, workDir string, loaded *ipkg.Loaded
 	outDir := filepath.Join(workDir, "out")
 	manifestsDir := filepath.Join(outDir, "manifests")
 	if clean {
-		if err := os.RemoveAll(manifestsDir); err != nil {
-			return err
-		}
-		if err := os.RemoveAll(filepath.Join(outDir, "secrets")); err != nil {
+		if err := render.CleanRenderedOutput(outDir); err != nil {
 			return err
 		}
 	}
@@ -466,6 +463,6 @@ Setup does NOT upload. Run install upload to push to ConfigHub.`,
 	cmd.Flags().BoolVar(&opts.reuse, "reuse", false, "skip prompts and re-use the prior install's selection + inputs (requires prior state)")
 	cmd.Flags().StringVar(&opts.preset, "components", "", "component preset: minimal | default | all | selected. Mutually exclusive with --select.")
 	cmd.Flags().StringSliceVar(&opts.setImage, "set-image", nil, "image override as name=ref (repeatable); applied via `kustomize edit set image` against the chosen base before render. The base's kustomization.yaml must declare an `images:` block.")
-	cmd.Flags().BoolVar(&opts.clean, "clean", false, "remove out/manifests/ and out/secrets/ before rendering")
+	cmd.Flags().BoolVar(&opts.clean, "clean", false, "remove previously rendered out/manifests/ (preserving any kpt Kptfile) and out/secrets/ before rendering")
 	return cmd
 }

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -272,7 +272,7 @@ func runUploadReconcile(ctx context.Context, workDir string, loaded *ipkg.Loaded
 	if err != nil {
 		return err
 	}
-	fmt.Printf("\nApplied: %d created, %d updated, %d deleted.\n", res.Created, res.Updated, res.Deleted)
+	fmt.Printf("\nApplied: %d created, %d updated, %d emptied.\n", res.Created, res.Updated, res.Deleted)
 	if len(res.ChangeSetsOpened) > 0 {
 		fmt.Println("Updates revertable via:")
 		for _, cs := range res.ChangeSetsOpened {

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -71,6 +71,6 @@ Pass --non-interactive to script the wizard with --base, --components,
 	cmd.Flags().StringVar(&opts.preset, "components", "", "component preset: minimal | default | all | selected. Mutually exclusive with --select.")
 	cmd.Flags().StringSliceVar(&opts.setImage, "set-image", nil, "image override as name=ref (repeatable); applied via `kustomize edit set image` against the chosen base before render. The base's kustomization.yaml must declare an `images:` block.")
 	cmd.Flags().BoolVar(&opts.runRender, "render", true, "render after the wizard writes spec docs; pass --render=false to skip and run install render later")
-	cmd.Flags().BoolVar(&opts.clean, "clean", false, "remove out/manifests/ and out/secrets/ before rendering")
+	cmd.Flags().BoolVar(&opts.clean, "clean", false, "remove previously rendered out/manifests/ (preserving any kpt Kptfile) and out/secrets/ before rendering")
 	return cmd
 }

--- a/internal/diff/apply.go
+++ b/internal/diff/apply.go
@@ -3,10 +3,13 @@ package diff
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"sort"
+	"strings"
 
 	"github.com/confighub/installer/internal/changeset"
 	"github.com/confighub/installer/internal/upload"
@@ -142,7 +145,7 @@ func Apply(ctx context.Context, plan Plan, opts ApplyOptions) (ApplyResult, erro
 			}
 		}
 		if len(sp.Deletes) > 0 {
-			deleted, err := deleteUnits(ctx, sp.SpaceSlug, sp.Deletes, opts, stdout, stderr)
+			deleted, err := emptyUnits(ctx, sp.SpaceSlug, sp.Deletes, opts, stdout, stderr)
 			if err != nil {
 				return res, err
 			}
@@ -260,29 +263,122 @@ func closeChangeSet(ctx context.Context, space string, updates []SlugDiff, stdou
 	return nil
 }
 
-func deleteUnits(ctx context.Context, space string, deletes []SlugDiff, opts ApplyOptions, stdout, stderr io.Writer) (int, error) {
+// emptyUnits reconciles Units that exist in ConfigHub (under this
+// package's Component label) but no longer appear in the rendered
+// output. It does NOT run `cub unit delete`: upload reconciles Data
+// only, never the deployed live state. Deleting the Unit record would
+// orphan whatever it has deployed (the resources must be destroyed via
+// `cub unit apply` first, which upload does not do), discard any
+// post-install edits the operator made, and fail outright on Units
+// guarded by DeleteGates.
+//
+// Instead it feeds empty content through a `cub unit update
+// --merge-external-source`. That is a 3-way merge against the last
+// external (installer) push, so it removes only the resources the
+// installer contributed and leaves any post-install additions in place
+// — never a blunt full-replace-to-empty. The Unit record, target
+// binding, and metadata survive; the next `cub unit apply` removes the
+// now-absent resources through the normal deploy path. Prior Data stays
+// in revision history, so an emptying can be reverted with `cub unit
+// update --restore`.
+//
+// Because applying an emptied Unit destroys its deployed resources,
+// emptying is refused for any Unit carrying a DestroyGate — the same
+// protection the server enforces on the destroy action itself. The
+// whole batch is scanned first so a gated Unit is reported before
+// anything is touched.
+func emptyUnits(ctx context.Context, space string, deletes []SlugDiff, opts ApplyOptions, stdout, stderr io.Writer) (int, error) {
 	if !opts.Yes {
-		fmt.Fprintf(stdout, "Refusing to delete %d Unit(s) in %s without --yes:\n", len(deletes), space)
+		fmt.Fprintf(stdout, "Refusing to empty %d Unit(s) in %s without --yes:\n", len(deletes), space)
 		for _, d := range deletes {
 			fmt.Fprintf(stdout, "  - %s\n", d.Slug)
 		}
-		return 0, fmt.Errorf("re-run with --yes to delete Units")
+		return 0, fmt.Errorf("re-run with --yes to empty Units no longer in the rendered output")
 	}
-	deleted := 0
+
+	var gated []string
 	for _, d := range deletes {
-		cmd := exec.CommandContext(ctx, "cub", "unit", "delete",
-			"--space", space, "--quiet", d.Slug)
+		gates, err := unitDestroyGates(ctx, space, d.Slug, stderr)
+		if err != nil {
+			return 0, err
+		}
+		if len(gates) > 0 {
+			gated = append(gated, fmt.Sprintf("  - %s (DestroyGates: %s)", d.Slug, strings.Join(gates, ", ")))
+		}
+	}
+	if len(gated) > 0 {
+		fmt.Fprintf(stdout, "Refusing to empty %d Unit(s) in %s guarded by DestroyGates:\n", len(gated), space)
+		for _, line := range gated {
+			fmt.Fprintln(stdout, line)
+		}
+		return 0, fmt.Errorf("remove the DestroyGate(s) (e.g. `cub unit update --patch --destroy-gate <key>=-`) before these Units can be emptied")
+	}
+
+	// Stage a single empty file to feed every merge-on-update.
+	empty, err := os.CreateTemp("", "installer-empty-*")
+	if err != nil {
+		return 0, err
+	}
+	defer os.Remove(empty.Name())
+	if err := empty.Close(); err != nil {
+		return 0, err
+	}
+
+	emptied := 0
+	for _, d := range deletes {
+		// --merge-external-source makes this a 3-way merge against the
+		// last installer push (the server picks that base by source
+		// type, so the identifier value only labels the change). Pass
+		// the slug as that label; --change-desc below is what actually
+		// lands on the revision.
+		cmd := exec.CommandContext(ctx, "cub", "unit", "update",
+			"--space", space, "--quiet",
+			"--merge-external-source", d.Slug,
+			"--change-desc", fmt.Sprintf("install upload: emptied %s (no longer in rendered output)", d.Slug),
+			d.Slug, empty.Name())
 		var combined bytes.Buffer
 		cmd.Stdout = &combined
 		cmd.Stderr = &combined
 		if err := cmd.Run(); err != nil {
 			io.Copy(stderr, &combined)
-			return deleted, fmt.Errorf("cub unit delete %s in %s: %w", d.Slug, space, err)
+			return emptied, fmt.Errorf("cub unit update (empty) %s in %s: %w", d.Slug, space, err)
 		}
-		fmt.Fprintf(stdout, "Deleted %s/%s\n", space, d.Slug)
-		deleted++
+		fmt.Fprintf(stdout, "Emptied %s/%s (apply to remove its deployed resources)\n", space, d.Slug)
+		emptied++
 	}
-	return deleted, nil
+	return emptied, nil
+}
+
+// unitDestroyGates returns the DestroyGate keys set on a Unit, or nil if
+// it has none. Used to refuse emptying a Unit whose deployed resources
+// the gate is meant to protect.
+func unitDestroyGates(ctx context.Context, space, slug string, stderr io.Writer) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "cub", "unit", "get",
+		"--space", space, "-o", "json", slug)
+	var stdout, errb bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		io.Copy(stderr, &errb)
+		return nil, fmt.Errorf("cub unit get %s in %s: %w", slug, space, err)
+	}
+	var resp struct {
+		Unit struct {
+			DestroyGates map[string]bool `json:"DestroyGates"`
+		} `json:"Unit"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		return nil, fmt.Errorf("parse cub unit get %s in %s: %w", slug, space, err)
+	}
+	if len(resp.Unit.DestroyGates) == 0 {
+		return nil, nil
+	}
+	gates := make([]string, 0, len(resp.Unit.DestroyGates))
+	for k := range resp.Unit.DestroyGates {
+		gates = append(gates, k)
+	}
+	sort.Strings(gates)
+	return gates, nil
 }
 
 func baseName(path string) string {

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -300,6 +300,30 @@ func TestApplyNoChangesNoOp(t *testing.T) {
 	}
 }
 
+func TestEmptyUnitsRefusesWithoutYes(t *testing.T) {
+	// Without --yes, emptyUnits must refuse the whole batch up front —
+	// before shelling out to cub — listing every Unit it would empty.
+	var stdout, stderr bytes.Buffer
+	deletes := []SlugDiff{{Slug: "deployment-gone"}, {Slug: "service-gone"}}
+	n, err := emptyUnits(context.Background(), "statusboard-prod", deletes,
+		ApplyOptions{Yes: false}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected error when --yes is not set")
+	}
+	if n != 0 {
+		t.Errorf("expected 0 emptied, got %d", n)
+	}
+	out := stdout.String()
+	for _, slug := range []string{"deployment-gone", "service-gone"} {
+		if !strings.Contains(out, slug) {
+			t.Errorf("expected refusal to list %q, got:\n%s", slug, out)
+		}
+	}
+	if strings.Contains(out, "Emptied") {
+		t.Errorf("must not empty anything when refusing, got:\n%s", out)
+	}
+}
+
 func mustWrite(t *testing.T, path, body string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/render/clean.go
+++ b/internal/render/clean.go
@@ -1,0 +1,32 @@
+package render
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// CleanRenderedOutput clears previously rendered output so a re-render starts
+// from a clean slate — in particular so resources dropped by an upgrade don't
+// linger as stale files (a plain Render overwrites produced files but never
+// removes ones it didn't produce).
+//
+// It deletes the rendered manifests in out/manifests/ but PRESERVES a Kptfile
+// there, if present, so the directory stays a valid kpt base package across
+// upgrades (its package identity and any consumer's upstream pointer survive).
+// See docs/kpt-guide.md. out/secrets/ is removed wholesale.
+func CleanRenderedOutput(outDir string) error {
+	manifestsDir := filepath.Join(outDir, "manifests")
+	entries, err := os.ReadDir(manifestsDir)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	for _, e := range entries {
+		if e.Name() == "Kptfile" {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(manifestsDir, e.Name())); err != nil {
+			return err
+		}
+	}
+	return os.RemoveAll(filepath.Join(outDir, "secrets"))
+}

--- a/internal/render/clean_test.go
+++ b/internal/render/clean_test.go
@@ -1,0 +1,56 @@
+package render_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/confighub/installer/internal/render"
+)
+
+func TestCleanRenderedOutput(t *testing.T) {
+	outDir := t.TempDir()
+	manifestsDir := filepath.Join(outDir, "manifests")
+	secretsDir := filepath.Join(outDir, "secrets")
+	for _, d := range []string{manifestsDir, secretsDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write := func(path string) {
+		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(manifestsDir, "Kptfile"))
+	write(filepath.Join(manifestsDir, "deployment.yaml"))
+	write(filepath.Join(manifestsDir, "service.yaml"))
+	write(filepath.Join(secretsDir, "secret.yaml"))
+
+	if err := render.CleanRenderedOutput(outDir); err != nil {
+		t.Fatalf("CleanRenderedOutput: %v", err)
+	}
+
+	// Kptfile is preserved so the dir stays a valid kpt base package.
+	if _, err := os.Stat(filepath.Join(manifestsDir, "Kptfile")); err != nil {
+		t.Errorf("Kptfile should be preserved, got: %v", err)
+	}
+	// Rendered manifests are removed.
+	for _, f := range []string{"deployment.yaml", "service.yaml"} {
+		if _, err := os.Stat(filepath.Join(manifestsDir, f)); !os.IsNotExist(err) {
+			t.Errorf("%s should be removed, stat err = %v", f, err)
+		}
+	}
+	// secrets/ is removed wholesale.
+	if _, err := os.Stat(secretsDir); !os.IsNotExist(err) {
+		t.Errorf("secrets/ should be removed, stat err = %v", err)
+	}
+}
+
+// A missing manifests/ directory is not an error (clean before first render).
+func TestCleanRenderedOutput_NoManifestsDir(t *testing.T) {
+	outDir := t.TempDir()
+	if err := render.CleanRenderedOutput(outDir); err != nil {
+		t.Fatalf("CleanRenderedOutput on empty out/: %v", err)
+	}
+}

--- a/internal/render/e2e_test.go
+++ b/internal/render/e2e_test.go
@@ -96,6 +96,15 @@ func TestEndToEnd_HelloApp(t *testing.T) {
 			t.Errorf("missing spec doc %s: %v", name, err)
 		}
 	}
+
+	// out/.gitignore keeps rendered secrets out of version control.
+	gi, err := os.ReadFile(filepath.Join(outDir, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read out/.gitignore: %v", err)
+	}
+	if !strings.Contains(string(gi), "secrets/") {
+		t.Errorf("out/.gitignore should ignore the secrets/ subdirectory, got:\n%s", gi)
+	}
 }
 
 func filenames(files []render.File) []string {

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -148,6 +148,14 @@ func Render(ctx context.Context, opts Options, outDir string) (*Result, error) {
 	if err := os.MkdirAll(specDir, 0o755); err != nil {
 		return nil, err
 	}
+	// Keep rendered secrets out of version control. out/secrets/ holds
+	// sensitive resources (e.g. Secrets split off the upload path); a
+	// .gitignore at the out/ root ignores the whole subdirectory so its
+	// contents can never be committed by accident.
+	gitignore := filepath.Join(outDir, ".gitignore")
+	if err := os.WriteFile(gitignore, []byte("# Rendered secrets must never be committed.\nsecrets/\n"), 0o644); err != nil {
+		return nil, err
+	}
 	if len(secrets) > 0 {
 		if err := os.MkdirAll(secretsDir, 0o700); err != nil {
 			return nil, err

--- a/test/e2e/upload-reconcile.sh
+++ b/test/e2e/upload-reconcile.sh
@@ -22,6 +22,10 @@
 #   re-run         — second upload is a no-op (no ChangeSet)
 #   AppConfig edit — edits the .env carrier, re-renders, reconciles —
 #                    proves the AppConfig pathway round-trips
+#   drop manifest  — removes a rendered manifest so its Unit falls out of
+#                    the rendered set; reconcile EMPTIES the Unit (via
+#                    merge-external-source), never `cub unit delete`, and
+#                    refuses outright while the Unit carries a DestroyGate
 #
 # Unlike package-and-deps.sh, this test does NOT delete the destination
 # Space on exit — the resulting Space is left for manual inspection.
@@ -285,7 +289,7 @@ if grep -q "~ confighub-worker-env-rendered" "$WORK_TMP/plan-appcfg.log"; then
 fi
 
 run upload-appcfg "$BIN" upload --work-dir "$WORK_TMP" --yes || fail "upload after AppConfig edit failed (see $WORK_TMP/upload-appcfg.log)"
-grep -qE "^Applied: 0 created, 1 updated, 0 deleted\\.$" "$WORK_TMP/upload-appcfg.log" \
+grep -qE "^Applied: 0 created, 1 updated, 0 emptied\\.$" "$WORK_TMP/upload-appcfg.log" \
   || fail "upload reconcile after AppConfig edit should report exactly 1 update (see $WORK_TMP/upload-appcfg.log)"
 
 # Verify the AppConfig Unit body on the server actually has the new
@@ -335,7 +339,7 @@ grep -q "~ $EDIT_SLUG" "$WORK_TMP/plan-edited.log" \
 # 11. upload reconcile — applies the diff inside a ChangeSet.
 log "install upload (reconcile Deployment marker) — applies 1 change"
 run upload-reconcile "$BIN" upload --work-dir "$WORK_TMP" --yes || fail "upload reconcile failed (see $WORK_TMP/upload-reconcile.log)"
-grep -q "^Applied: 0 created, 1 updated, 0 deleted\\.$" "$WORK_TMP/upload-reconcile.log" \
+grep -q "^Applied: 0 created, 1 updated, 0 emptied\\.$" "$WORK_TMP/upload-reconcile.log" \
   || fail "upload reconcile should apply 1 change (see $WORK_TMP/upload-reconcile.log)"
 grep -q "ChangeSet: " "$WORK_TMP/upload-reconcile.log" \
   || fail "upload reconcile should open and name a ChangeSet"
@@ -360,6 +364,60 @@ grep -q "^No changes\\.$" "$WORK_TMP/upload-converge-2.log" \
 if grep -q "ChangeSet: " "$WORK_TMP/upload-converge-2.log"; then
   fail "converge upload should not open a ChangeSet (no changes)"
 fi
+
+# 13. Resource deletion: drop a rendered manifest so its Unit falls out
+#     of the rendered set. Reconcile must EMPTY the Unit (via `cub unit
+#     update --merge-external-source` with empty content) — never `cub
+#     unit delete`. The Unit record, target binding, and metadata must
+#     survive so the next apply can remove the deployed resources. The
+#     ClusterRoleBinding is a safe leaf to drop (cluster-scoped, nothing
+#     Needs it).
+log "resource deletion: drop a rendered manifest, reconcile empties (not deletes) the Unit"
+DEL_FILE=$(ls "$WORK_TMP/out/manifests"/clusterrolebinding-*.yaml 2>/dev/null | head -1)
+[[ -n "$DEL_FILE" ]] || fail "no rendered ClusterRoleBinding manifest to delete"
+DEL_SLUG=$(basename "$DEL_FILE" .yaml)
+note "dropping rendered manifest for slug $DEL_SLUG"
+rm -f "$DEL_FILE"
+
+# Plan surfaces exactly one delete, naming the slug under "-".
+run plan-deleted "$BIN" plan --work-dir "$WORK_TMP" || fail "plan after manifest drop failed (see $WORK_TMP/plan-deleted.log)"
+grep -q "^Plan: 0 to add, 0 to change, 1 to delete\\.$" "$WORK_TMP/plan-deleted.log" \
+  || fail "plan after manifest drop should report exactly 1 delete (see $WORK_TMP/plan-deleted.log)"
+grep -q "^  - $DEL_SLUG$" "$WORK_TMP/plan-deleted.log" \
+  || fail "plan after manifest drop should list '  - $DEL_SLUG' (see $WORK_TMP/plan-deleted.log)"
+
+# 13a. DestroyGate refusal: a Unit guarded by a DestroyGate must NOT be
+#      emptied (emptying + apply would destroy its deployed resources).
+log "DestroyGate refusal: gated Unit must not be emptied"
+cub unit update --patch --space "$SPACE" --destroy-gate "installer-e2e" "$DEL_SLUG" >/dev/null \
+  || fail "failed to set DestroyGate on $DEL_SLUG"
+if run upload-gated "$BIN" upload --work-dir "$WORK_TMP" --yes; then
+  fail "upload must refuse to empty $DEL_SLUG while it carries a DestroyGate (see $WORK_TMP/upload-gated.log)"
+fi
+grep -q "guarded by DestroyGates" "$WORK_TMP/upload-gated.log" \
+  || fail "upload refusal should mention DestroyGates (see $WORK_TMP/upload-gated.log)"
+cub unit data --space "$SPACE" "$DEL_SLUG" 2>/dev/null | grep -q "kind: ClusterRoleBinding" \
+  || fail "gated Unit $DEL_SLUG must remain intact (still a ClusterRoleBinding) after refusal"
+note "gated Unit $DEL_SLUG left untouched"
+
+# 13b. Clear the gate, reconcile for real: the Unit is emptied, not deleted.
+log "clear the gate, reconcile empties the Unit"
+cub unit update --patch --space "$SPACE" --destroy-gate "installer-e2e=-" "$DEL_SLUG" >/dev/null \
+  || fail "failed to remove DestroyGate from $DEL_SLUG"
+run upload-emptied "$BIN" upload --work-dir "$WORK_TMP" --yes || fail "upload empty failed (see $WORK_TMP/upload-emptied.log)"
+grep -qE "^Applied: 0 created, 0 updated, 1 emptied\\.$" "$WORK_TMP/upload-emptied.log" \
+  || fail "upload should report exactly 1 emptied (see $WORK_TMP/upload-emptied.log)"
+grep -q "Emptied $SPACE/$DEL_SLUG" "$WORK_TMP/upload-emptied.log" \
+  || fail "upload should print 'Emptied $SPACE/$DEL_SLUG' (see $WORK_TMP/upload-emptied.log)"
+
+# The Unit record must still exist (no cub unit delete) and its Data must
+# no longer contain the ClusterRoleBinding.
+cub unit get --space "$SPACE" "$DEL_SLUG" >/dev/null 2>&1 \
+  || fail "emptied Unit $DEL_SLUG must still exist — upload must never run 'cub unit delete'"
+if cub unit data --space "$SPACE" "$DEL_SLUG" 2>/dev/null | grep -q "kind: ClusterRoleBinding"; then
+  fail "emptied Unit $DEL_SLUG should no longer contain the ClusterRoleBinding"
+fi
+note "Unit $DEL_SLUG still exists and no longer contains the ClusterRoleBinding"
 
 log "summary"
 note "Space:           $SPACE"


### PR DESCRIPTION
Two day-2 changes for the installer.

## 1. Reconcile empties Units instead of deleting them

When a Unit owned by the package drops out of the rendered output, `install upload` previously ran `cub unit delete`. That orphaned any resources the Unit had deployed (they must be destroyed via apply, which upload doesn't do), discarded post-install edits, and failed outright on Units with DeleteGates.

It now **empties** the Unit via `cub unit update --merge-external-source` with empty content instead:

- The Unit record, its target binding, and any post-install edits survive; prior Data stays in revision history.
- The next `cub unit apply` removes the deployed resources through the normal deploy path (upload never destroys).
- Units guarded by a **DestroyGate** are refused up front (mirroring the `--yes` refusal), since emptying + apply would tear down their deployed resources.

The apply summary now reports `… emptied`. Added an e2e deletion + DestroyGate-refusal scenario to `upload-reconcile.sh` and a unit test for the refusal path.

## 2. kpt as an alternative for post-install changes

New `docs/kpt-guide.md` (linked from consumer-guide §3): manage the rendered manifests with [kpt](https://kpt.dev) as an alternative to `install upload` + `cub unit apply` — for kpt users, or for trying post-install changes without ConfigHub first. kpt's `resource-merge` on `kpt pkg update` preserves post-install edits across re-renders, the git-based analogue of `--merge-external-source`. The guide leads with a local-upstream workflow (the work-dir is its own kpt upstream — commits only, no pushes) and documents a real-remote setup as the portable option, plus `kpt live apply`, version tagging, and applying to the cluster.

Supporting changes for that workflow:

- **Render writes `out/.gitignore`** ignoring `secrets/`, so rendered Secrets are never committed.
- **`install --clean` preserves `out/manifests/Kptfile`** (via `render.CleanRenderedOutput`), so the base stays a valid kpt package across upgrades while still pruning resources dropped by a re-render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)