### PR TITLE
install upload: Space labels/annotations, well-known labels, and a TargetID round-trip

### DIFF
--- a/docs/consumer-guide.md
+++ b/docs/consumer-guide.md
@@ -252,7 +252,7 @@ Images in statusboard-prod (post-render):
 ```
 
 Plan computes the diff by listing existing Units (filtered by the
-`Component=<package>` label) and dry-running a merge of each
+`Package=<package>` label) and dry-running a merge of each
 rendered file against ConfigHub. Empty diff (after filtering
 ConfigHub bookkeeping) means no change.
 
@@ -315,12 +315,12 @@ To revert a reconcile upload, run the printed `cub unit update --patch
   upload` to repopulate it.
 
 If you need to roll back a multi-Unit change, this is where having
-the Component label pays off:
+the Package label pays off:
 
 ```bash
 # Delete every Unit this package owns in this Space.
 cub unit delete --space statusboard-prod \
-    --where "Labels.Component='statusboard'"
+    --where "Labels.Package='statusboard'"
 # Then re-render + re-upload from the work-dir's prior state.
 ```
 

--- a/docs/lifecycle-plan.md
+++ b/docs/lifecycle-plan.md
@@ -72,7 +72,7 @@ Goal: read-only diff of `<work-dir>/out` against ConfigHub.
 - New: `internal/diff/diff.go`
   - `Compute(ctx, pkg upload.Package) (Plan, error)`.
   - Lists current Units via
-    `cub unit list --space <slug> --where "Labels.Component='<pkg.Name>'" -o json`
+    `cub unit list --space <slug> --where "Labels.Package='<pkg.Name>'" -o json`
     to bucket adds vs updates (the dry-run path errors on a
     non-existent Unit, so the list step is required).
   - For each intersection slug, runs
@@ -103,7 +103,7 @@ Goal: execute the Phase B plan inside a ChangeSet.
   formats the user-facing revert hint.
 - New: `internal/diff/apply.go` — `Apply(ctx, plan Plan, opts
   ApplyOptions)`.
-  - `cub unit create --label Component=<pkg> --merge-external-source ...`
+  - `cub unit create --label Package=<pkg> --merge-external-source ...`
     for adds.
   - `cub unit update --merge-external-source --changeset <slug> ...`
     for updates (no `--dry-run`).
@@ -237,7 +237,7 @@ remediation. We do not silently switch contexts.
 
 Existing work-dirs without `out/spec/upload.yaml` fall through to local
 spec on wizard re-entry — no migration needed. Existing Units without
-the `Component=<pkg>` label are not visible to plan/update; once the
+the `Package=<pkg>` label are not visible to plan/update; once the
 prior task ships and the Space is re-uploaded with the label, they
 participate normally. (We could add an
 `installer migrate-labels <work-dir>` one-shot for users who do not want

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -437,7 +437,7 @@ base kustomization.yaml has no `images:` block; declare one to use
 - **Reverting an `install upload` reconcile**:
   ```bash
   cub unit update --restore Before:ChangeSet:<slug> \
-      --where "Labels.Component='hello-app'"
+      --where "Labels.Package='hello-app'"
   ```
   Reverts updates only. Creates and deletes from that upload are not
   reverted by ChangeSet restore — to undo a create, delete the Unit; to

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -23,15 +24,23 @@ import (
 
 func newUploadCmd() *cobra.Command {
 	var (
-		workDir       string
-		space         string
-		spacePattern  string
-		target        string
-		annotations   []string
-		labels        []string
-		retry         bool
-		yes           bool
-		changeSetSlug string
+		workDir          string
+		space            string
+		spacePattern     string
+		target           string
+		unitAnnotations  []string
+		unitLabels       []string
+		spaceAnnotations []string
+		spaceLabels      []string
+		component        string
+		layer            string
+		environment      string
+		region           string
+		owner            string
+		variant          string
+		retry            bool
+		yes              bool
+		changeSetSlug    string
 	)
 	cmd := &cobra.Command{
 		Use:   "upload",
@@ -53,13 +62,13 @@ Reconcile (upload.yaml exists):
   Re-computes the same plan install plan would produce. Opens one
   ChangeSet per Space, runs cub unit update --merge-external-source
   --changeset for updates, cub unit create for adds (with --label
-  Component=<pkg>), cub unit delete for deletes (gated on --yes or
-  per-delete confirmation). Re-runs intra-Space link inference; existing
+  Package=<pkg>), cub unit update with no data for deletes (gated on --yes
+  or per-delete confirmation). Re-runs intra-Space link inference; existing
   links pointing at still-present Units are left as-is. Refreshes the
   installer-record Unit so subsequent setups re-enter from up-to-date
   state. A reconcile against an unchanged work-dir is a no-op (no
   ChangeSet opened). Only updates are revertable via
-  cub unit update --restore Before:ChangeSet:<slug>; creates and deletes
+  cub unit update --restore Before:ChangeSet:<slug>; creates
   from a reconcile require manual undo (delete the Unit / re-render +
   re-upload).
 
@@ -70,29 +79,66 @@ Space selection (first upload only):
                                     .Variant). Default '{{.PackageName}}'.
   On reconcile, --space / --space-pattern are read from upload.yaml.
 
-Every Unit and Link upload creates carries a "Component" label whose
+Every Unit and Link upload creates carries a "Package" label whose
 value is the package name (the parent's name for cross-Space dep
 links), so all entities belonging to one package can be queried
-together.
+together and Units the operator added to the Space themselves are left
+alone. Units also get a "PackageVersion" annotation, refreshed on
+update, so you can see which package version last touched each Unit.
+
+Spaces carry the well-known capitalized labels set via --component
+(default: the package name), --layer, --environment, --region, --owner,
+and --variant, plus any --space-label / --space-annotation pairs. When
+--target is given its resolved TargetID is recorded as the Space's
+"TargetID" annotation; on a later reconcile --target may be omitted and
+is read back from there. None of this Space/Unit metadata is stored in
+upload.yaml — ConfigHub is its source of truth; upload.yaml only needs
+enough to find the Space(s).
 
 Files in <work-dir>/out/secrets/ are never uploaded — they hold rendered
 Secret resources flagged as sensitive by render. Apply them out-of-band
 or stage them however your environment manages secrets.
 
---target, --annotation, and --label are forwarded to ` + "`cub unit create`" + ` on
-adds (first upload OR reconcile). They do NOT apply to existing Units
+--target, --unit-annotation, and --unit-label are forwarded to ` + "`cub unit create`" + `
+on adds (first upload OR reconcile). They do NOT apply to existing Units
 on reconcile — that would clobber post-install metadata edits in
-ConfigHub.`,
+ConfigHub. The well-known Space labels and --space-* pairs are set on
+first upload and re-applied on a reconcile only when their flag is
+passed again.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if _, err := exec.LookPath("cub"); err != nil {
 				return fmt.Errorf("cub CLI not found on PATH: %w", err)
 			}
-			if err := validateKeyValueFlags("--annotation", annotations); err != nil {
+			if err := validateKeyValueFlags("--unit-annotation", unitAnnotations); err != nil {
 				return err
 			}
-			if err := validateKeyValueFlags("--label", labels); err != nil {
+			if err := validateKeyValueFlags("--unit-label", unitLabels); err != nil {
 				return err
+			}
+			if err := validateSpaceLabelFlags(spaceLabels); err != nil {
+				return err
+			}
+			if err := validateSpaceAnnotationFlags(spaceAnnotations); err != nil {
+				return err
+			}
+			meta := spaceMetaInput{
+				component:      component,
+				layer:          layer,
+				environment:    environment,
+				region:         region,
+				owner:          owner,
+				variant:        variant,
+				labels:         spaceLabels,
+				annotations:    spaceAnnotations,
+				target:         target,
+				componentSet:   cmd.Flags().Changed("component"),
+				layerSet:       cmd.Flags().Changed("layer"),
+				environmentSet: cmd.Flags().Changed("environment"),
+				regionSet:      cmd.Flags().Changed("region"),
+				ownerSet:       cmd.Flags().Changed("owner"),
+				variantSet:     cmd.Flags().Changed("variant"),
+				targetSet:      cmd.Flags().Changed("target"),
 			}
 			absWork, err := filepath.Abs(workDir)
 			if err != nil {
@@ -113,7 +159,7 @@ ConfigHub.`,
 			// this work-dir has already been pushed to ConfigHub once.
 			uploadDocPath := filepath.Join(absWork, "out", "spec", upload.UploadDocFilename)
 			if _, statErr := os.Stat(uploadDocPath); statErr == nil {
-				return runUploadReconcile(ctx, absWork, loaded, target, annotations, labels, yes, changeSetSlug, space, spacePattern)
+				return runUploadReconcile(ctx, absWork, loaded, meta, unitAnnotations, unitLabels, yes, changeSetSlug, space, spacePattern)
 			} else if !os.IsNotExist(statErr) {
 				return statErr
 			}
@@ -180,7 +226,7 @@ ConfigHub.`,
 			}
 
 			for _, pkg := range packages {
-				if err := uploadOnePackage(pkg, target, annotations, labels, retry); err != nil {
+				if err := uploadOnePackage(ctx, pkg, meta, unitAnnotations, unitLabels, retry); err != nil {
 					return err
 				}
 			}
@@ -204,9 +250,17 @@ ConfigHub.`,
 	}
 	cmd.Flags().StringVar(&space, "space", "", "destination ConfigHub Space slug (single-package mode)")
 	cmd.Flags().StringVar(&spacePattern, "space-pattern", "", "Go template for the Space slug per package (vars: .PackageName, .PackageVersion, .Variant). Default: '{{.PackageName}}'.")
-	cmd.Flags().StringVar(&target, "target", "", "target slug; forwarded to cub unit create --target on every rendered Unit (not the installer-record Unit)")
-	cmd.Flags().StringSliceVar(&annotations, "annotation", nil, "annotation key=value to set on every rendered Unit (repeatable)")
-	cmd.Flags().StringSliceVar(&labels, "label", nil, "label key=value to set on every rendered Unit (repeatable)")
+	cmd.Flags().StringVar(&target, "target", "", "target ref (<target-slug>, <space-slug>/<target-slug>, or UUID); forwarded to cub unit create --target on every rendered Unit (not the installer-record Unit). Its resolved TargetID is recorded as the Space's \"TargetID\" annotation; on a later reconcile --target may be omitted and is read back from there.")
+	cmd.Flags().StringSliceVar(&unitAnnotations, "unit-annotation", nil, "annotation key=value to set on every rendered Unit (repeatable)")
+	cmd.Flags().StringSliceVar(&unitLabels, "unit-label", nil, "label key=value to set on every rendered Unit (repeatable)")
+	cmd.Flags().StringSliceVar(&spaceAnnotations, "space-annotation", nil, "annotation key=value to set on the Space(s) (repeatable); \"TargetID\" is reserved (use --target)")
+	cmd.Flags().StringSliceVar(&spaceLabels, "space-label", nil, "label key=value to set on the Space(s) (repeatable); the well-known labels Component/Layer/Environment/Owner/Variant are reserved (use their dedicated flags)")
+	cmd.Flags().StringVar(&component, "component", "", "value for the well-known \"Component\" Space label (default: the package name)")
+	cmd.Flags().StringVar(&layer, "layer", "", "value for the well-known \"Layer\" Space label (e.g. App)")
+	cmd.Flags().StringVar(&environment, "environment", "", "value for the well-known \"Environment\" Space label (e.g. Prod)")
+	cmd.Flags().StringVar(&region, "region", "", "value for the well-known \"Region\" Space label (e.g. us-east1)")
+	cmd.Flags().StringVar(&owner, "owner", "", "value for the well-known \"Owner\" Space label (e.g. Engineering)")
+	cmd.Flags().StringVar(&variant, "variant", "", "value for the well-known \"Variant\" Space label (e.g. Base)")
 	cmd.Flags().StringVar(&workDir, "work-dir", ".", "working directory")
 	cmd.Flags().BoolVar(&retry, "retry", false, "first upload only: tolerate Units, Invocations, and Links that already exist so a partially-failed first upload can be retried. Space auto-create is always idempotent — this flag only affects content. Ignored on reconcile (reconcile is always idempotent).")
 	cmd.Flags().BoolVar(&yes, "yes", false, "reconcile only: skip confirmation for deletes (required when stdin is not a TTY and the plan contains deletes)")
@@ -218,7 +272,7 @@ ConfigHub.`,
 // reads upload.yaml, computes a diff against ConfigHub, opens a
 // ChangeSet, and applies. Same semantics as the previous standalone
 // `install update` command.
-func runUploadReconcile(ctx context.Context, workDir string, loaded *ipkg.Loaded, target string, annotations, labels []string, yes bool, changeSetSlug, spaceFlag, spacePatternFlag string) error {
+func runUploadReconcile(ctx context.Context, workDir string, loaded *ipkg.Loaded, meta spaceMetaInput, unitAnnotations, unitLabels []string, yes bool, changeSetSlug, spaceFlag, spacePatternFlag string) error {
 	if spaceFlag != "" || spacePatternFlag != "" {
 		fmt.Fprintln(os.Stderr, "note: --space / --space-pattern are read from upload.yaml on reconcile; flag value ignored")
 	}
@@ -247,6 +301,46 @@ func runUploadReconcile(ctx context.Context, workDir string, loaded *ipkg.Loaded
 		return err
 	}
 
+	// Reconcile Space metadata and resolve the per-Space target up front,
+	// before diffing, so a metadata-only reconcile (no Unit changes) still
+	// updates the Space and so any adds bind to the right target. The
+	// well-known labels / --space-* pairs are applied only when re-passed
+	// ("set once, update if re-passed"); --target, when omitted, is read
+	// back from each Space's recorded TargetID annotation.
+	targets := map[string]string{}
+	for _, pkg := range packages {
+		var targetID, effective string
+		switch {
+		case meta.targetSet && meta.target != "":
+			effective = meta.target
+			id, err := resolveTargetID(ctx, pkg.SpaceSlug, meta.target)
+			if err != nil {
+				return err
+			}
+			targetID = id
+		case !meta.targetSet:
+			// Read the recorded TargetID (a UUID) and resolve it to a
+			// <space>/<slug> reference so adds can bind even when the
+			// Target lives in another Space (a bare UUID --target is
+			// resolved scoped to the Unit's Space and would 404).
+			id, err := readSpaceTargetID(ctx, pkg.SpaceSlug)
+			if err != nil {
+				return err
+			}
+			if id != "" {
+				ref, err := targetRefFromID(ctx, id)
+				if err != nil {
+					return err
+				}
+				effective = ref
+			}
+		}
+		targets[pkg.SpaceSlug] = effective
+		if err := applySpaceMeta(ctx, pkg.SpaceSlug, meta.labelArgs(pkg.Name, false), meta.annotationArgs(targetID)); err != nil {
+			return err
+		}
+	}
+
 	plan, err := diff.Compute(ctx, packages)
 	if err != nil {
 		return err
@@ -264,9 +358,9 @@ func runUploadReconcile(ctx context.Context, workDir string, loaded *ipkg.Loaded
 		Yes:                  yes,
 		ChangeSetSlug:        changeSetSlug,
 		ChangeSetDescription: fmt.Sprintf("install upload (reconcile) from %s@%s", loaded.Package.Metadata.Name, loaded.Package.Metadata.Version),
-		Target:               target,
-		Annotations:          annotations,
-		Labels:               labels,
+		Targets:              targets,
+		Annotations:          unitAnnotations,
+		Labels:               unitLabels,
 		PostSpaceHook:        refreshInstallerRecordHook(packages),
 	})
 	if err != nil {
@@ -302,15 +396,34 @@ func refreshInstallerRecordHook(packages []upload.Package) diff.PackageRefresher
 	}
 }
 
-// uploadOnePackage creates pkg.SpaceSlug if missing, uploads each rendered
-// manifest as a Unit (with --target/--annotation/--label applied), splits
-// AppConfig-annotated ConfigMaps into AppConfig Unit + render-configmap
-// Invocation + placeholder + Upsert link, creates the untargeted
-// installer-record Unit, and runs the intra-Space link inference.
-func uploadOnePackage(pkg upload.Package, target string, annotations, labels []string, retry bool) error {
+// uploadOnePackage creates pkg.SpaceSlug if missing, stamps the Space's
+// well-known labels + operator metadata + TargetID annotation, uploads
+// each rendered manifest as a Unit (with --target/--unit-annotation/
+// --unit-label plus the Package label and PackageVersion annotation),
+// splits AppConfig-annotated ConfigMaps into AppConfig Unit +
+// render-configmap Invocation + placeholder + Upsert link, creates the
+// untargeted installer-record Unit, and runs the intra-Space link
+// inference.
+func uploadOnePackage(ctx context.Context, pkg upload.Package, meta spaceMetaInput, unitAnnotations, unitLabels []string, retry bool) error {
 	fmt.Printf("== %s@%s → Space %s ==\n", pkg.Name, pkg.Version, pkg.SpaceSlug)
 
 	if err := ensureSpace(pkg.SpaceSlug); err != nil {
+		return err
+	}
+
+	// Stamp the Space's well-known labels and operator-supplied metadata.
+	// Component defaults to the package name on a first upload. When
+	// --target is given, record its resolved TargetID so later reconciles
+	// can omit --target and read it back from here.
+	var targetID string
+	if meta.target != "" {
+		id, err := resolveTargetID(ctx, pkg.SpaceSlug, meta.target)
+		if err != nil {
+			return err
+		}
+		targetID = id
+	}
+	if err := applySpaceMeta(ctx, pkg.SpaceSlug, meta.labelArgs(pkg.Name, true), meta.annotationArgs(targetID)); err != nil {
 		return err
 	}
 
@@ -327,7 +440,8 @@ func uploadOnePackage(pkg upload.Package, target string, annotations, labels []s
 	}
 	namespace := inputs.Spec.Namespace
 
-	componentLabel := "Component=" + pkg.Name
+	packageLabel := "Package=" + pkg.Name
+	packageVersionAnnotation := "PackageVersion=" + pkg.Version
 
 	entries, err := os.ReadDir(pkg.ManifestsDir)
 	if err != nil {
@@ -344,7 +458,7 @@ func uploadOnePackage(pkg upload.Package, target string, annotations, labels []s
 			return err
 		}
 		if appCfg != nil {
-			if err := uploadAppConfigManifest(pkg, appCfg, target, componentLabel, namespace, annotations, labels, retry); err != nil {
+			if err := uploadAppConfigManifest(pkg, appCfg, meta.target, packageLabel, packageVersionAnnotation, namespace, unitAnnotations, unitLabels, retry); err != nil {
 				return err
 			}
 			continue
@@ -354,14 +468,15 @@ func uploadOnePackage(pkg upload.Package, target string, annotations, labels []s
 		if retry {
 			cubArgs = append(cubArgs, "--allow-exists")
 		}
-		cubArgs = append(cubArgs, "--space", pkg.SpaceSlug, "--merge-external-source", e.Name(), "--label", componentLabel)
-		if target != "" {
-			cubArgs = append(cubArgs, "--target", target)
+		cubArgs = append(cubArgs, "--space", pkg.SpaceSlug, "--merge-external-source", e.Name(),
+			"--label", packageLabel, "--annotation", packageVersionAnnotation)
+		if meta.target != "" {
+			cubArgs = append(cubArgs, "--target", meta.target)
 		}
-		for _, a := range annotations {
+		for _, a := range unitAnnotations {
 			cubArgs = append(cubArgs, "--annotation", a)
 		}
-		for _, l := range labels {
+		for _, l := range unitLabels {
 			cubArgs = append(cubArgs, "--label", l)
 		}
 		cubArgs = append(cubArgs, slug, path)
@@ -378,7 +493,7 @@ func uploadOnePackage(pkg upload.Package, target string, annotations, labels []s
 	}
 	renderedSecrets := loadRenderedSecretsFromDir(pkg.SecretsDir)
 	skipUnmatched := skipKeysForRenderedSecrets(renderedSecrets)
-	if err := upload.ReconcileLinks(context.Background(), pkg.SpaceSlug, pkg.Name, skipUnmatched); err != nil {
+	if err := upload.ReconcileLinks(ctx, pkg.SpaceSlug, pkg.Name, skipUnmatched); err != nil {
 		return err
 	}
 	reportSecretsNotUploaded(pkg, renderedSecrets)
@@ -508,7 +623,7 @@ func reportSecretsNotUploaded(pkg upload.Package, secrets []renderedSecret) {
 // Idempotent via --allow-exists on the Invocation, Units, and link;
 // re-running upload after re-rendering refreshes the AppConfig Unit body
 // via the --merge-external-source mechanism the regular path uses.
-func uploadAppConfigManifest(pkg upload.Package, appCfg *upload.AppConfigManifest, target, componentLabel, namespace string, annotations, labels []string, retry bool) error {
+func uploadAppConfigManifest(pkg upload.Package, appCfg *upload.AppConfigManifest, target, packageLabel, packageVersionAnnotation, namespace string, unitAnnotations, unitLabels []string, retry bool) error {
 	fmt.Printf("AppConfig: %s (toolchain=%s, mode=%s)\n", appCfg.CarrierName, appCfg.Toolchain, appCfg.Mode)
 
 	// 1. Stage the extracted raw config in a temp file so cub unit
@@ -533,7 +648,7 @@ func uploadAppConfigManifest(pkg upload.Package, appCfg *upload.AppConfigManifes
 	}
 	invArgs = append(invArgs,
 		"--space", pkg.SpaceSlug,
-		"--label", componentLabel,
+		"--label", packageLabel,
 		appCfg.InvocationSlug(), appCfg.Toolchain,
 		"--", "render-configmap",
 	)
@@ -554,12 +669,13 @@ func uploadAppConfigManifest(pkg upload.Package, appCfg *upload.AppConfigManifes
 		"--space", pkg.SpaceSlug,
 		"--toolchain", appCfg.Toolchain,
 		"--merge-external-source", filepath.Base(appCfg.ManifestPath),
-		"--label", componentLabel,
+		"--label", packageLabel,
+		"--annotation", packageVersionAnnotation,
 	)
-	for _, a := range annotations {
+	for _, a := range unitAnnotations {
 		unitArgs = append(unitArgs, "--annotation", a)
 	}
-	for _, l := range labels {
+	for _, l := range unitLabels {
 		unitArgs = append(unitArgs, "--label", l)
 	}
 	unitArgs = append(unitArgs, appCfg.UnitSlug(), tmp.Name())
@@ -579,15 +695,16 @@ func uploadAppConfigManifest(pkg upload.Package, appCfg *upload.AppConfigManifes
 	placeholderArgs = append(placeholderArgs,
 		"--space", pkg.SpaceSlug,
 		"--toolchain", "Kubernetes/YAML",
-		"--label", componentLabel,
+		"--label", packageLabel,
+		"--annotation", packageVersionAnnotation,
 	)
 	if target != "" {
 		placeholderArgs = append(placeholderArgs, "--target", target)
 	}
-	for _, a := range annotations {
+	for _, a := range unitAnnotations {
 		placeholderArgs = append(placeholderArgs, "--annotation", a)
 	}
-	for _, l := range labels {
+	for _, l := range unitLabels {
 		placeholderArgs = append(placeholderArgs, "--label", l)
 	}
 	placeholderArgs = append(placeholderArgs, appCfg.PlaceholderSlug())
@@ -612,7 +729,7 @@ func uploadAppConfigManifest(pkg upload.Package, appCfg *upload.AppConfigManifes
 		"--space", pkg.SpaceSlug,
 		"--update-type", "Upsert", "--auto-update",
 		"--transform-invocation", pkg.SpaceSlug+"/"+appCfg.InvocationSlug(),
-		"--label", componentLabel,
+		"--label", packageLabel,
 		"-", appCfg.PlaceholderSlug(), appCfg.UnitSlug(),
 	)
 	lcmd := exec.Command("cub", linkArgs...)
@@ -701,7 +818,8 @@ func createInstallerRecordUnit(pkg upload.Package, retry bool) error {
 		"--space", pkg.SpaceSlug,
 		"--annotation", "installer.confighub.com/role=installer-record",
 		"--annotation", "installer.confighub.com/package="+pkg.Name,
-		"--label", "Component="+pkg.Name,
+		"--annotation", "PackageVersion="+pkg.Version,
+		"--label", "Package="+pkg.Name,
 		upload.InstallerRecordSlug, tmp.Name(),
 	)
 	ccmd := exec.Command("cub", args...)
@@ -722,7 +840,7 @@ func createCrossSpaceLink(l upload.CrossSpaceLink, retry bool) error {
 	}
 	args = append(args,
 		"--space", l.FromSpace, "--quiet",
-		"--label", "Component="+l.Component,
+		"--label", "Package="+l.Package,
 		l.Slug, l.FromUnit, l.ToUnit, l.ToSpace,
 	)
 	ccmd := exec.Command("cub", args...)
@@ -742,4 +860,211 @@ func validateKeyValueFlags(flag string, vals []string) error {
 		}
 	}
 	return nil
+}
+
+// reservedSpaceLabelKeys maps each well-known Space label to the flag
+// that owns it, so --space-label can reject attempts to set them
+// directly.
+var reservedSpaceLabelKeys = map[string]string{
+	"Component":   "--component",
+	"Layer":       "--layer",
+	"Environment": "--environment",
+	"Region":      "--region",
+	"Owner":       "--owner",
+	"Variant":     "--variant",
+}
+
+func validateSpaceLabelFlags(vals []string) error {
+	for _, v := range vals {
+		if !strings.Contains(v, "=") {
+			return fmt.Errorf("--space-label %q must be key=value", v)
+		}
+		key := strings.SplitN(v, "=", 2)[0]
+		if flag, ok := reservedSpaceLabelKeys[key]; ok {
+			return fmt.Errorf("--space-label %q: %q is a reserved well-known label; set it with %s", v, key, flag)
+		}
+	}
+	return nil
+}
+
+func validateSpaceAnnotationFlags(vals []string) error {
+	for _, v := range vals {
+		if !strings.Contains(v, "=") {
+			return fmt.Errorf("--space-annotation %q must be key=value", v)
+		}
+		if key := strings.SplitN(v, "=", 2)[0]; key == "TargetID" {
+			return fmt.Errorf("--space-annotation %q: %q is reserved; set it with --target", v, key)
+		}
+	}
+	return nil
+}
+
+// spaceMetaInput carries the Space-level metadata flags for one upload
+// run: the well-known capitalized labels (Component/Layer/Environment/
+// Owner/Variant), the free-form --space-label / --space-annotation
+// pairs, and the --target whose resolved TargetID is recorded as a Space
+// annotation. None of this is persisted in upload.yaml — ConfigHub is
+// the source of truth for it; the installer only needs enough to find
+// the Space(s) again.
+type spaceMetaInput struct {
+	component   string
+	layer       string
+	environment string
+	region      string
+	owner       string
+	variant     string
+	labels      []string // --space-label key=value pairs
+	annotations []string // --space-annotation key=value pairs
+	target      string   // --target ref (slug, space/slug, or UUID)
+
+	componentSet   bool
+	layerSet       bool
+	environmentSet bool
+	regionSet      bool
+	ownerSet       bool
+	variantSet     bool
+	targetSet      bool
+}
+
+// labelArgs returns the Space label key=value pairs to apply via
+// `cub space update --patch`. On a first upload (firstUpload=true) the
+// Component label is always included, defaulting to the package name
+// when --component was not given. On a reconcile the well-known labels
+// are included only when their flag was explicitly passed this run
+// ("set once, update if re-passed"); --space-label pairs are always
+// applied because their presence means the operator passed them.
+func (m spaceMetaInput) labelArgs(pkgName string, firstUpload bool) []string {
+	var out []string
+	if firstUpload || m.componentSet {
+		comp := m.component
+		if comp == "" {
+			comp = pkgName
+		}
+		out = append(out, "Component="+comp)
+	}
+	if m.layerSet {
+		out = append(out, "Layer="+m.layer)
+	}
+	if m.environmentSet {
+		out = append(out, "Environment="+m.environment)
+	}
+	if m.regionSet {
+		out = append(out, "Region="+m.region)
+	}
+	if m.ownerSet {
+		out = append(out, "Owner="+m.owner)
+	}
+	if m.variantSet {
+		out = append(out, "Variant="+m.variant)
+	}
+	out = append(out, m.labels...)
+	return out
+}
+
+// annotationArgs returns the Space annotation key=value pairs to apply.
+// targetID, when non-empty, is recorded as the well-known "TargetID"
+// annotation; the caller resolves it only when it intends to (re)write
+// it (a first upload with --target, or a reconcile that re-passed
+// --target).
+func (m spaceMetaInput) annotationArgs(targetID string) []string {
+	out := append([]string(nil), m.annotations...)
+	if targetID != "" {
+		out = append(out, "TargetID="+targetID)
+	}
+	return out
+}
+
+// applySpaceMeta patches the Space's labels and annotations in one
+// `cub space update --patch` call. Patch mode merges, so labels and
+// annotations the call does not name are preserved. A no-op when there
+// is nothing to set.
+func applySpaceMeta(ctx context.Context, space string, labelKVs, annotationKVs []string) error {
+	if len(labelKVs) == 0 && len(annotationKVs) == 0 {
+		return nil
+	}
+	args := []string{"space", "update", "--patch", "--quiet"}
+	for _, l := range labelKVs {
+		args = append(args, "--label", l)
+	}
+	for _, a := range annotationKVs {
+		args = append(args, "--annotation", a)
+	}
+	args = append(args, space)
+	ccmd := exec.Command("cub", args...)
+	ccmd.Stderr = os.Stderr
+	if err := ccmd.Run(); err != nil {
+		return fmt.Errorf("cub space update --patch %s: %w", space, err)
+	}
+	return nil
+}
+
+// resolveTargetID resolves a --target ref to its TargetID UUID. The ref
+// is interpreted the way `cub unit create --target` interprets it: a
+// bare slug resolves in the Unit's Space (unitSpace), a
+// <space-slug>/<target-slug> resolves the target in the named Space, and
+// a UUID resolves directly.
+func resolveTargetID(ctx context.Context, unitSpace, targetRef string) (string, error) {
+	lookupSpace, slug := unitSpace, targetRef
+	if i := strings.IndexByte(targetRef, '/'); i >= 0 {
+		lookupSpace, slug = targetRef[:i], targetRef[i+1:]
+	}
+	var stdout, stderr bytes.Buffer
+	ccmd := exec.CommandContext(ctx, "cub", "target", "get",
+		"--space", lookupSpace, "-o", "jq=.Target.TargetID", slug)
+	ccmd.Stdout = &stdout
+	ccmd.Stderr = &stderr
+	if err := ccmd.Run(); err != nil {
+		return "", fmt.Errorf("cub target get %s in %s: %w\n%s", slug, lookupSpace, err, stderr.String())
+	}
+	id := strings.Trim(strings.TrimSpace(stdout.String()), "\"")
+	if id == "" || id == "null" {
+		return "", fmt.Errorf("target %q in space %s has no TargetID", slug, lookupSpace)
+	}
+	return id, nil
+}
+
+// targetRefFromID resolves a TargetID UUID to a
+// "<space-slug>/<target-slug>" reference that `cub unit create --target`
+// can bind. A bare UUID can't be passed straight through: cub resolves a
+// UUID --target scoped to the Unit's Space (parse.go), so a Target living
+// in another Space 404s. The reference form looks the Target up in its
+// own Space. Returns "" (no error) when no Target with that ID exists
+// (e.g. it was deleted since the annotation was written).
+func targetRefFromID(ctx context.Context, targetID string) (string, error) {
+	var stdout, stderr bytes.Buffer
+	ccmd := exec.CommandContext(ctx, "cub", "target", "list",
+		"--space", "*",
+		"--where", fmt.Sprintf("TargetID = '%s'", targetID),
+		"-o", `jq=.[] | .Space.Slug + "/" + .Target.Slug`)
+	ccmd.Stdout = &stdout
+	ccmd.Stderr = &stderr
+	if err := ccmd.Run(); err != nil {
+		return "", fmt.Errorf("cub target list (resolve TargetID %s): %w\n%s", targetID, err, stderr.String())
+	}
+	for _, line := range strings.Split(strings.TrimSpace(stdout.String()), "\n") {
+		ref := strings.Trim(strings.TrimSpace(line), "\"")
+		if ref != "" && ref != "/" {
+			return ref, nil
+		}
+	}
+	return "", nil
+}
+
+// readSpaceTargetID reads the "TargetID" annotation a prior upload
+// recorded on the Space. Returns "" (no error) when the Space has no
+// such annotation — e.g. it was uploaded without --target.
+func readSpaceTargetID(ctx context.Context, space string) (string, error) {
+	var stdout, stderr bytes.Buffer
+	ccmd := exec.CommandContext(ctx, "cub", "space", "get",
+		"-o", "jq=.Space.Annotations.TargetID", space)
+	ccmd.Stdout = &stdout
+	ccmd.Stderr = &stderr
+	if err := ccmd.Run(); err != nil {
+		return "", fmt.Errorf("cub space get %s: %w\n%s", space, err, stderr.String())
+	}
+	id := strings.Trim(strings.TrimSpace(stdout.String()), "\"")
+	if id == "null" {
+		return "", nil
+	}
+	return id, nil
 }

--- a/internal/cli/upload_meta_test.go
+++ b/internal/cli/upload_meta_test.go
@@ -1,0 +1,91 @@
+package cli
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestLabelArgs_FirstUploadDefaultsComponent verifies that on a first
+// upload the Component label is always emitted, defaulting to the package
+// name, and that the explicitly-set well-known labels and --space-label
+// pairs follow.
+func TestLabelArgs_FirstUploadDefaultsComponent(t *testing.T) {
+	m := spaceMetaInput{
+		layer:      "App",
+		layerSet:   true,
+		labels:     []string{"team=payments"},
+		variantSet: false, // not passed → omitted
+	}
+	got := m.labelArgs("hello-app", true)
+	want := []string{"Component=hello-app", "Layer=App", "team=payments"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("labelArgs first upload = %v, want %v", got, want)
+	}
+}
+
+// TestLabelArgs_ComponentOverride verifies --component overrides the
+// default Component value on a first upload.
+func TestLabelArgs_ComponentOverride(t *testing.T) {
+	m := spaceMetaInput{component: "frontend", componentSet: true}
+	got := m.labelArgs("hello-app", true)
+	want := []string{"Component=frontend"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("labelArgs = %v, want %v", got, want)
+	}
+}
+
+// TestLabelArgs_ReconcileSetOnce verifies that on a reconcile the
+// well-known labels are emitted only when their flag was passed this run
+// ("set once, update if re-passed"); Component is NOT re-emitted from its
+// default.
+func TestLabelArgs_ReconcileSetOnce(t *testing.T) {
+	// Nothing passed → no labels (so applySpaceMeta is a no-op and we
+	// never clobber the Space's existing well-known labels).
+	if got := (spaceMetaInput{}).labelArgs("hello-app", false); len(got) != 0 {
+		t.Fatalf("reconcile with no flags = %v, want empty", got)
+	}
+	// Only --environment re-passed → only Environment patched.
+	m := spaceMetaInput{environment: "Prod", environmentSet: true}
+	got := m.labelArgs("hello-app", false)
+	want := []string{"Environment=Prod"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("reconcile labelArgs = %v, want %v", got, want)
+	}
+}
+
+// TestAnnotationArgs_TargetID verifies the TargetID annotation rides
+// alongside --space-annotation pairs only when a resolved id is given.
+func TestAnnotationArgs_TargetID(t *testing.T) {
+	m := spaceMetaInput{annotations: []string{"note=hi"}}
+	if got := m.annotationArgs(""); !slices.Equal(got, []string{"note=hi"}) {
+		t.Fatalf("annotationArgs without id = %v", got)
+	}
+	got := m.annotationArgs("11111111-1111-1111-1111-111111111111")
+	want := []string{"note=hi", "TargetID=11111111-1111-1111-1111-111111111111"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("annotationArgs with id = %v, want %v", got, want)
+	}
+}
+
+func TestValidateSpaceLabelFlags_ReservedKeys(t *testing.T) {
+	for _, kv := range []string{"Component=x", "Layer=App", "Environment=Prod", "Region=us-east1", "Owner=Eng", "Variant=Base"} {
+		if err := validateSpaceLabelFlags([]string{kv}); err == nil {
+			t.Errorf("--space-label %q should be rejected as reserved", kv)
+		}
+	}
+	if err := validateSpaceLabelFlags([]string{"team=payments"}); err != nil {
+		t.Errorf("non-reserved --space-label should be accepted: %v", err)
+	}
+	if err := validateSpaceLabelFlags([]string{"missing-eq"}); err == nil {
+		t.Errorf("--space-label without '=' should be rejected")
+	}
+}
+
+func TestValidateSpaceAnnotationFlags_ReservedTargetID(t *testing.T) {
+	if err := validateSpaceAnnotationFlags([]string{"TargetID=abc"}); err == nil {
+		t.Errorf("--space-annotation TargetID should be rejected as reserved")
+	}
+	if err := validateSpaceAnnotationFlags([]string{"note=hi"}); err != nil {
+		t.Errorf("non-reserved --space-annotation should be accepted: %v", err)
+	}
+}

--- a/internal/diff/apply.go
+++ b/internal/diff/apply.go
@@ -36,14 +36,21 @@ type ApplyOptions struct {
 	// opened ChangeSet. Defaults to a generic "install update" line
 	// when empty.
 	ChangeSetDescription string
-	// Target is forwarded to `cub unit create --target` for adds. Empty
-	// means no target binding (matching upload's default).
-	Target string
-	// Annotations and Labels are forwarded to `cub unit create` for
-	// adds. They are NOT applied to existing Units on update — that
-	// would clobber user post-install metadata edits, which Principle 1
+	// Targets maps a Space slug to the target ref forwarded to
+	// `cub unit create --target` for adds in that Space. The ref is the
+	// explicit --target (slug, space/slug, or UUID) when the operator
+	// passed one, otherwise the Space's recorded TargetID annotation
+	// (resolved by the CLI before Apply runs). A missing or empty entry
+	// means no target binding.
+	Targets map[string]string
+	// Annotations and Labels are the operator's --unit-annotation /
+	// --unit-label values, forwarded to `cub unit create` for adds. They
+	// are NOT applied to existing Units on update — that would clobber
+	// user post-install metadata edits, which Principle 1
 	// (read-only-to-installer for post-install state in ConfigHub) does
-	// not allow.
+	// not allow. (The PackageVersion annotation is the one exception —
+	// see updateUnit — because it tracks which package version last
+	// touched each Unit, which the installer owns.)
 	Annotations []string
 	Labels      []string
 	// Stdout/Stderr override the I/O streams; nil uses os.Stdout/Stderr.
@@ -122,13 +129,13 @@ func Apply(ctx context.Context, plan Plan, opts ApplyOptions) (ApplyResult, erro
 		}
 
 		for _, a := range sp.Adds {
-			if err := createUnit(ctx, sp.SpaceSlug, sp.Package, a, opts, stdout, stderr); err != nil {
+			if err := createUnit(ctx, sp.SpaceSlug, sp.Package, sp.PackageVersion, opts.Targets[sp.SpaceSlug], a, opts, stdout, stderr); err != nil {
 				return res, err
 			}
 			res.Created++
 		}
 		for _, u := range sp.Updates {
-			if err := updateUnit(ctx, sp.SpaceSlug, u, changeSetSlug, stdout, stderr); err != nil {
+			if err := updateUnit(ctx, sp.SpaceSlug, u, sp.PackageVersion, changeSetSlug, stdout, stderr); err != nil {
 				return res, err
 			}
 			res.Updated++
@@ -176,14 +183,15 @@ func descriptionOrDefault(d, pkg, ver string) string {
 	return fmt.Sprintf("install update from %s", pkg)
 }
 
-func createUnit(ctx context.Context, space, component string, a SlugDiff, opts ApplyOptions, stdout, stderr io.Writer) error {
+func createUnit(ctx context.Context, space, pkg, version, target string, a SlugDiff, opts ApplyOptions, stdout, stderr io.Writer) error {
 	args := []string{"unit", "create",
 		"--space", space,
 		"--merge-external-source", baseName(a.Path),
-		"--label", "Component=" + component,
+		"--label", "Package=" + pkg,
+		"--annotation", "PackageVersion=" + version,
 	}
-	if opts.Target != "" {
-		args = append(args, "--target", opts.Target)
+	if target != "" {
+		args = append(args, "--target", target)
 	}
 	for _, an := range opts.Annotations {
 		args = append(args, "--annotation", an)
@@ -201,7 +209,7 @@ func createUnit(ctx context.Context, space, component string, a SlugDiff, opts A
 	return nil
 }
 
-func updateUnit(ctx context.Context, space string, u SlugDiff, changeSetSlug string, stdout, stderr io.Writer) error {
+func updateUnit(ctx context.Context, space string, u SlugDiff, version, changeSetSlug string, stdout, stderr io.Writer) error {
 	// For AppConfig Units, the local source is the raw env content
 	// (not the rendered ConfigMap manifest). Stage it to a temp file
 	// so cub reads it from disk the same way it reads regular
@@ -240,6 +248,29 @@ func updateUnit(ctx context.Context, space string, u SlugDiff, changeSetSlug str
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("cub unit update %s in %s: %w", u.Slug, space, err)
 	}
+	// Stamp the package version that last touched this Unit. Done as a
+	// separate --patch so it merges into the Unit's annotations without
+	// disturbing the data merge above or any other annotation. This lets
+	// an operator see which Units a given upload changed (e.g. to triage
+	// a partial failure). Unlike --unit-annotation/--unit-label, this is
+	// installer-owned bookkeeping, so refreshing it on update is allowed.
+	// It must ride the same ChangeSet as the data update — while a Unit is
+	// attached to a ChangeSet the server rejects updates that omit it — so
+	// the version stamp reverts cleanly alongside the data change.
+	pvArgs := []string{"unit", "update",
+		"--space", space, "--patch", "--quiet",
+		"--annotation", "PackageVersion=" + version,
+	}
+	if changeSetSlug != "" {
+		pvArgs = append(pvArgs, "--changeset", changeSetSlug)
+	}
+	pvArgs = append(pvArgs, u.Slug)
+	pv := exec.CommandContext(ctx, "cub", pvArgs...)
+	pv.Stdout = stdout
+	pv.Stderr = stderr
+	if err := pv.Run(); err != nil {
+		return fmt.Errorf("cub unit update --patch PackageVersion on %s in %s: %w", u.Slug, space, err)
+	}
 	return nil
 }
 
@@ -264,7 +295,7 @@ func closeChangeSet(ctx context.Context, space string, updates []SlugDiff, stdou
 }
 
 // emptyUnits reconciles Units that exist in ConfigHub (under this
-// package's Component label) but no longer appear in the rendered
+// package's Package label) but no longer appear in the rendered
 // output. It does NOT run `cub unit delete`: upload reconciles Data
 // only, never the deployed live state. Deleting the Unit record would
 // orphan whatever it has deployed (the resources must be destroyed via

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -3,9 +3,10 @@
 // `install plan` (read-only) and `install update` (executes the
 // plan).
 //
-// The Component label written by upload (Component=<pkg.Name>) is what
+// The Package label written by upload (Package=<pkg.Name>) is what
 // scopes ownership: a Space may contain Units owned by other tools or
-// other packages, and we must never delete those.
+// other packages (or added by the operator before cloning the Space),
+// and we must never delete those.
 package diff
 
 import (
@@ -30,7 +31,7 @@ type Plan struct {
 
 // SpacePlan is the slice of a Plan that lives in one ConfigHub Space.
 type SpacePlan struct {
-	// Package is the source-package name (the value of the Component
+	// Package is the source-package name (the value of the Package
 	// label).
 	Package string
 	// PackageVersion is informational; rendered alongside Package.
@@ -44,7 +45,7 @@ type SpacePlan struct {
 	// reporting non-empty mutations. DiffText is the cub -o mutations
 	// output (ANSI-stripped).
 	Updates []SlugDiff
-	// Deletes are slugs that exist in ConfigHub (under the Component
+	// Deletes are slugs that exist in ConfigHub (under the Package
 	// label) but not in the rendered output. The installer-record Unit
 	// is excluded.
 	Deletes []SlugDiff
@@ -93,7 +94,7 @@ func (p Plan) Counts() (adds, updates, deletes int) {
 }
 
 // Compute walks the discovered packages and produces a Plan by
-// querying ConfigHub for the current Unit set under the Component
+// querying ConfigHub for the current Unit set under the Package
 // label, then running a dry-run merge-external-source per intersecting
 // slug. ConfigHub state is the single source of truth — local-only
 // state (e.g., a stale prior render) is not considered.
@@ -276,9 +277,9 @@ func listRenderedSlugs(dir string) (map[string]renderedItem, error) {
 }
 
 // listCurrentSlugs returns the slugs of Units in space scoped by the
-// Component=<pkg> label.
+// Package=<pkg> label.
 func listCurrentSlugs(ctx context.Context, space, pkg string) ([]string, error) {
-	where := fmt.Sprintf("Labels.Component='%s'", pkg)
+	where := fmt.Sprintf("Labels.Package='%s'", pkg)
 	cmd := exec.CommandContext(ctx, "cub", "unit", "list",
 		"--space", space, "--where", where,
 		"-o", "jq=.[].Unit.Slug")
@@ -401,10 +402,10 @@ func filterBookkeepingMutations(in string) string {
 		dropped bool
 	}
 	var (
-		out         []string
-		currentRes  []string
-		blocks      []block
-		flushRes    func()
+		out        []string
+		currentRes []string
+		blocks     []block
+		flushRes   func()
 	)
 	flushBlocks := func() {
 		for _, b := range blocks {

--- a/internal/upload/links.go
+++ b/internal/upload/links.go
@@ -20,7 +20,7 @@ import (
 // missing. Idempotent: existing links matching (FromUnit.Slug,
 // ToUnit.Slug, ToSpace == space) are left alone.
 //
-// Each new link is labeled Component=<component> so it can be
+// Each new link is labeled Package=<pkgName> so it can be
 // filtered alongside the package's units.
 //
 // skipUnmatched suppresses entries from the unmatched-references
@@ -35,7 +35,7 @@ import (
 // Used by `install upload` (after the per-package Unit creation
 // loop) and by `install update` (after Apply mutates the Unit set).
 // The two paths share an implementation so behavior cannot drift.
-func ReconcileLinks(ctx context.Context, space, component string, skipUnmatched map[string]struct{}) error {
+func ReconcileLinks(ctx context.Context, space, pkgName string, skipUnmatched map[string]struct{}) error {
 	resources, err := loadResources(ctx, space)
 	if err != nil {
 		return err
@@ -65,7 +65,7 @@ func ReconcileLinks(ctx context.Context, space, component string, skipUnmatched 
 		if _, exists := existing[key]; exists {
 			continue
 		}
-		if err := createLink(ctx, space, component, e); err != nil {
+		if err := createLink(ctx, space, pkgName, e); err != nil {
 			return err
 		}
 		existing[key] = struct{}{}
@@ -149,11 +149,11 @@ type UnmatchedReference struct {
 	TargetName string
 }
 
-func createLink(ctx context.Context, space, component string, e LinkEdge) error {
+func createLink(ctx context.Context, space, pkgName string, e LinkEdge) error {
 	slug := "-"
 	cmd := exec.CommandContext(ctx, "cub", "link", "create",
 		"--space", space, "--quiet",
-		"--label", "Component="+component,
+		"--label", "Package="+pkgName,
 		slug, e.FromUnit, e.ToUnit,
 	)
 	cmd.Stderr = os.Stderr

--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -5,9 +5,9 @@
 //
 // Phase 6 wires this up:
 //   - One Space per package (parent + each locked dep).
-//   - One untargeted installer-record Unit per Space, holding installer.yaml
-//     + every file in that package's out/<pkg>/spec/ (plus the lock for the
-//     parent).
+//   - One untargeted installer-record Unit per Space, holding
+//     installer.yaml plus every file in that package's out/<pkg>/spec/
+//     (plus the lock for the parent).
 //   - Cross-Space NeedsProvides links from the parent's record Unit to each
 //     dep's record Unit, derived from the lock.
 package upload
@@ -501,9 +501,9 @@ func WriteUploadDoc(ctx context.Context, workDir, spacePattern string, packages 
 type CrossSpaceLink struct {
 	// Slug is the link's deterministic slug, derived from the dep name.
 	Slug string
-	// Component is the parent package name, used as the value of the
-	// "Component" label on the created link.
-	Component string
+	// Package is the parent package name, used as the value of the
+	// "Package" label on the created link.
+	Package string
 	// FromSpace is the parent's Space; FromUnit is the parent's
 	// installer-record Unit slug.
 	FromSpace string
@@ -531,7 +531,7 @@ func PlanCrossSpaceLinks(packages []Package) []CrossSpaceLink {
 	for _, dep := range packages[1:] {
 		out = append(out, CrossSpaceLink{
 			Slug:      "dep-" + dep.LocalHandle,
-			Component: parent.Name,
+			Package:   parent.Name,
 			FromSpace: parent.SpaceSlug,
 			FromUnit:  InstallerRecordSlug,
 			ToSpace:   dep.SpaceSlug,

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -285,8 +285,8 @@ func TestPlanCrossSpaceLinks(t *testing.T) {
 	if links[0].FromUnit != InstallerRecordSlug || links[0].ToUnit != InstallerRecordSlug {
 		t.Errorf("link[0] units should be the record slug: %+v", links[0])
 	}
-	if links[0].Component != "parent" {
-		t.Errorf("link[0].Component = %q want %q", links[0].Component, "parent")
+	if links[0].Package != "parent" {
+		t.Errorf("link[0].Package = %q want %q", links[0].Package, "parent")
 	}
 }
 

--- a/test/e2e/upload-reconcile.sh
+++ b/test/e2e/upload-reconcile.sh
@@ -12,11 +12,24 @@
 #   pin image      — edits facts.yaml to a known release tag, re-renders
 #                    via `install render` (bypasses setup's collector,
 #                    which would overwrite facts back to :latest)
+#   make Target    — creates a Target in its own Space so the upload can
+#                    bind Units to it via cross-Space <space>/<target>
 #   upload         — first upload: creates Space + Units + installer-
 #                    record + AppConfig set (render-configmap Invocation/
 #                    AppConfig Unit/placeholder + Upsert link) + cross-Unit
-#                    links
+#                    links. Carries the well-known Space labels (Component
+#                    via --component, plus Layer/Environment/Region/Owner/Variant),
+#                    --space-label/--space-annotation, --unit-label/
+#                    --unit-annotation, and --target.
+#   metadata check — asserts the Space labels/annotations, the Unit
+#                    Package label + PackageVersion + --unit-* pairs, the
+#                    cross-Space TargetID annotation and per-Unit binding,
+#                    and that the AppConfig Unit has no Target
 #   plan (clean)   — No changes
+#   add w/o target — reconcile creates a new Unit with NO --target; it
+#                    binds to the Target read back from the Space's
+#                    TargetID annotation. Re-passes --environment to prove
+#                    "set once, update if re-passed" (others preserved)
 #   edit + plan    — surfaces the edited slug
 #   reconcile      — applies inside a ChangeSet
 #   re-run         — second upload is a no-op (no ChangeSet)
@@ -71,10 +84,22 @@ KEEP_WD=${INSTALLER_UPLOAD_KEEP_WD:-1}
 VERBOSE=${INSTALLER_UPLOAD_VERBOSE:-0}
 WORKER_SLUG=installer-test-worker
 PINNED_IMAGE=${INSTALLER_UPLOAD_IMAGE:-ghcr.io/confighubai/confighub-worker:v0.1.44}
+# A Target lives in its own Space so the first upload can bind Units to it
+# via the cross-Space <space>/<target> --target syntax and record the
+# resolved TargetID as $SPACE's "TargetID" annotation.
+TARGET_SPACE="${SPACE}-targets"
+TARGET_SLUG=installer-test-target
+TARGET_WORKER_SLUG=installer-test-target-worker
 
 log()    { printf '\n=== %s ===\n' "$*" >&2; }
 note()   { printf '    %s\n' "$*" >&2; }
 fail()   { printf '\nFAIL: %s\n' "$*" >&2; exit 1; }
+
+# jq helpers: read a single field from a Space/Unit, stripping the quotes
+# jq prints around string values (prints "null"/empty when the field is
+# absent). Used by the metadata assertions below.
+space_jq() { cub space get "$SPACE" -o "jq=$1" 2>/dev/null | tr -d '"'; }
+unit_jq()  { cub unit get --space "$SPACE" "$1" -o "jq=$2" 2>/dev/null | tr -d '"'; }
 
 # run <log-name> <cmd> [args...]
 # Runs the command, redirecting both stdout and stderr to
@@ -102,7 +127,7 @@ cleanup_msg() {
   printf '\n----- inspection state preserved -----\n'
   printf 'Space:    %s\n' "$SPACE"
   printf 'Work-dir: %s\n' "$WORK_TMP"
-  printf '\nClean up the Space (and everything in it — Units, Invocations, Links,\nthe BridgeWorker entity, ChangeSets) with:\n  cub space delete --recursive %s\n' "$SPACE"
+  printf '\nClean up the Space (and everything in it — Units, Invocations, Links,\nthe BridgeWorker entity, ChangeSets) plus the Target Space with:\n  cub space delete --recursive %s\n  cub space delete --recursive %s\n' "$SPACE" "$TARGET_SPACE"
   if [[ "$KEEP_WD" = "1" ]]; then
     printf 'Clean up the work-dir with:\n  rm -rf %s\n' "$WORK_TMP"
   fi
@@ -212,9 +237,47 @@ note "AppConfig carrier ConfigMap: $(basename "$appcfg_cm")"
 cub worker list --space "$SPACE" 2>/dev/null | awk '{print $1}' | grep -qx "$WORKER_SLUG" \
   || fail "collector did not create BridgeWorker '$WORKER_SLUG' in Space $SPACE"
 
-# 6. First upload — creates Units + AppConfig artifacts.
-log "install upload --space $SPACE (first upload — exercises AppConfig pathway)"
-run upload-first "$BIN" upload --work-dir "$WORK_TMP" --space "$SPACE" || fail "first upload failed (see $WORK_TMP/upload-first.log)"
+# 5c. Create the cross-Space Target the first upload will bind Units to.
+#     It needs no live cluster — upload only binds Units (sets TargetID),
+#     it never applies — so a backing worker entity that merely *declares*
+#     Kubernetes/YAML support (no running process) plus a default
+#     Kubernetes Target with empty parameters is enough. Resolving its
+#     UUID up front lets later steps assert the recorded "TargetID"
+#     annotation and the per-Unit bindings.
+log "create cross-Space Target ($TARGET_SPACE/$TARGET_SLUG)"
+cub space create --quiet "$TARGET_SPACE" >/dev/null || fail "failed to create Target Space $TARGET_SPACE"
+# A Target needs a BridgeWorker that advertises the ConfigType. We don't
+# run a worker here (no cluster), so declare the supported ConfigType on
+# the worker entity directly via --from-stdin — enough for target-create
+# validation and for binding Units (upload binds, it never applies).
+printf '%s' '{"ProvidedInfo":{"BridgeWorkerInfo":{"SupportedConfigTypes":[{"ProviderType":"Kubernetes","ToolchainType":"Kubernetes/YAML"}]}}}' \
+  | cub worker create --space "$TARGET_SPACE" --from-stdin "$TARGET_WORKER_SLUG" >/dev/null \
+  || fail "failed to create Target worker $TARGET_SPACE/$TARGET_WORKER_SLUG"
+cub target create --space "$TARGET_SPACE" "$TARGET_SLUG" '{}' "$TARGET_WORKER_SLUG" >/dev/null \
+  || fail "failed to create Target $TARGET_SPACE/$TARGET_SLUG"
+TARGET_ID=$(cub target get --space "$TARGET_SPACE" "$TARGET_SLUG" -o jq=.Target.TargetID 2>/dev/null | tr -d '"')
+[[ -n "$TARGET_ID" && "$TARGET_ID" != "null" ]] || fail "could not resolve TargetID for $TARGET_SPACE/$TARGET_SLUG"
+note "Target $TARGET_SPACE/$TARGET_SLUG → TargetID $TARGET_ID"
+
+# 6. First upload — creates Units + AppConfig artifacts, carrying the
+#    well-known Space labels (Component overridden via --component), the
+#    free-form --space-label / --space-annotation pairs, the --unit-label
+#    / --unit-annotation pairs on every Unit, and binding Units to the
+#    cross-Space Target (whose TargetID is recorded as a Space annotation).
+log "install upload --space $SPACE (first upload — exercises AppConfig pathway + Space/Unit metadata + cross-Space --target)"
+run upload-first "$BIN" upload --work-dir "$WORK_TMP" --space "$SPACE" \
+  --component my-component \
+  --layer App \
+  --environment Prod \
+  --region us-east1 \
+  --owner Engineering \
+  --variant Base \
+  --space-label tier=infra \
+  --space-annotation note=e2e \
+  --unit-label managed-by=installer-e2e \
+  --unit-annotation install-note=hello \
+  --target "$TARGET_SPACE/$TARGET_SLUG" \
+  || fail "first upload failed (see $WORK_TMP/upload-first.log)"
 
 [[ -f "$WORK_TMP/out/spec/upload.yaml" ]] || fail "first upload did not write out/spec/upload.yaml"
 
@@ -249,6 +312,38 @@ note "Links in $SPACE: $link_count"
 
 note "Units in $SPACE:"
 cub unit list --space "$SPACE" 2>/dev/null | awk 'NR>1 {print "      "$1}'
+
+# 6c. Metadata assertions: the well-known Space labels, the free-form
+#     --space-label / --space-annotation pairs, the --unit-* pairs and the
+#     Package/PackageVersion the installer owns, and the --target →
+#     TargetID round-trip (Space annotation + per-Unit binding).
+log "metadata assertions: Space labels/annotations, Unit labels/annotations, TargetID round-trip"
+[[ "$(space_jq .Space.Labels.Component)"   == "my-component" ]] || fail "Space label Component != my-component (got '$(space_jq .Space.Labels.Component)')"
+[[ "$(space_jq .Space.Labels.Layer)"       == "App" ]]          || fail "Space label Layer != App"
+[[ "$(space_jq .Space.Labels.Environment)" == "Prod" ]]         || fail "Space label Environment != Prod"
+[[ "$(space_jq .Space.Labels.Region)"      == "us-east1" ]]     || fail "Space label Region != us-east1"
+[[ "$(space_jq .Space.Labels.Owner)"       == "Engineering" ]]  || fail "Space label Owner != Engineering"
+[[ "$(space_jq .Space.Labels.Variant)"     == "Base" ]]         || fail "Space label Variant != Base"
+[[ "$(space_jq .Space.Labels.tier)"        == "infra" ]]        || fail "Space label tier != infra (--space-label)"
+[[ "$(space_jq '.Space.Annotations.note')" == "e2e" ]]          || fail "Space annotation note != e2e (--space-annotation)"
+[[ "$(space_jq '.Space.Annotations.TargetID')" == "$TARGET_ID" ]] || fail "Space TargetID annotation != $TARGET_ID (got '$(space_jq '.Space.Annotations.TargetID')')"
+note "Space carries Component=my-component + Layer/Environment/Region/Owner/Variant + tier + note + TargetID=$TARGET_ID"
+
+# A standard (non-AppConfig) Unit carries the Package label, the
+# PackageVersion annotation, the --unit-* pairs, and the Target binding.
+META_UNIT=$(cub unit list --space "$SPACE" 2>/dev/null | awk 'NR>1 && /^deployment-/ {print $1; exit}')
+[[ -n "$META_UNIT" ]] || fail "no deployment Unit to check metadata on"
+[[ "$(unit_jq "$META_UNIT" .Unit.Labels.Package)" == "confighub-worker" ]] || fail "Unit $META_UNIT Package label != confighub-worker"
+[[ "$(unit_jq "$META_UNIT" '.Unit.Labels["managed-by"]')" == "installer-e2e" ]] || fail "Unit $META_UNIT managed-by label != installer-e2e (--unit-label)"
+pv=$(unit_jq "$META_UNIT" .Unit.Annotations.PackageVersion); [[ -n "$pv" && "$pv" != "null" ]] || fail "Unit $META_UNIT missing PackageVersion annotation"
+[[ "$(unit_jq "$META_UNIT" '.Unit.Annotations["install-note"]')" == "hello" ]] || fail "Unit $META_UNIT install-note annotation != hello (--unit-annotation)"
+[[ "$(unit_jq "$META_UNIT" .Unit.TargetID)" == "$TARGET_ID" ]] || fail "Unit $META_UNIT TargetID != $TARGET_ID (cross-Space --target binding)"
+note "Unit $META_UNIT: Package=confighub-worker, managed-by=installer-e2e, PackageVersion=$pv, install-note=hello, TargetID=$TARGET_ID"
+
+# The AppConfig Unit is a pure data source → it must NOT be bound to a Target.
+appcfg_tid=$(unit_jq confighub-worker-env .Unit.TargetID)
+[[ -z "$appcfg_tid" || "$appcfg_tid" == "null" ]] || fail "AppConfig Unit confighub-worker-env should have no Target, got '$appcfg_tid'"
+note "AppConfig Unit confighub-worker-env has no Target (pure data source)"
 
 # 7. plan against unchanged work-dir → No changes.
 log "install plan (clean) — expect No changes"
@@ -305,6 +400,43 @@ log "install upload (no changes after AppConfig edit) — re-run is a no-op"
 run upload-converge-1 "$BIN" upload --work-dir "$WORK_TMP" || fail "converge upload failed (see $WORK_TMP/upload-converge-1.log)"
 grep -q "^No changes\\.$" "$WORK_TMP/upload-converge-1.log" \
   || fail "upload on the same work-dir after AppConfig reconcile should be No changes (see $WORK_TMP/upload-converge-1.log)"
+
+# 9b. Reconcile an ADD without --target: the new Unit must bind to the
+#     Target read back from the Space's TargetID annotation. Re-pass ONE
+#     well-known label (--environment) with a new value to prove
+#     "set once, update if re-passed": Environment updates while the
+#     others (not re-passed) and the TargetID annotation are preserved.
+#     The manifest is dropped into out/manifests directly (no re-render,
+#     so it survives into the reconcile dry-run like the marker edit below).
+log "reconcile add without --target: binds from Space TargetID annotation; --environment re-pass updates only Environment"
+EXTRA_SLUG=extra-e2e-config
+cat > "$WORK_TMP/out/manifests/$EXTRA_SLUG.yaml" <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: $EXTRA_SLUG
+  namespace: $SPACE
+data:
+  hello: world
+EOF
+
+run upload-readback "$BIN" upload --work-dir "$WORK_TMP" --yes --environment Staging \
+  || fail "reconcile add without --target failed (see $WORK_TMP/upload-readback.log)"
+grep -qE "^Applied: 1 created, 0 updated, 0 emptied\\.$" "$WORK_TMP/upload-readback.log" \
+  || fail "reconcile add should report exactly 1 created (see $WORK_TMP/upload-readback.log)"
+
+# The added Unit must be bound to the Target read back from the annotation.
+extra_tid=$(unit_jq "$EXTRA_SLUG" .Unit.TargetID)
+[[ "$extra_tid" == "$TARGET_ID" ]] || fail "added Unit $EXTRA_SLUG TargetID = '$extra_tid', want $TARGET_ID (read back from Space annotation, no --target passed)"
+note "added Unit $EXTRA_SLUG bound to TargetID $TARGET_ID without --target (read back from Space annotation)"
+
+# set-once: Environment updated; Component/Layer untouched; TargetID preserved.
+[[ "$(space_jq .Space.Labels.Environment)" == "Staging" ]]       || fail "Environment label != Staging (re-passed value should update)"
+[[ "$(space_jq .Space.Labels.Component)"   == "my-component" ]]  || fail "Component label changed; should be set-once (not re-passed)"
+[[ "$(space_jq .Space.Labels.Layer)"       == "App" ]]           || fail "Layer label changed; should be set-once (not re-passed)"
+[[ "$(space_jq .Space.Labels.Region)"      == "us-east1" ]]      || fail "Region label changed; should be set-once (not re-passed)"
+[[ "$(space_jq '.Space.Annotations.TargetID')" == "$TARGET_ID" ]] || fail "TargetID annotation changed across reconcile without --target"
+note "set-once verified: Environment→Staging; Component/Layer/Region + TargetID preserved"
 
 # 10. Edit a rendered Kubernetes manifest (the Deployment) → plan
 #     surfaces the diff. This exercises the standard (non-AppConfig)


### PR DESCRIPTION
## What changes for users

`install upload` can now organize the **Space(s)** it creates, not just the Units inside them.

**New flags**
- `--space-label key=value` / `--space-annotation key=value` — set arbitrary metadata on each Space (repeatable). The per-Unit flags `--label` / `--annotation` are renamed `--unit-label` / `--unit-annotation`.
- Well-known capitalized Space labels:
  - `--component` (defaults to the package name)
  - `--layer` (e.g. `App`), `--environment` (e.g. `Prod`), `--region` (e.g. `us-east1`), `--owner` (e.g. `Engineering`), `--variant` (e.g. `Base`)
  - These keys are reserved — `--space-label` rejects them, so the dedicated flags stay authoritative.
- `--target` now:
  - records the resolved Target's **`TargetID`** as a Space annotation, and
  - accepts `<space-slug>/<target-slug>`, so the Target can live in a different Space than the upload context.
  - On a later reconcile `--target` may be omitted — the binding for newly-added Units is read back from the Space's `TargetID` annotation.

**Unit metadata**
- Units now carry a **`Package`** label (the package name) instead of `Component`. This frees `Component` for Space-level organization and means Units an operator adds to a Space (before cloning it to a new variant) are ignored by reconcile.
- Units also get a **`PackageVersion`** annotation, refreshed on update, so you can see which package version last touched each Unit.

**Source of truth**
- None of this label/annotation/target metadata is written to `upload.yaml` — ConfigHub is its source of truth; `upload.yaml` only needs enough to find the Space(s).
- Well-known Space labels and `--space-*` pairs are set on first upload and re-applied on reconcile only when their flag is passed again ("set once, update if re-passed").

## Testing

- Unit tests for the label/annotation composition and reserved-key validation.
- `test/e2e/upload-reconcile.sh` extended to assert the Space labels/annotations, the Unit `Package`/`PackageVersion` and `--unit-*` metadata, the cross-Space `--target` → `TargetID` round-trip (with per-Unit binding), and a reconcile that adds a Unit with no `--target` (binding read back from the Space) while re-passing `--environment` to verify the "set once, update if re-passed" behavior. Passing against a live server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)