### PR TITLE
kubernetes-resources: use confighubplaceholder for cross-resource refs

### DIFF
--- a/packages/kubernetes-resources/bases/default/hello-certificate.yaml
+++ b/packages/kubernetes-resources/bases/default/hello-certificate.yaml
@@ -11,4 +11,7 @@ spec:
   issuerRef:
     kind: ClusterIssuer
     name: letsencrypt-prod
-  secretName: hello-app-tls
+  # The Secret cert-manager produces. Left as a placeholder so ConfigHub
+  # Links resolve it to a Secret Unit's slug when one is created; without a
+  # Link, edit it to the desired Secret name.
+  secretName: confighubplaceholder

--- a/packages/kubernetes-resources/bases/default/hello-externalsecret.yaml
+++ b/packages/kubernetes-resources/bases/default/hello-externalsecret.yaml
@@ -11,8 +11,10 @@ spec:
   target:
     # Owner mode: ESO creates the target Secret with exactly the keys declared
     # below. Use Owner when no other manifest ships the Secret (the common
-    # case when the upstream's empty stub Secret is excluded).
-    name: hello-app
+    # case when the upstream's empty stub Secret is excluded). name is a
+    # placeholder so ConfigHub Links resolve it to a Secret Unit's slug;
+    # without a Link, edit it to the desired Secret name.
+    name: confighubplaceholder
     creationPolicy: Owner
   data:
     # One entry per key to project into the target Secret. remoteRef.key is the

--- a/packages/kubernetes-resources/bases/default/hello-ingressroute.yaml
+++ b/packages/kubernetes-resources/bases/default/hello-ingressroute.yaml
@@ -15,7 +15,11 @@ spec:
     - kind: Rule
       match: Host(`confighubplaceholder`)
       services:
-        - name: hello-app
+        # Service this route forwards to. Placeholder so a ConfigHub Link
+        # resolves it to a Service Unit in the same Space.
+        - name: confighubplaceholder
           port: 80
   tls:
-    secretName: hello-app-tls
+    # The Secret holding the TLS cert (typically produced by a cert-manager
+    # Certificate). Placeholder so a ConfigHub Link resolves it.
+    secretName: confighubplaceholder


### PR DESCRIPTION
## Summary

Replace hardcoded names on cross-resource reference fields in the three CRD templates added in #25 with \`confighubplaceholder\`:

| template | field |
|---|---|
| Certificate | \`spec.secretName\` |
| IngressRoute | \`spec.routes[].services[].name\` |
| IngressRoute | \`spec.tls.secretName\` |
| ExternalSecret | \`spec.target.name\` |

These paths are registered as cross-resource references for the matching Kubernetes types, so a ConfigHub Link to the target Unit resolves the placeholder to the linked Unit's slug at apply time. Without a Link, the consumer edits the value to the desired name.

This removes the \`install new\` rename-leftovers problem (where \`install new certificate foo\` would still leave \`secretName: hello-app-tls\` and operators had to hand-edit it). Fields that reference cluster-wide singletons rather than peer Units in the same Space — \`Certificate.spec.issuerRef.name\` (ClusterIssuer), \`ExternalSecret.spec.secretStoreRef.name\` (ClusterSecretStore) — keep concrete defaults (\`letsencrypt-prod\`, \`aws-ssm\`).

## Test plan

- [x] \`install setup --pull packages/kubernetes-resources --namespace kubernetes-resources --non-interactive --clean\` renders cleanly (19 manifests, vet-schemas/merge-keys/format all pass).
- [x] The placeholders survive set-namespace and reach the rendered manifests intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)