### PR TITLE
installer: rename, MIT headers, Metadata split, api comments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 # Makefile for the installer CLI.
 #
-# The output binary is `bin/install` because the cub plugin protocol
+# The output binary is `bin/installer` because the cub plugin protocol
 # names the plugin after its entrypoint basename: invoking it via cub
-# reads as `cub install ...`, matching the standalone form.
+# reads as `cub installer ...`, matching the standalone form.
 
 GO     ?= go
-BIN    ?= bin/install
+BIN    ?= bin/installer
 PKG    ?= ./cmd/installer
 
-.PHONY: all build install test vet fmt clean
+.PHONY: all build test vet fmt clean
 
 all: build
 
@@ -16,10 +16,6 @@ build: $(BIN)
 
 $(BIN): $(shell find . -name '*.go' -not -path './bin/*')
 	$(GO) build -o $(BIN) $(PKG)
-
-# Alias: `make install` builds the binary (it does NOT install it on
-# PATH — name matches the binary, not the verb).
-install: build
 
 test:
 	$(GO) test ./...

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Kubernetes off-the-shelf component installer using
 [configuration as data](https://docs.confighub.com/background/config-as-data/).
 
 This tool is intended to play the role of an
-[install wizard](https://www.revenera.com/install/products/installshield/installshield-tips-tricks/what-is-an-installation-wizard)
+[installer wizard](https://www.revenera.com/install/products/installshield/installshield-tips-tricks/what-is-an-installation-wizard)
 and a [package dependency manager](https://medium.com/@sdboyer/so-you-want-to-write-a-package-manager-4ae9c17d9527).
 
 This installer aims to present only the minimal number of high-level decisions, such as
@@ -43,7 +43,7 @@ a sequence of ConfigHub functions executed at install (render) time locally via 
 
 Output from the rendering process goes to plain YAML files that can be uploaded to ConfigHub for delivery
 via ArgoCD or Flux, or could be committed to git to be deployed by ArgoCD, Flux, or other Kubernetes
-deployment tool.
+applier or deployment tool.
 
 For post-installation customization, [ConfigHub's function suite](https://docs.confighub.com/guide/functions/#frequently-used-functions) includes functions for changing commonly changed Kubernetes resource properties,
 such as `set-container-image`, `set-container-resources`, `set-replicas`, `set-env`, and `set-hostname`,
@@ -65,7 +65,7 @@ storing rendered configuration somewhere other than git, and so on.
 
 Working:
 
-- **Package authoring + distribution.** `install package` (deterministic
+- **Package authoring + distribution.** `installer package` (deterministic
   bundle), `push` / `pull` / `inspect` / `list` / `tag` /
   `login` / `logout` (OCI artifacts), `sign` / `verify` (cosign keyed +
   keyless) with a `~/.config/installer/policy.yaml` trust policy that
@@ -73,39 +73,39 @@ Working:
 - **Dependencies.** SemVer resolver + lock (`deps update`, `deps tree`),
   multi-package render into per-dep subtrees, upload into per-dep Spaces
   with cross-Space Links.
-- **Install lifecycle.** `install setup` (the one-shot consumer entry
+- **Install lifecycle.** `installer setup` (the one-shot consumer entry
   point: optional pull, wizard with high-level component presets
   `minimal` / `default` / `all` / `selected`, render). Interactive +
   non-interactive. Prior-state re-entry from ConfigHub (via the
   persisted `installer-record` Unit) or local `out/spec/`,
   organization + server sanity-check against the active cub context.
-- **Day-2 lifecycle.** `install setup` and `install upload`
+- **Day-2 lifecycle.** `installer setup` and `installer upload`
   auto-detect first-install vs upgrade vs reconcile via the presence
   of prior spec files / `out/spec/upload.yaml`. Re-running `setup`
   with `--pull <new-ref>` runs the schema-diff machinery (carry
   forward existing values, adopt new defaults, prompt for new
   required-without-default). Re-running `upload` against an already-
   uploaded work-dir opens a ChangeSet and reconciles updates / adds /
-  deletes. `install plan` previews the reconcile diff read-only.
+  deletes. `installer plan` previews the reconcile diff read-only.
   `--merge-external-source` is the change predicate, so post-install
   ConfigHub edits survive re-render.
-- **Image overrides.** `install setup --set-image` applies
+- **Image overrides.** `installer setup --set-image` applies
   `kustomize edit set image` before render. Overrides round-trip via
   `Inputs.Spec.ImageOverrides` and carry forward across re-renders /
   upgrades. The chosen base must declare an `images:` block; render
   fails fast otherwise.
 
-Stubbed: `install preflight` — cluster-side constraint checks.
+Stubbed: `installer preflight` — cluster-side constraint checks.
 
 ## Build
 
 ```bash
-make build       # writes bin/install
+make build       # writes bin/installer
 ```
 
-The binary is named `install` so the cub plugin protocol exposes it as
-`cub install ...` (cub names plugins after the entrypoint basename in
-`cub-plugin.yaml`). `install` shells out to `kustomize` for
+The binary is named `installer` so the cub plugin protocol exposes it as
+`cub installer ...` (cub names plugins after the entrypoint basename in
+`cub-plugin.yaml`). `installer` shells out to `kustomize` for
 `kustomize build`. Install it from
 [kubernetes-sigs/kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/)
 or `brew install kustomize`.
@@ -116,12 +116,12 @@ End to end against the included example, no ConfigHub server required:
 
 ```bash
 # 1. Inspect what's in the package.
-bin/install doc ./examples/hello-app
+bin/installer doc ./examples/hello-app
 
 # 2. Setup: pull (here: a local dir), pick base + components, supply
 #    inputs, and render. One command replaces pull + wizard + render.
 mkdir -p /tmp/hello && cd /tmp/hello
-bin/install setup \
+bin/installer setup \
   --pull ./examples/hello-app \
   --non-interactive \
   --select monitoring --select ingress \
@@ -130,17 +130,17 @@ bin/install setup \
 # 3. Upload to ConfigHub. Records the destination Space(s) in
 #    out/spec/upload.yaml so subsequent commands re-enter the same
 #    Space without re-typing.
-bin/install upload --space my-greeter
+bin/installer upload --space my-greeter
 
 # 4. Day-2: edit a rendered file, see what upload would do, apply.
 $EDITOR out/manifests/deployment-demo-hello-app.yaml
-bin/install plan                       # read-only diff vs ConfigHub
-bin/install upload --yes               # reconcile (ChangeSet-wrapped)
+bin/installer plan                       # read-only diff vs ConfigHub
+bin/installer upload --yes               # reconcile (ChangeSet-wrapped)
 
 # 5. Upgrade: re-pull (atomic), re-render via setup, then upload.
-bin/install setup --pull ./examples/hello-app \
+bin/installer setup --pull ./examples/hello-app \
   --set-image nginxdemos/hello=nginxdemos/hello:plain-text-v2
-bin/install upload --yes
+bin/installer upload --yes
 ```
 
 The wizard's `--select` is closed under each component's `requires:` list, so
@@ -189,7 +189,7 @@ kustomize build --enable-exec --enable-alpha-plugins .` to reproduce
 the render byte-for-byte outside the installer.
 
 The two spec docs (`selection.yaml`, `inputs.yaml`) are the load-bearing inputs
-to re-render: edit them, re-run `install render`, get a deterministic new set
+to re-render: edit them, re-run `installer render`, get a deterministic new set
 of manifests.
 
 ## Package format
@@ -201,6 +201,7 @@ apiVersion: installer.confighub.com/v1alpha1
 kind: Package
 metadata:
   name: my-package
+installerMetadata:
   version: 0.1.0
 spec:
   bases: # alternative top-level kustomize trees
@@ -236,7 +237,7 @@ The `transformers:` list is resolved with Go `text/template` syntax —
 `{{ .Namespace }}`, `{{ .Inputs.* }}`, `{{ .Selection.* }}`,
 `{{ .Facts.* }}`, `{{ .Package.* }}` — then emitted as a
 `ConfigHubTransformers` KRM function config that kustomize invokes
-through the `install transformer` exec plugin. Each group's
+through the `installer transformer` exec plugin. Each group's
 `toolchain` and `whereResource` are applied per-group, so a single
 chain can mutate raw Kubernetes manifests with `Kubernetes/YAML` and
 AppConfig-carried files (`AppConfig/Properties`, `AppConfig/Env`, …)
@@ -247,14 +248,14 @@ when the component is selected.
 ## Plugin install
 
 The binary doubles as a `cub` plugin. After publishing a release that includes
-a platform binary at the path `bin/install`, install with:
+a platform binary at the path `bin/installer`, install with:
 
 ```bash
 cub plugin install confighub/installer
 ```
 
 The `cub-plugin.yaml` at the repo root tells cub the entry point. Once
-installed, the same commands work via `cub install ...`.
+installed, the same commands work via `cub installer ...`.
 
 ## Layout
 
@@ -264,7 +265,7 @@ installed, the same commands work via `cub install ...`.
 ├── internal/
 │   ├── cli/                    # cobra subcommands
 │   ├── pkg/                    # package load + OCI pull (oras-go)
-│   ├── bundle/                 # deterministic tarball for `install package`
+│   ├── bundle/                 # deterministic tarball for `installer package`
 │   ├── selection/              # required-deps closure + conflict detection
 │   ├── wizard/                 # interactive + non-interactive answer collection,
 │   │                           # prior-state load, schema diff for upgrades
@@ -283,7 +284,7 @@ installed, the same commands work via `cub install ...`.
 │                               # Lock, Upload schemas
 ├── packages/                   # "published" packages bundled in this repo
 │   ├── kubernetes-resources/   # 11 canonical resource templates with
-│   │                           # per-type defaults (used by `install new`)
+│   │                           # per-type defaults (used by `installer new`)
 │   └── worker/                 # ConfigHub bridge worker
 ├── examples/                   # test fixtures for the e2e + unit tests
 │   ├── hello-app/              # single-package end-to-end test package
@@ -336,7 +337,7 @@ authoring packages, the user docs above are what you want.
     vs ConfigHub, ChangeSet-wrapped update, staged upgrade with
     schema-diff, and `--set-image` overrides. Phases A–E shipped.
 - [Kustomize transformer plugin and AppConfig support](docs/transformer.md)
-  — design for the `install transformer` exec plugin (folds the
+  — design for the `installer transformer` exec plugin (folds the
   function chain into kustomize), durable `out/compose/`,
   component-scoped function-chain mixins, and AppConfig support via
   `configMapGenerator` round-trip. Not yet implemented.
@@ -362,13 +363,9 @@ upgrade --set-image preflight rejection`. Spaces created with the
 
 ## Roadmap
 
-- Better Secrets support (currently we generate secrets during fact collection).
-- `install preflight` — evaluate `externalRequires` against a live cluster.
-- Automatic apply ordering (CRDs before custom resources, Namespace before
-  namespaced resources, etc.) inferred from resource kind plus the existing
-  link graph — no per-package phase declarations.
-- Real packages: ArgoCD, Flux, llm-d, KServe, vLLM production stack
+- Better Secrets support. Currently we generate secrets during fact collection.
+  Explicit support for ESO and CSI, and possibly "drop" and "stub" options.
+- `installer preflight` — evaluate `externalRequires` against a live cluster.
+- More packages: Flux, llm-d, KServe, vLLM production stack
   (KubeRay and Gateway API Inference Extension shipped — see `examples/`).
-- TBD: Hooks, in-cluster and local.
-- TBD: variant creation and promotion.
-- TBD: support deploying via ArgoCD and Flux directly.
+- TBD: More comprehensive hooks, in-cluster and local.

--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -1,6 +1,9 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 // Command installer renders config-as-data Kubernetes packages into per-
 // resource YAML files for upload to ConfigHub. It can be invoked standalone
-// or as a `cub` plugin (cub install ...).
+// or as a `cub` plugin (cub installer ...).
 package main
 
 import (

--- a/cub-plugin.yaml
+++ b/cub-plugin.yaml
@@ -1,1 +1,1 @@
-entrypoint: bin/install
+entrypoint: bin/installer

--- a/docs/author-guide.md
+++ b/docs/author-guide.md
@@ -1,6 +1,6 @@
 # Package Author Guide
 
-Reference for authoring an install package — file layout, the
+Reference for authoring an installer package — file layout, the
 `installer.yaml` schema, what each declaration becomes at install time,
 publishing, signing, and version-to-version evolution.
 
@@ -12,17 +12,17 @@ tutorial](./author-tutorial.md).
 
 The CLI provides four authoring shortcuts:
 
-- `install init <dir>` — scaffold a new package with the
+- `installer init <dir>` — scaffold a new package with the
   recommended defaults.
-- `install new <kind> <name>` — clone a Kubernetes resource
+- `installer new <kind> <name>` — clone a Kubernetes resource
   template from the bootstrapped `kubernetes-resources` package.
-- `install edit add/remove/set input|component|dependency` —
+- `installer edit add/remove/set input|component|dependency` —
   mutate `installer.yaml` fields (no hand-editing YAML).
-- `install vet <work-dir>` — run the package's validators against
+- `installer vet <work-dir>` — run the package's validators against
   the existing render without re-rendering.
 
 These all operate on package source on disk; there's no ConfigHub
-interaction except `install new`, which fetches templates from
+interaction except `installer new`, which fetches templates from
 the bootstrapped kubernetes-resources Space.
 
 > **Note.** This guide describes _what_ to put in a package and _why_.
@@ -71,14 +71,14 @@ my-package/
 The fastest way to get this layout is:
 
 ```bash
-install init ./my-package
+installer init ./my-package
 ```
 
-`install init` scaffolds the manifest (with the recommended
+`installer init` scaffolds the manifest (with the recommended
 validator chain — see [Validators](#specvalidators) below), an
 empty `bases/default/`, an empty `components/`, and an empty
 `validation/`. From there, drop your kustomize resources into
-`bases/default/` and either hand-author them or use `install new
+`bases/default/` and either hand-author them or use `installer new
 <kind> <name>` to clone canonical templates from the
 [`kubernetes-resources`](#kubernetes-resources-package) package.
 
@@ -105,7 +105,7 @@ my-package/
 ├── validation/                    # optional: bundled docs about
 │   ├── env.schema.json            # configurable env vars / flags /
 │   ├── command.yaml               # runtime expectations. Surfaced
-│   └── runtime.yaml               # by `install doc`.
+│   └── runtime.yaml               # by `installer doc`.
 └── collector/                     # optional: install-time fact
     └── collect.sh                 # discovery script (see Collector)
 ```
@@ -124,6 +124,7 @@ apiVersion: installer.confighub.com/v1alpha1
 kind: Package
 metadata:
   name: my-package
+installerMetadata:
   version: 0.1.0          # SemVer
   kubeVersion: ">= 1.28"  # SemVer range; empty means unconstrained
   installerVersion: ">= 0.2.0"
@@ -131,7 +132,7 @@ spec:
   ...
 ```
 
-`metadata.name` and `metadata.version` are required. The two
+`metadata.name` and `installerMetadata.version` are required. The two
 `*Version` fields constrain what cluster Kubernetes / installer
 versions the package supports; mismatches are an error at resolve
 and render time.
@@ -288,7 +289,7 @@ prompts.
 ### `spec.validators`
 
 A list of validating-function invocation groups, run automatically
-at the end of every `install render` against the post-mutation
+at the end of every `installer render` against the post-mutation
 output. Each group has the same shape as
 [`transformers`](#specfunctionchaintemplate) — a toolchain,
 optional `whereResource` filter, ordered `invocations` — but every
@@ -307,12 +308,12 @@ spec:
         - name: vet-format
 ```
 
-`install init` seeds `vet-schemas`, `vet-merge-keys`, and
+`installer init` seeds `vet-schemas`, `vet-merge-keys`, and
 `vet-format` by default. `vet-placeholders` is intentionally NOT
 seeded — packages that ship cloneable bases (with
 `confighubplaceholder` fields) would fail it.
 
-Edit the list with `install edit add/remove validator <name>`
+Edit the list with `installer edit add/remove validator <name>`
 (coming in a follow-up) or by hand. The full list of available
 validators:
 
@@ -335,7 +336,7 @@ Frequently used:
 | `vet-starlark` | Custom Starlark validation. |
 | `vet-values` | Field values outside an allowed set. |
 
-When the list changes, run `install vet <work-dir>` against an
+When the list changes, run `installer vet <work-dir>` against an
 existing render to check the new validators without re-rendering.
 
 `whereResource` filters in `validators[].whereResource` use the same
@@ -424,7 +425,7 @@ should leave `--namespace` unset.
 ### `spec.externalRequires`
 
 Cluster preconditions your package needs but does not provide. The
-wizard surfaces them; `install preflight` (when shipped) probes them
+wizard surfaces them; `installer preflight` (when shipped) probes them
 against a live cluster.
 
 ```yaml
@@ -533,7 +534,7 @@ kustomize secretGenerator references; the installer never reads or
 uploads those files. Rendered Secret resources are routed to
 `out/secrets/` and never uploaded as Units.
 
-**Re-run on every setup**. `install setup` re-runs the collector
+**Re-run on every setup**. `installer setup` re-runs the collector
 on each invocation (whether or not `--pull` was passed). Facts are
 not assumed to survive a version bump or a cluster-state change.
 
@@ -542,7 +543,7 @@ not assumed to survive a version bump or a cluster-state change.
 Points at machine-readable component documentation bundled in the
 package (typically generated by `docker run <image> docgen
 {command,env,runtime}` and committed under `./validation/`). Surfaced
-by `install doc` so an AI agent or human can read what env vars
+by `installer doc` so an AI agent or human can read what env vars
 your workload accepts and what runtime expectations it has without
 re-pulling the image.
 
@@ -621,12 +622,12 @@ published artifacts.
 Knowing the pipeline helps you reason about what's load-bearing and
 what isn't.
 
-1. **`install pull <ref> <work-dir>/package`** — fetches the
+1. **`installer pull <ref> <work-dir>/package`** — fetches the
    bundled tgz from OCI, verifies signature if a policy is configured,
    extracts into `<work-dir>/package/`. Your `installer.yaml`,
    `bases/`, `components/`, etc. land here verbatim.
 
-2. **`install setup`** (or `install wizard <ref>` + `installer
+2. **`installer setup`** (or `installer wizard <ref>` + `installer
    render` granularly) — loads `installer.yaml`, runs the selection
    solver (closure of `requires:`, conflict / `validForBases` checks),
    runs your collector if present, writes
@@ -639,12 +640,12 @@ what isn't.
    `.Selection` / `.Package` / `.Namespace` / `.Facts`, writes them as
    KRM function configs, and runs
    `kustomize build --enable-exec --enable-alpha-plugins`. Kustomize
-   invokes the `install transformer` subcommand as an exec plugin
+   invokes the `installer transformer` subcommand as an exec plugin
    to run each function group in process; the result lands as one
    resource per file in `out/manifests/`. For multi-package installs,
    each dep is rendered into its own subtree under `out/<dep-name>/`.
 
-3. **`install upload`** — creates one Space per package (parent +
+3. **`installer upload`** — creates one Space per package (parent +
    each locked dep) and one Unit per rendered file, plus one
    untargeted `installer-record` Unit per Space carrying your
    `installer.yaml` + the spec docs (so a freshly cloned work-dir is
@@ -652,8 +653,8 @@ what isn't.
    record to each dep's record. Subsequent uploads against the same
    work-dir reconcile inside a ChangeSet (updates / adds / deletes).
 
-4. **`install plan`** — day-2 read-only preview of what the next
-   `install upload` reconcile would change in ConfigHub. The
+4. **`installer plan`** — day-2 read-only preview of what the next
+   `installer upload` reconcile would change in ConfigHub. The
    operator's job, but several things you author shape how it
    behaves: your `images:` block enables `--set-image`; your
    `default: true` components are adopted by `default`-preset
@@ -671,7 +672,7 @@ recommended defaults pre-applied via per-type ConfigHub functions
 automountServiceAccountToken=false, pod-security labels on
 Namespace, etc.).
 
-Once installed in your ConfigHub organization, `install new
+Once installed in your ConfigHub organization, `installer new
 <kind> <name>` clones any of these templates into your package's
 `bases/default/` with operator customizations applied (renamed,
 optional `--image` / `--port` / `--replicas`, namespace replaced
@@ -681,21 +682,21 @@ function rewrites it at install time).
 Bootstrap the package once per organization:
 
 ```bash
-install setup \
+installer setup \
     --pull ./packages/kubernetes-resources \
     --work-dir /tmp/k8s-res \
     --non-interactive --namespace kubernetes-resources
-install upload --work-dir /tmp/k8s-res --space kubernetes-resources
+installer upload --work-dir /tmp/k8s-res --space kubernetes-resources
 ```
 
-The `install upload` step records the install in
-`~/.confighub/installer/state.yaml`; subsequent `install new`
+The `installer upload` step records the install in
+`~/.confighub/installer/state.yaml`; subsequent `installer new`
 calls find it automatically.
 
 After bootstrap, scaffold a Deployment into your package:
 
 ```bash
-install new deployment my-app \
+installer new deployment my-app \
     --image myorg/my-app:1.0.0 --port 8080 --replicas 3
 ```
 
@@ -705,7 +706,7 @@ Supported kinds: `cronjob`, `daemonset`, `deployment`, `hpa`
 `poddisruptionbudget`), `role`, `rolebinding`, `service`,
 `serviceaccount`, `statefulset`.
 
-`install new --update-kustomization` (default true) appends the
+`installer new --update-kustomization` (default true) appends the
 new file to your package's `bases/default/kustomization.yaml`'s
 resources list.
 
@@ -761,7 +762,7 @@ Supported toolchain values:
 
 ### What the installer does with it
 
-At render time, the `install transformer` plugin (which kustomize
+At render time, the `installer transformer` plugin (which kustomize
 invokes as an exec transformer) recognizes ConfigMaps carrying the
 toolchain annotation and:
 
@@ -824,14 +825,14 @@ These are the prescriptive ones. The full doctrine is
 
 Inputs without defaults force prompts. Components without `default:
 true` are invisible to the `default` preset. Operators of a
-well-authored package can install with `install setup --pull <ref>
+well-authored package can install with `installer setup --pull <ref>
 --namespace foo` and walk away. Aim for that.
 
 ### Declare an `images:` block
 
 Put a kustomize `images:` block in your chosen base's
 `kustomization.yaml`, with `newName` / `newTag` matching what's
-hard-coded in your manifests. This enables `install setup
+hard-coded in your manifests. This enables `installer setup
 --set-image name=ref` for operators. Without it, `--set-image`
 fails fast with a message pointing at this guide. Cost: three lines
 of YAML; benefit: image mirroring + patch-version bumps without
@@ -892,23 +893,23 @@ once, up front.
 
 ## Publishing
 
-The publish flow is `install package` → `install push`:
+The publish flow is `installer package` → `installer push`:
 
 ```bash
 # Build a deterministic .tgz of the source tree.
-install package ./my-package -o my-package-0.1.0.tgz
+installer package ./my-package -o my-package-0.1.0.tgz
 # Output names the digest:
 #   sha256:bc4e...
 
 # Push to an OCI registry as an installer artifact.
-install push my-package-0.1.0.tgz oci://ghcr.io/myorg/my-package:0.1.0
+installer push my-package-0.1.0.tgz oci://ghcr.io/myorg/my-package:0.1.0
 
 # Inspect what's in a registry without pulling the layer.
-install inspect oci://ghcr.io/myorg/my-package:0.1.0
-install list oci://ghcr.io/myorg/my-package
+installer inspect oci://ghcr.io/myorg/my-package:0.1.0
+installer list oci://ghcr.io/myorg/my-package
 ```
 
-`install package` is byte-deterministic: sorted entries, zeroed
+`installer package` is byte-deterministic: sorted entries, zeroed
 mtimes / uids / gids, canonicalized modes, gzip without filename or
 mtime metadata. The same source tree on two machines produces an
 identical tarball.
@@ -929,23 +930,23 @@ What's refused:
 
 ## Signing
 
-After `install push`, attach a cosign signature with
-`install sign <ref>`. Keyless mode (Sigstore Fulcio + Rekor) is
+After `installer push`, attach a cosign signature with
+`installer sign <ref>`. Keyless mode (Sigstore Fulcio + Rekor) is
 the default; pass `--key <ref>` for keyed mode. Operators verify
-with `install verify` or by configuring
+with `installer verify` or by configuring
 `~/.config/installer/policy.yaml` to require signatures matching
 trusted keys / identities — when that policy exists, `installer
-pull` and `install deps update` enforce verification on every
+pull` and `installer deps update` enforce verification on every
 fetch. Requires the `cosign` binary on PATH (override via
 `INSTALLER_COSIGN_BIN`).
 
 ```bash
 # Keyless (Sigstore Fulcio + Rekor — interactive OIDC flow).
 # Add --yes to skip the cosign confirmation prompt in CI.
-install sign oci://ghcr.io/myorg/my-package:0.1.0 --yes
+installer sign oci://ghcr.io/myorg/my-package:0.1.0 --yes
 
 # Keyed.
-install sign oci://ghcr.io/myorg/my-package:0.1.0 --key cosign.key
+installer sign oci://ghcr.io/myorg/my-package:0.1.0 --key cosign.key
 ```
 
 If your package will be consumed by people you don't know, sign every
@@ -954,7 +955,7 @@ substantial.
 
 ## Versioning + upgrade considerations
 
-Operators upgrade with `install setup --pull <new-ref>` against an
+Operators upgrade with `installer setup --pull <new-ref>` against an
 existing work-dir. The setup auto-detects prior state and runs the
 schema-diff machinery between the prior install's package and yours.
 As an author, this gives you a few rules of the road:
@@ -974,7 +975,7 @@ not need to do anything.
 
 ### Changing input types
 
-Errors out setup. The operator must re-run `install setup`
+Errors out setup. The operator must re-run `installer setup`
 interactively to re-answer. Avoid type changes; if you need one, ship
 a new input under a different name and remove the old in a later
 release.
@@ -984,7 +985,7 @@ release.
 - **New component with `default: true`**: adopted on upgrade _only_
   if the operator's prior selection matched the old package's
   default preset exactly. Otherwise the component is available but
-  not enabled by default — operators discover it via `install doc`
+  not enabled by default — operators discover it via `installer doc`
   or the wizard.
 - **New component without `default: true`**: invisible until the
   operator picks it.
@@ -1009,13 +1010,13 @@ applied `--set-image` overrides that are now stored in their
 automatically — your new release does not need to do anything special
 for them.
 
-### Bumping `metadata.version`
+### Bumping `installerMetadata.version`
 
 Use SemVer. The version is what shows up in the `installer-upgrade-…`
 ChangeSet name and in operator-facing diagnostics; honest
 versioning makes operator audit trails readable.
 
-### Bumping `kubeVersion` / `installerVersion`
+### Bumping `installerMetadata.kubeVersion` / `installerMetadata.installerVersion`
 
 Tighten these as you start using newer features. The installer
 refuses to render against incompatible cluster + installer versions.
@@ -1025,19 +1026,19 @@ refuses to render against incompatible cluster + installer versions.
 ### Start a new package
 
 ```bash
-install init ./my-package
+installer init ./my-package
 ```
 
 Scaffolds `installer.yaml` (with the recommended validators),
 `bases/default/kustomization.yaml`, `bases/default/`,
 `components/`, `validation/`. Drop your kustomize resources into
 `bases/default/`, then add inputs / components / dependencies via
-`install edit add` or hand-edit `installer.yaml`.
+`installer edit add` or hand-edit `installer.yaml`.
 
 ### Add a Kubernetes resource
 
 ```bash
-install new deployment my-app --image myorg/my-app:1.0 --port 8080
+installer new deployment my-app --image myorg/my-app:1.0 --port 8080
 ```
 
 Clones the `kubernetes-resources` Deployment template (defaults
@@ -1054,13 +1055,13 @@ YAML and add it to `bases/default/kustomization.yaml`.
 ```bash
 mkdir -p components/monitoring
 # drop kustomization.yaml + resources into components/monitoring/
-install edit add component monitoring \
+installer edit add component monitoring \
     --path components/monitoring \
     --default \
     --description "Adds a ServiceMonitor for Prometheus scraping."
 ```
 
-`install edit add component` writes the entry under
+`installer edit add component` writes the entry under
 `spec.components` and re-validates the manifest. Use `--requires`,
 `--conflicts`, `--valid-for-bases` (each repeatable) for
 constraints.
@@ -1068,33 +1069,33 @@ constraints.
 ### Add an input
 
 ```bash
-install edit add input replicas \
+installer edit add input replicas \
     --type int --default 2 \
     --prompt "Number of replicas"
 ```
 
 Then reference it from `transformers` invocations as
-`{{ .Inputs.replicas }}`. Use `install edit set input <name>` to
-modify, `install edit remove input <name>` to drop.
+`{{ .Inputs.replicas }}`. Use `installer edit set input <name>` to
+modify, `installer edit remove input <name>` to drop.
 
-### Depend on another install package
+### Depend on another installer package
 
 ```bash
-install edit add dependency gateway-api \
+installer edit add dependency gateway-api \
     --package-ref oci://ghcr.io/myorg/gateway-api \
     --version "^1.2.0"
 # Optionally:
-install edit set dependency gateway-api --when-component ingress
+installer edit set dependency gateway-api --when-component ingress
 ```
 
 For more nuanced fields (`selection`, `inputs`, `satisfies`), edit
 `spec.dependencies` directly — they have nested structure that
-`install edit` doesn't model in v1.
+`installer edit` doesn't model in v1.
 
 ### Re-vet after editing the validator list
 
 ```bash
-install vet <work-dir>
+installer vet <work-dir>
 ```
 
 Runs `spec.validators` against the existing `out/manifests/`
@@ -1106,14 +1107,14 @@ case.)
 
 ### Cut a release
 
-1. Bump `metadata.version` per SemVer.
-2. `install package ./my-package -o my-package-X.Y.Z.tgz` — record
+1. Bump `installerMetadata.version` per SemVer.
+2. `installer package ./my-package -o my-package-X.Y.Z.tgz` — record
    the printed sha256.
-3. `install push my-package-X.Y.Z.tgz oci://.../my-package:X.Y.Z`.
-4. `install sign oci://.../my-package:X.Y.Z --yes` (keyless) or
-   `install sign oci://.../my-package:X.Y.Z --key cosign.key`
+3. `installer push my-package-X.Y.Z.tgz oci://.../my-package:X.Y.Z`.
+4. `installer sign oci://.../my-package:X.Y.Z --yes` (keyless) or
+   `installer sign oci://.../my-package:X.Y.Z --key cosign.key`
    (keyed).
-5. Optionally `install tag oci://.../my-package:X.Y.Z latest` if
+5. Optionally `installer tag oci://.../my-package:X.Y.Z latest` if
    you publish a moving `latest` tag (most don't — a SemVer tag is
    reproducible).
 
@@ -1121,7 +1122,7 @@ case.)
 
 Ship `validation/` with `command.yaml` / `env.schema.json` /
 `runtime.yaml` — generated from the workload itself, committed in
-the package. `install doc <ref>` surfaces them. AI agents and
+the package. `installer doc <ref>` surfaces them. AI agents and
 humans both benefit.
 
 ## Next steps

--- a/docs/author-tutorial.md
+++ b/docs/author-tutorial.md
@@ -1,9 +1,9 @@
 # Author Tutorial: Build a Package From Scratch
 
-Walks you through authoring a small install package — a status
+Walks you through authoring a small installer package — a status
 page service called `statusboard` — from an empty directory to a
 signed OCI artifact. Takes ~20 minutes. Built from the new author
-shortcuts (`install init` / `new` / `edit` / `vet`) so you author
+shortcuts (`installer init` / `new` / `edit` / `vet`) so you author
 ~50 lines of YAML by the end instead of ~150.
 
 By the end you'll have:
@@ -20,7 +20,7 @@ For the doctrine the installer is anchored to, see
 
 ## Prerequisites
 
-- `install` binary on PATH (or invoke `bin/install` from a clone).
+- `installer` binary on PATH (or invoke `bin/installer` from a clone).
 - `kustomize` on PATH.
 - `cub` on PATH and signed in (`cub auth login`).
 - The `kubernetes-resources` package bootstrapped in your
@@ -30,27 +30,27 @@ For the doctrine the installer is anchored to, see
 
 ### One-time: bootstrap kubernetes-resources
 
-`install new` clones canonical resource templates from the
+`installer new` clones canonical resource templates from the
 `kubernetes-resources` package in ConfigHub. Install it once per
 organization:
 
 ```bash
 cd <path-to-installer-repo>
-install setup --pull ./packages/kubernetes-resources \
+installer setup --pull ./packages/kubernetes-resources \
     --work-dir /tmp/k8s-res \
     --non-interactive --namespace kubernetes-resources
-install upload --work-dir /tmp/k8s-res --space kubernetes-resources
+installer upload --work-dir /tmp/k8s-res --space kubernetes-resources
 # Recorded kubernetes-resources install in ~/.confighub/installer/state.yaml
 ```
 
-After this, `install new` knows where to find templates without
+After this, `installer new` knows where to find templates without
 asking. The bootstrap is per-organization; if you switch ConfigHub
 contexts, re-bootstrap there.
 
 ## Step 1: scaffold the package
 
 ```bash
-install init .
+installer init .
 # Initialized package "statusboard-pkg" at /Users/.../statusboard-pkg
 #   - installer.yaml
 #   - bases/default/
@@ -58,7 +58,7 @@ install init .
 #   - validation/
 ```
 
-`install init` writes the manifest with one default base, a
+`installer init` writes the manifest with one default base, a
 `set-namespace` group under `spec.transformers`, and the recommended
 validator chain (`vet-schemas`, `vet-merge-keys`, `vet-format`).
 We'll fix the package name in a moment. Have a look at what was
@@ -70,6 +70,7 @@ cat installer.yaml
 # kind: Package
 # metadata:
 #   name: statusboard-pkg
+# installerMetadata:
 #   version: 0.1.0
 # spec:
 #   bases:
@@ -93,18 +94,18 @@ Rename the package and let `init` re-write the manifest with
 `--force`:
 
 ```bash
-install init . --name statusboard --force > /dev/null
+installer init . --name statusboard --force > /dev/null
 ```
 
 Now scaffold the resources. We want a Namespace, a Deployment, and
-a Service. `install new` clones each from the
+a Service. `installer new` clones each from the
 `kubernetes-resources` package with operator customizations
 applied:
 
 ```bash
-install new namespace statusboard
-install new deployment statusboard --image nginxdemos/hello:plain-text --port 80 --replicas 1
-install new service statusboard --port 80
+installer new namespace statusboard
+installer new deployment statusboard --image nginxdemos/hello:plain-text --port 80 --replicas 1
+installer new service statusboard --port 80
 ```
 
 Each writes a file under `bases/default/` and updates
@@ -127,7 +128,7 @@ cat bases/default/kustomization.yaml
 Render and verify:
 
 ```bash
-install setup --pull ./. --work-dir /tmp/statusboard \
+installer setup --pull ./. --work-dir /tmp/statusboard \
     --non-interactive --namespace demo
 ls /tmp/statusboard/out/manifests/
 # deployment-demo-statusboard.yaml
@@ -152,18 +153,18 @@ Two things to notice:
 ## Step 2: a wizard input
 
 Add a `replicas` input so operators can size the deployment without
-editing the package. Use `install edit add input`:
+editing the package. Use `installer edit add input`:
 
 ```bash
-install edit add input replicas \
+installer edit add input replicas \
     --type int --default 1 \
     --prompt "Number of replicas" \
     --description "How many statusboard pods to run."
 ```
 
 Wire it into `spec.transformers`. The chain already has
-`set-namespace` from `install init`; we want to add `set-replicas`
-after it. There's no `install edit` for transformer entries yet,
+`set-namespace` from `installer init`; we want to add `set-replicas`
+after it. There's no `installer edit` for transformer entries yet,
 so hand-edit `installer.yaml`:
 
 ```yaml
@@ -180,7 +181,7 @@ Re-render with a non-default value:
 
 ```bash
 rm -rf /tmp/statusboard
-install setup --pull ./. --work-dir /tmp/statusboard \
+installer setup --pull ./. --work-dir /tmp/statusboard \
     --non-interactive --namespace demo --input replicas=3
 grep replicas /tmp/statusboard/out/manifests/deployment-demo-statusboard.yaml
 #  replicas: 3
@@ -190,7 +191,7 @@ And confirm the default takes when `--input replicas=…` is absent:
 
 ```bash
 rm -rf /tmp/statusboard
-install setup --pull ./. --work-dir /tmp/statusboard \
+installer setup --pull ./. --work-dir /tmp/statusboard \
     --non-interactive --namespace demo
 grep replicas /tmp/statusboard/out/manifests/deployment-demo-statusboard.yaml
 #  replicas: 1
@@ -206,10 +207,10 @@ grep replicas /tmp/statusboard/out/manifests/deployment-demo-statusboard.yaml
 Operators frequently want to pin a specific image tag, mirror to an
 internal registry, or bump a patch version — without hand-editing
 your source. Declare a kustomize `images:` block in your base, and
-they get `install setup --set-image` for free.
+they get `installer setup --set-image` for free.
 
 Edit `bases/default/kustomization.yaml` to add an `images:` block.
-`install init` already left a comment showing the shape; add:
+`installer init` already left a comment showing the shape; add:
 
 ```yaml
 images:
@@ -228,7 +229,7 @@ Test with an override:
 
 ```bash
 rm -rf /tmp/statusboard
-install setup --pull ./. \
+installer setup --pull ./. \
   --work-dir /tmp/statusboard \
   --non-interactive --namespace demo \
   --set-image nginxdemos/hello=nginxdemos/hello:plain-text-v2
@@ -279,10 +280,10 @@ resources:
 YAML
 ```
 
-Register it via `install edit add component`:
+Register it via `installer edit add component`:
 
 ```bash
-install edit add component monitoring \
+installer edit add component monitoring \
     --path components/monitoring --default \
     --description "Adds a ServiceMonitor for Prometheus scraping."
 ```
@@ -295,14 +296,14 @@ Two things to notice:
 - For the `externalRequires` declaration ("cluster needs the
   ServiceMonitor CRD before this component can apply") hand-edit
   `installer.yaml` and append it to the `monitoring` component
-  entry — `install edit` doesn't model nested
+  entry — `installer edit` doesn't model nested
   externalRequires today.
 
 Test:
 
 ```bash
 rm -rf /tmp/statusboard
-install setup --pull ./. --work-dir /tmp/statusboard --non-interactive \
+installer setup --pull ./. --work-dir /tmp/statusboard --non-interactive \
   --namespace demo --select monitoring
 ls /tmp/statusboard/out/manifests/
 # adds: servicemonitor-demo-statusboard.yaml
@@ -312,7 +313,7 @@ Or via the `default` preset:
 
 ```bash
 rm -rf /tmp/statusboard
-install setup --pull ./. --work-dir /tmp/statusboard --non-interactive \
+installer setup --pull ./. --work-dir /tmp/statusboard --non-interactive \
   --namespace demo --components default
 ls /tmp/statusboard/out/manifests/
 # also adds servicemonitor-demo-statusboard.yaml
@@ -374,14 +375,14 @@ patches:
 YAML
 ```
 
-Register both via `install edit add component`:
+Register both via `installer edit add component`:
 
 ```bash
-install edit add component ingress \
+installer edit add component ingress \
     --path components/ingress \
     --description "Expose the service via an Ingress."
 
-install edit add component ingress-tls \
+installer edit add component ingress-tls \
     --path components/ingress-tls \
     --description "Annotate the Ingress to request a cert from cert-manager." \
     --requires ingress
@@ -396,7 +397,7 @@ errors on conflicts. Test:
 
 ```bash
 rm -rf /tmp/statusboard
-install setup --pull ./. --work-dir /tmp/statusboard --non-interactive \
+installer setup --pull ./. --work-dir /tmp/statusboard --non-interactive \
   --namespace demo --select ingress-tls
 cat /tmp/statusboard/out/spec/selection.yaml
 #   components: [ingress, ingress-tls]   # both selected
@@ -407,10 +408,10 @@ cat /tmp/statusboard/out/spec/selection.yaml
 The default validator chain (`vet-schemas`, `vet-merge-keys`,
 `vet-format`) ran during render in steps 1–5. To re-run validators
 against the existing render — without re-running kustomize — use
-`install vet`:
+`installer vet`:
 
 ```bash
-install vet --work-dir /tmp/statusboard
+installer vet --work-dir /tmp/statusboard
 # Vetting N resource(s) under /tmp/statusboard/out/manifests against 1 validator group(s)...
 # All validators passed.
 ```
@@ -435,7 +436,7 @@ flags). Try it interactively to see what an operator sees:
 
 ```bash
 rm -rf /tmp/statusboard
-install setup --pull ./. --work-dir /tmp/statusboard
+installer setup --pull ./. --work-dir /tmp/statusboard
 # Prompts:
 #   Components: [minimal/default/all/selected]
 #   Kubernetes namespace: <text>
@@ -452,7 +453,7 @@ ask one or two questions and ship.
 Build a deterministic tarball:
 
 ```bash
-install package ./. -o statusboard-0.1.0.tgz
+installer package ./. -o statusboard-0.1.0.tgz
 # Wrote statusboard-0.1.0.tgz (sha256:bc4e...)
 ```
 
@@ -460,30 +461,30 @@ Two builds on two machines from the same source produce the same
 sha256. Publish to a registry:
 
 ```bash
-install push statusboard-0.1.0.tgz oci://ghcr.io/myorg/statusboard:0.1.0
+installer push statusboard-0.1.0.tgz oci://ghcr.io/myorg/statusboard:0.1.0
 ```
 
 Operators can now:
 
 ```bash
-install inspect oci://ghcr.io/myorg/statusboard:0.1.0
-install pull oci://ghcr.io/myorg/statusboard:0.1.0 ./statusboard-pulled
+installer inspect oci://ghcr.io/myorg/statusboard:0.1.0
+installer pull oci://ghcr.io/myorg/statusboard:0.1.0 ./statusboard-pulled
 ```
 
-For production releases, sign with `install sign` after push.
+For production releases, sign with `installer sign` after push.
 Keyless (Sigstore Fulcio + Rekor) is the default — an interactive
 OIDC flow opens a browser; `--yes` skips cosign's TTY confirmation
 prompt for CI:
 
 ```bash
-install sign oci://ghcr.io/myorg/statusboard:0.1.0 --yes
+installer sign oci://ghcr.io/myorg/statusboard:0.1.0 --yes
 ```
 
 Or keyed:
 
 ```bash
 cosign generate-key-pair
-install sign oci://ghcr.io/myorg/statusboard:0.1.0 --key cosign.key
+installer sign oci://ghcr.io/myorg/statusboard:0.1.0 --key cosign.key
 ```
 
 Requires the `cosign` binary on PATH (override via
@@ -498,9 +499,9 @@ re-package, re-push. Operators upgrade by re-running setup with
 `--pull` pointed at the new ref:
 
 ```bash
-install setup --pull oci://ghcr.io/myorg/statusboard:0.2.0 \
+installer setup --pull oci://ghcr.io/myorg/statusboard:0.2.0 \
     --work-dir <work-dir>
-install upload --work-dir <work-dir> --yes
+installer upload --work-dir <work-dir> --yes
 ```
 
 Setup's schema-diff machinery diffs your old vs new schema:

--- a/docs/consumer-guide.md
+++ b/docs/consumer-guide.md
@@ -26,12 +26,12 @@ installer is anchored to lives in [principles.md](./principles.md).
 
 Day-2 commands operate on the same work-dir:
 
-- `install setup` — re-runs wizard + render against the existing
+- `installer setup` — re-runs wizard + render against the existing
   package, picking up edits to `out/spec/inputs.yaml` or a different
   pulled package version.
-- `install plan` — show what's different between the work-dir and
+- `installer plan` — show what's different between the work-dir and
   ConfigHub.
-- `install upload` — reconcile the work-dir with ConfigHub. First
+- `installer upload` — reconcile the work-dir with ConfigHub. First
   upload creates Units; subsequent uploads open a ChangeSet and
   update/add/delete.
 
@@ -47,7 +47,7 @@ packages under `packages/` as starting points:
 
 - `packages/kubernetes-resources/` — eleven canonical Kubernetes
   resource templates with best-practice defaults pre-applied. Used
-  by `install new` to scaffold resources into your own packages
+  by `installer new` to scaffold resources into your own packages
   (see [author guide](./author-guide.md#kubernetes-resources-package)).
 - `packages/worker/` — the ConfigHub bridge worker.
 
@@ -57,16 +57,16 @@ you have a candidate ref:
 ```bash
 # What's in this artifact? Reads only the manifest + config blob,
 # does not pull the layer.
-install inspect oci://ghcr.io/myorg/statusboard:0.1.0
+installer inspect oci://ghcr.io/myorg/statusboard:0.1.0
 
 # What versions are available?
-install list oci://ghcr.io/myorg/statusboard
+installer list oci://ghcr.io/myorg/statusboard
 ```
 
 For private registries, log in first:
 
 ```bash
-install login ghcr.io
+installer login ghcr.io
 # uses ~/.docker/config.json; same auth as docker / podman
 ```
 
@@ -79,7 +79,7 @@ is the only command that talks to ConfigHub.
 mkdir my-statusboard && cd my-statusboard
 
 # 1. Pull the package, answer the wizard, and render.
-install setup --pull oci://ghcr.io/myorg/statusboard:0.1.0 \
+installer setup --pull oci://ghcr.io/myorg/statusboard:0.1.0 \
     --namespace statusboard
 
 # Interactive prompts (skip with --non-interactive + flags):
@@ -93,7 +93,7 @@ output to `./out/spec/`, then renders manifests to `./out/manifests/`.
 If you prefer to script the wizard:
 
 ```bash
-install setup \
+installer setup \
     --pull oci://ghcr.io/myorg/statusboard:0.1.0 \
     --non-interactive \
     --namespace statusboard \
@@ -105,7 +105,7 @@ The working directory defaults to `.`. To work in an explicit dir
 instead, pass `--work-dir <dir>` (no `cd`-into-it needed):
 
 ```bash
-install setup --pull oci://ghcr.io/myorg/statusboard:0.1.0 \
+installer setup --pull oci://ghcr.io/myorg/statusboard:0.1.0 \
     --work-dir /tmp/statusboard --namespace statusboard
 ```
 
@@ -121,17 +121,17 @@ ls out/manifests/
 You can edit these files directly — the next `plan` / `upload` will
 diff your edits against ConfigHub. But editing rendered output is
 usually the wrong layer; prefer editing `out/spec/inputs.yaml` and
-re-running `install setup`. See "Where to make changes" below.
+re-running `installer setup`. See "Where to make changes" below.
 
 Finally, upload to ConfigHub:
 
 ```bash
 # 2. Upload: one Unit per file, plus an installer-record Unit
 #    holding installer.yaml + spec/ docs.
-install upload --space statusboard-prod
+installer upload --space statusboard-prod
 ```
 
-`install upload` records the destination Space (and your active
+`installer upload` records the destination Space (and your active
 cub organization + server) into `./out/spec/upload.yaml` so all
 subsequent commands re-enter without you re-typing.
 
@@ -139,13 +139,13 @@ For multi-package installs (a parent that declares dependencies),
 use `--space-pattern` instead of `--space`:
 
 ```bash
-install upload --space-pattern '{{.PackageName}}-prod'
+installer upload --space-pattern '{{.PackageName}}-prod'
 # Each package — parent + each locked dep — gets its own Space.
 ```
 
 If the package ships application-config files (a `configMapGenerator`
 tagged with `installer.confighub.com/toolchain`, e.g.
-`AppConfig/Properties` or `AppConfig/Env`), `install upload` also
+`AppConfig/Properties` or `AppConfig/Env`), `installer upload` also
 creates a separate AppConfig Unit holding the raw config body, a
 `render-configmap` Invocation, and a placeholder Kubernetes/YAML Unit
 wired by an Upsert link that renders the ConfigMap into the
@@ -169,15 +169,15 @@ interactively to walk every prompt with prior values pre-filled):
 # Re-run setup. If a prior install is recorded, it loads those values
 # and offers "Re-use last choices?" — answer no to walk every prompt
 # with the prior values pre-filled.
-install setup
+installer setup
 
 # Or hand-edit and re-render via setup --non-interactive:
 $EDITOR out/spec/inputs.yaml
-install setup --non-interactive
+installer setup --non-interactive
 ```
 
-Then `install plan` to see what the change would do, and
-`install upload --yes` to apply it.
+Then `installer plan` to see what the change would do, and
+`installer upload --yes` to apply it.
 
 ### 2. `--set-image` overrides (install-time, image-only)
 
@@ -187,8 +187,8 @@ chosen base, you can override at setup time without editing the
 package source:
 
 ```bash
-install setup --set-image myorg/statusboard=myorg/statusboard:1.2.4
-install upload
+installer setup --set-image myorg/statusboard=myorg/statusboard:1.2.4
+installer upload
 ```
 
 The override is recorded in `out/spec/inputs.yaml` under
@@ -206,7 +206,7 @@ cub function do --space statusboard-prod set-container-image \
     deployment-statusboard-statusboard app myorg/statusboard:1.2.5
 ```
 
-These edits survive re-render: `install upload` uses
+These edits survive re-render: `installer upload` uses
 `--merge-external-source`, which only writes paths that changed in
 the new render. Your post-install ConfigHub edits are preserved.
 
@@ -217,14 +217,14 @@ change tracked in cub's revision history rather than your work-dir.
 Post-install mutations can also be made with [kpt](https://kpt.dev)
 instead of ConfigHub — a git-based configuration-as-data tool whose
 package merge preserves your edits across re-renders the same way
-`--merge-external-source` does. This is an alternative to `install
+`--merge-external-source` does. This is an alternative to `installer
 upload` + `cub unit apply` for kpt users, or for trying post-install
 changes without ConfigHub first. See the [kpt guide](./kpt-guide.md).
 
 ### What NOT to do
 
 - **Don't edit the package source tree** (`./package/`). The next
-  `install setup --pull` overwrites it. If you find yourself
+  `installer setup --pull` overwrites it. If you find yourself
   running `kustomize edit` against `./package/...`, stop —
   use `--set-image` or post-install mutations instead. (See
   [Principle 1](./principles.md#1-package-files-are-read-only-to-consumers).)
@@ -233,7 +233,7 @@ changes without ConfigHub first. See the [kpt guide](./kpt-guide.md).
 
 ### Plan
 
-`install plan` is read-only. It shows three things per Space:
+`installer plan` is read-only. It shows three things per Space:
 
 ```
 Plan: 1 to add, 2 to change, 0 to delete.
@@ -262,12 +262,12 @@ of whether plan shows other changes.
 
 ### Upload reconcile
 
-`install upload` on an already-uploaded work-dir reconciles the
+`installer upload` on an already-uploaded work-dir reconciles the
 local render with ConfigHub. It re-runs the same plan and executes
 it inside a ChangeSet:
 
 ```bash
-install upload --yes
+installer upload --yes
 # == Space statusboard-prod (statusboard@0.1.0) ==
 # ChangeSet: statusboard-prod/installer-update-20260514-…
 # Successfully updated unit deployment-statusboard-statusboard …
@@ -295,7 +295,7 @@ clear the gate first if you really intend to tear them down.
 A re-run on a converged work-dir is a no-op (no ChangeSet opened):
 
 ```bash
-install upload
+installer upload
 # No changes.
 ```
 
@@ -311,7 +311,7 @@ To revert a reconcile upload, run the printed `cub unit update --patch
 - **Empties** from that upload (Units that dropped out of the render)
   are not part of the ChangeSet, but the prior Data is preserved in the
   Unit's revision history — restore it with `cub unit update --restore`
-  against the pre-empty revision, or re-render and re-run `install
+  against the pre-empty revision, or re-render and re-run `installer
   upload` to repopulate it.
 
 If you need to roll back a multi-Unit change, this is where having
@@ -336,16 +336,16 @@ default, etc.).
 ### Routine upgrade
 
 ```bash
-install setup --pull oci://ghcr.io/myorg/statusboard:0.2.0
+installer setup --pull oci://ghcr.io/myorg/statusboard:0.2.0
 # Loaded prior install state from confighub.
 # Adopted new default for input "metrics_port": 9090
 # Adopted new default-flagged component(s): metrics-collector
 # Wizard wrote out/spec/{selection,inputs}.yaml
 # Rendered 4 manifest(s) to out/manifests/
-# Next: install upload --work-dir … --space <slug>
+# Next: installer upload --work-dir … --space <slug>
 
-install plan                         # preview
-install upload --yes                 # apply
+installer plan                         # preview
+installer upload --yes                 # apply
 ```
 
 The pull is atomic — it stages into a sibling temp dir and renames
@@ -356,8 +356,8 @@ intact. If you want a record of the prior package source, commit
 For a one-shot upgrade + execute, chain:
 
 ```bash
-install setup --pull oci://ghcr.io/myorg/statusboard:0.2.0 && \
-    install upload --yes
+installer setup --pull oci://ghcr.io/myorg/statusboard:0.2.0 && \
+    installer upload --yes
 ```
 
 ### Image-only upgrade
@@ -366,8 +366,8 @@ A common case is "same package version, new image tag" — e.g., a
 patch-level container bump:
 
 ```bash
-install setup --set-image myorg/statusboard=myorg/statusboard:0.2.1
-install upload --yes
+installer setup --set-image myorg/statusboard=myorg/statusboard:0.2.1
+installer upload --yes
 ```
 
 (`--pull` is optional here — if you've already got the version
@@ -402,7 +402,7 @@ changed in a way the collector picks up (a worker was rotated, the
 cub server moved, etc.):
 
 ```bash
-install setup --pull oci://ghcr.io/myorg/statusboard:0.2.0
+installer setup --pull oci://ghcr.io/myorg/statusboard:0.2.0
 # even if 0.2.0 is what you already have — re-runs the collector.
 ```
 
@@ -411,13 +411,13 @@ install setup --pull oci://ghcr.io/myorg/statusboard:0.2.0
 Most operators only need `setup` and `upload`. The granular commands
 are available for step-by-step debugging or advanced workflows:
 
-- `install pull <ref> --work-dir <dir>` — fetch only, no wizard.
+- `installer pull <ref> --work-dir <dir>` — fetch only, no wizard.
   Writes to `<work-dir>/package/`.
-- `install wizard <ref> --work-dir <dir> [--render=false]` — pull
+- `installer wizard <ref> --work-dir <dir> [--render=false]` — pull
   + Q&A. Renders by default; pass `--render=false` to skip.
-- `install render --work-dir <dir>` — render only; reads existing
+- `installer render --work-dir <dir>` — render only; reads existing
   `<work-dir>/package/` + `<work-dir>/out/spec/`.
-- `install deps update --work-dir <dir>` — multi-package only:
+- `installer deps update --work-dir <dir>` — multi-package only:
   resolve the dependency DAG and write `out/spec/lock.yaml`. (`setup`
   runs this automatically before render.)
 
@@ -434,17 +434,17 @@ pull. Two ways:
 ### One-off verification
 
 ```bash
-install verify oci://ghcr.io/myorg/statusboard:0.1.0 --key cosign.pub
+installer verify oci://ghcr.io/myorg/statusboard:0.1.0 --key cosign.pub
 # or for keyless (Sigstore Fulcio + OIDC):
-install verify oci://ghcr.io/myorg/statusboard:0.1.0 \
+installer verify oci://ghcr.io/myorg/statusboard:0.1.0 \
     --identity author@myorg.com --issuer https://accounts.google.com
 ```
 
 ### Enforced policy
 
 Configure `~/.config/installer/policy.yaml` to require signatures on
-every fetch. When the file exists, `install pull`, `installer
-setup --pull`, and `install deps update` enforce verification
+every fetch. When the file exists, `installer pull`, `installer
+setup --pull`, and `installer deps update` enforce verification
 automatically.
 
 ```yaml
@@ -481,25 +481,25 @@ Space:
 ```bash
 WD=stack-install
 mkdir $WD && cd $WD
-install setup --pull oci://ghcr.io/myorg/stack:1.0.0 --namespace stack
+installer setup --pull oci://ghcr.io/myorg/stack:1.0.0 --namespace stack
 
 ls out/manifests/                # parent's manifests
 ls out/<dep-name>/manifests/     # each dep's manifests
 
 # Upload one Space per package.
-install upload --space-pattern '{{.PackageName}}-prod'
+installer upload --space-pattern '{{.PackageName}}-prod'
 ```
 
 Plan / upload work the same way — each operates across all locked
 packages, opens one ChangeSet per Space when there are updates, and
 prints a per-Space revert command.
 
-`install deps tree` shows the resolved DAG if you want to audit
+`installer deps tree` shows the resolved DAG if you want to audit
 who depends on what.
 
 ## Re-entering an install from a fresh machine
 
-The `out/spec/upload.yaml` file written by `install upload` is
+The `out/spec/upload.yaml` file written by `installer upload` is
 what bootstraps everything. From a fresh clone of the work-dir, all
 day-2 commands work because they read `upload.yaml` to find the
 Spaces.
@@ -512,7 +512,7 @@ package's `installer-record` Unit on ConfigHub holds the full spec
 mkdir recovered && cd recovered
 
 # Pull the package source.
-install pull oci://ghcr.io/myorg/statusboard:0.1.0
+installer pull oci://ghcr.io/myorg/statusboard:0.1.0
 
 # Pull the installer-record Unit body and split it into spec docs.
 mkdir -p out/spec
@@ -522,8 +522,8 @@ cub unit data --space statusboard-prod installer-record \
 # / upload.yaml is a manual step today; an `installer recover`
 # command will automate this.)
 
-install render
-install plan       # should be No changes if cub is in sync
+installer render
+installer plan       # should be No changes if cub is in sync
 ```
 
 ## Common errors
@@ -543,20 +543,20 @@ the one the install was uploaded to. Switch with `cub context set
 
 ### `no package found in <work-dir>/package/ — pass --pull <ref> to fetch one`
 
-You ran `install setup` (without `--pull`) in a work-dir that has
+You ran `installer setup` (without `--pull`) in a work-dir that has
 never been populated. Pass `--pull <ref>` to fetch the package, or
-run `install pull <ref> --work-dir <dir>` first.
+run `installer pull <ref> --work-dir <dir>` first.
 
 ### `package declares dependencies but … lock.yaml does not exist`
 
-You ran a granular command (`install render` / `install upload`)
-before `install deps update` on a multi-package install. Run
-`install deps update` first. `install setup` runs this
+You ran a granular command (`installer render` / `installer upload`)
+before `installer deps update` on a multi-package install. Run
+`installer deps update` first. `installer setup` runs this
 automatically.
 
 ### `the new package adds N required input(s) that the prior install did not answer`
 
-A non-interactive `install setup --pull <new-ref>` ran against a
+A non-interactive `installer setup --pull <new-ref>` ran against a
 package version that adds new required inputs. Re-run setup
 interactively to answer them.
 
@@ -572,26 +572,26 @@ re-run.
 The installer-record Unit was deleted from cub, or the recorded
 Space slug in `upload.yaml` is stale. Setup's prior-state load falls
 back to local `out/spec/*.yaml` automatically with a warning. If you
-want to refresh ConfigHub from local state, re-run `install upload
+want to refresh ConfigHub from local state, re-run `installer upload
 --space <slug>` against the same Space.
 
 ## Quick reference
 
 | Task | Command |
 |---|---|
-| Discover what's in a registry | `install inspect <ref>` / `install list <repo>` |
-| Pull a package locally | `install pull <ref> [--work-dir <dir>]` |
-| Read the package's surface | `install doc <dir>` |
-| Install (interactive) | `install setup --pull <ref> --namespace <ns>` |
-| Install (scripted) | `install setup --pull <ref> --non-interactive --namespace <ns> --components default` |
-| Re-render after editing inputs | `install setup --non-interactive` |
-| Push to ConfigHub | `install upload --space <slug>` |
-| Preview cub-side changes | `install plan` |
-| Apply cub-side changes | `install upload --yes` |
-| Bump an image | `install setup --set-image NAME=REF && install upload --yes` |
-| Upgrade to a new version | `install setup --pull <new-ref> && install upload --yes` |
-| Resolve deps (advanced) | `install deps update` (multi-package only; setup does this automatically) |
-| Verify a signature | `install verify <ref> --key cosign.pub` |
+| Discover what's in a registry | `installer inspect <ref>` / `installer list <repo>` |
+| Pull a package locally | `installer pull <ref> [--work-dir <dir>]` |
+| Read the package's surface | `installer doc <dir>` |
+| Install (interactive) | `installer setup --pull <ref> --namespace <ns>` |
+| Install (scripted) | `installer setup --pull <ref> --non-interactive --namespace <ns> --components default` |
+| Re-render after editing inputs | `installer setup --non-interactive` |
+| Push to ConfigHub | `installer upload --space <slug>` |
+| Preview cub-side changes | `installer plan` |
+| Apply cub-side changes | `installer upload --yes` |
+| Bump an image | `installer setup --set-image NAME=REF && installer upload --yes` |
+| Upgrade to a new version | `installer setup --pull <new-ref> && installer upload --yes` |
+| Resolve deps (advanced) | `installer deps update` (multi-package only; setup does this automatically) |
+| Verify a signature | `installer verify <ref> --key cosign.pub` |
 | Make signature mandatory | edit `~/.config/installer/policy.yaml` |
 
 ## Where to go next

--- a/docs/kpt-guide.md
+++ b/docs/kpt-guide.md
@@ -2,7 +2,7 @@
 
 The installer renders fully-materialized Kubernetes manifests to
 `out/manifests/`. The recommended day-2 path is to upload them to
-ConfigHub and reconcile with `install upload` + `cub unit apply`:
+ConfigHub and reconcile with `installer upload` + `cub unit apply`:
 ConfigHub's `--merge-external-source` preserves your post-install edits
 across re-renders (see [Post-install ConfigHub
 mutations](./consumer-guide.md#3-post-install-confighub-mutations)).
@@ -12,7 +12,7 @@ using git instead of ConfigHub. This guide is for two audiences:
 
 - you already use kpt and want to manage the rendered output with it;
 - you want to make post-install changes **without** standing up
-  ConfigHub first — an alternative to `install upload` and `cub unit
+  ConfigHub first — an alternative to `installer upload` and `cub unit
   apply`.
 
 ## What kpt gives you
@@ -37,7 +37,7 @@ See the kpt package operations reference:
 Three pieces, all in one git repo (your work-dir):
 
 - **Base package** — `out/manifests/`, turned into a kpt package with a
-  `Kptfile`. Every `install render` rewrites it. This is the upstream.
+  `Kptfile`. Every `installer render` rewrites it. This is the upstream.
 - **Post-install clone** — `out/post-install/manifests/`, a kpt clone of
   the base. **You make your edits here**, never in the base.
 - **Upgrade** — re-render the base, commit, then `kpt pkg update` in the
@@ -110,8 +110,8 @@ the inventory it won't prune deleted resources.) See
 # 1. Re-render the base (new package version, new inputs, image bump…).
 #    --clean prunes resources dropped by the upgrade while PRESERVING the
 #    base package's Kptfile, so out/manifests stays a valid kpt package.
-install setup --pull <new-ref> --work-dir my-workdir --clean
-#    (or, to re-render in place without re-pulling: install render --clean)
+installer setup --pull <new-ref> --work-dir my-workdir --clean
+#    (or, to re-render in place without re-pulling: installer render --clean)
 git add . && git commit -m "render <pkg>@<new-version>"
 
 # 2. Merge the new render into your post-install clone.

--- a/docs/lifecycle-plan.md
+++ b/docs/lifecycle-plan.md
@@ -59,13 +59,13 @@ working interactive flow built on `survey/v2`.
     feeding scripted input, asserting the resulting `Result`.
   - `internal/wizard/prior_test.go` — local-only prior state load;
     ConfigHub fetch is exercised in the e2e script.
-- Acceptance: `install wizard ./examples/hello-app` (no flags) walks
+- Acceptance: `installer wizard ./examples/hello-app` (no flags) walks
   through prompts and emits the same files the non-interactive path
   produces. Re-running it offers "Re-use last choices?" and renders an
   unchanged spec. Re-running it after `cub context set` to a different
   org fails fast naming both org IDs.
 
-## Phase B — `install plan`
+## Phase B — `installer plan`
 
 Goal: read-only diff of `<work-dir>/out` against ConfigHub.
 
@@ -85,7 +85,7 @@ Goal: read-only diff of `<work-dir>/out` against ConfigHub.
   - Per-Space `Images:` footer from
     `cub function do --space <slug> get-container-image '*'` against the
     just-rendered manifests (not against ConfigHub).
-- New: `internal/cli/plan.go` — `install plan <work-dir>`. Reuses
+- New: `internal/cli/plan.go` — `installer plan <work-dir>`. Reuses
   `upload.Discover` to walk packages.
 - New: `internal/cli/plan_test.go` (table tests for print rendering).
 - Add to existing e2e: after `upload`, edit one rendered file, re-render,
@@ -93,7 +93,7 @@ Goal: read-only diff of `<work-dir>/out` against ConfigHub.
 - Acceptance: plan against an unchanged work-dir prints
   "No changes." Hand-edit one resource, re-render, plan shows the diff.
 
-## Phase C — `install update`
+## Phase C — `installer update`
 
 Goal: execute the Phase B plan inside a ChangeSet.
 
@@ -115,7 +115,7 @@ Goal: execute the Phase B plan inside a ChangeSet.
     Gated on `opts.Yes` or interactive confirm-each, and refused for
     Units carrying a DestroyGate. Stale links are auto-removed by
     ConfigHub when the Data no longer references them.
-- New: `internal/cli/update.go` — `install update <work-dir> [--yes]
+- New: `internal/cli/update.go` — `installer update <work-dir> [--yes]
   [--changeset <slug>]`. Default ChangeSet slug:
   `installer-update-<RFC3339-timestamp>`. Plan output names the
   ChangeSet that will be opened and prints the revert command.
@@ -131,7 +131,7 @@ Goal: execute the Phase B plan inside a ChangeSet.
   - Restoring `Before:ChangeSet:<slug>` reverts the updates from that
     invocation.
 
-## Phase D — `install upgrade` and `install upgrade-apply`
+## Phase D — `installer upgrade` and `installer upgrade-apply`
 
 Goal: split the upgrade flow into "stage" (pull, re-wizard non-
 interactively, re-collect facts, re-render, plan) and "promote"
@@ -147,21 +147,21 @@ interactively, re-collect facts, re-render, plan) and "promote"
   - Mirror helpers for components: `DiffComponents(oldPkg, newPkg,
     priorSelection)` honoring the prior preset (recorded in
     `selection.yaml`) for `default: true` adoption.
-- New: `internal/cli/upgrade.go` — `install upgrade <work-dir> <ref>
+- New: `internal/cli/upgrade.go` — `installer upgrade <work-dir> <ref>
   [--set-image …] [--apply]`.
   - Pulls into `<work-dir>/.upgrade/package`.
   - Runs `schemadiff.DiffInputs` and `DiffComponents`. Interactive
     mode prompts for new required inputs; non-interactive mode fails
-    with the missing input names and the `install wizard <work-dir>`
+    with the missing input names and the `installer wizard <work-dir>`
     hint.
   - Builds `RawAnswers` from carry + answers + prior selection.
   - Runs the collector against the new package.
   - Calls `render.Render` with `<work-dir>/.upgrade` as the work-dir.
   - Calls `diff.Compute` against current ConfigHub state and prints.
-  - `--apply` is sugar for `install upgrade-apply <work-dir>`
+  - `--apply` is sugar for `installer upgrade-apply <work-dir>`
     invoked immediately on success — does not change the staging
     contract.
-- New: `internal/cli/upgrade_apply.go` — `install upgrade-apply
+- New: `internal/cli/upgrade_apply.go` — `installer upgrade-apply
   <work-dir> [--yes]`.
   - Refuses if `.upgrade/` is missing or if the staged spec has
     unsatisfied required inputs (records this in
@@ -169,14 +169,14 @@ interactively, re-collect facts, re-render, plan) and "promote"
   - Atomic rename: archives the current `package/` and `out/` to
     `.upgrade-prev/`, then renames `.upgrade/package` → `package` and
     `.upgrade/out` → `out`.
-  - Invokes `install update <work-dir>` with a ChangeSet slug
+  - Invokes `installer update <work-dir>` with a ChangeSet slug
     `installer-upgrade-<from>-to-<to>-<timestamp>`.
 - Acceptance:
   - Starting from an installed `examples/hello-app`, `installer
     upgrade <work-dir> ./examples/hello-app` produces a `.upgrade/`
     tree and a "no changes" plan.
   - Editing `examples/hello-app/bases/default/...` and re-running
-    `install upgrade` surfaces the change in plan; `installer
+    `installer upgrade` surfaces the change in plan; `installer
     upgrade-apply <work-dir>` materializes it.
   - Adding a new required input to the package and running `installer
     upgrade` non-interactively fails fast with the new input named.
@@ -216,15 +216,15 @@ to [Principle 5](./principles.md#5-image-management-declare-a-kustomize-transfor
   - Unit: image overrides round-trip — `inputs.yaml` written by an
     upgrade-with-`--set-image` carries forward to a subsequent
     upgrade without `--set-image`.
-- Acceptance: `install upgrade <work-dir> <same-ref> --set-image
-  hello=hello:v2 && install upgrade-apply <work-dir>` produces a
+- Acceptance: `installer upgrade <work-dir> <same-ref> --set-image
+  hello=hello:v2 && installer upgrade-apply <work-dir>` produces a
   plan whose only diff is the image change.
 
 ## Cross-cutting
 
 ### Auth context check
 
-`install wizard`'s ConfigHub fetch and `installer
+`installer wizard`'s ConfigHub fetch and `installer
 plan/update/upgrade/upgrade-apply` all inherit the user's `cub` auth
 context. Each command starts by calling
 `cubctx.CheckOrganization(ctx, upload.Spec.OrganizationID)` (Phase A
@@ -246,7 +246,7 @@ to re-upload, but it is not required for the new commands to work.)
 ### Roadmap entries to update
 
 - README "Roadmap" section — replace the stub line about "interactive
-  wizard (e.g., `survey`)" and the "`install plan`" stub with phase
+  wizard (e.g., `survey`)" and the "`installer plan`" stub with phase
   pointers.
 - README "Status" section — same.
 - README "Design docs" section — link `principles.md` and
@@ -279,7 +279,7 @@ is the implementation plan.
 
 `internal/cli/setup.go`:
 
-- Flags: `--pull <ref>` (optional, replaces `install pull
+- Flags: `--pull <ref>` (optional, replaces `installer pull
   <ref> --work-dir`), plus every flag the existing `wizard` and
   `render` commands accept (`--namespace`, `--select`, `--input`,
   `--non-interactive`, `--components`, `--set-image`, `--reuse`,
@@ -383,12 +383,12 @@ behavior matches today's `wizard`. The render path is the same code
 
 ### Acceptance
 
-- `bin/install setup --pull oci://… --work-dir /tmp/foo
+- `bin/installer setup --pull oci://… --work-dir /tmp/foo
   --non-interactive --namespace foo` produces a render in
   `/tmp/foo/out/manifests/` and `/tmp/foo/package/` exists. Re-running
   the same command (no `--pull`) re-renders without re-pulling.
-- `bin/install upload --work-dir /tmp/foo --space foo-test` creates
-  Units; a second `bin/install upload --work-dir /tmp/foo` (no
+- `bin/installer upload --work-dir /tmp/foo --space foo-test` creates
+  Units; a second `bin/installer upload --work-dir /tmp/foo` (no
   `--space`) is a no-op on an unchanged work-dir.
 - Editing a rendered manifest and re-running `upload` opens a
   ChangeSet, applies the diff.
@@ -400,5 +400,5 @@ behavior matches today's `wizard`. The render path is the same code
   across subsequent setup invocations.
 - No `.upgrade/` or `.upgrade-prev/` directories are created at any
   point.
-- `install help` no longer lists `update`, `upgrade`, or
+- `installer help` no longer lists `update`, `upgrade`, or
   `upgrade-apply`.

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -35,7 +35,7 @@ the user do X," that doc says why.
 
 ## Non-goals
 
-- **Cluster drift detection.** `install plan` diffs the new render
+- **Cluster drift detection.** `installer plan` diffs the new render
   against ConfigHub state; it does not look at the live cluster. Cluster
   reconciliation is `cub-apply` / `verify-apply` / `drift-reconcile`.
 - **Bidirectional sync.** ConfigHub state is the source of truth for
@@ -67,15 +67,15 @@ working-dir argument anywhere. A typical session is:
 
 ```bash
 mkdir my-install && cd my-install
-install setup --pull oci://ghcr.io/foo/bar:1.0 --namespace foo
-install upload --space foo-prod
+installer setup --pull oci://ghcr.io/foo/bar:1.0 --namespace foo
+installer upload --space foo-prod
 ```
 
 Or for advanced use with an explicit work-dir:
 
 ```bash
-install setup --pull oci://… --work-dir /tmp/foo --namespace foo
-install upload --work-dir /tmp/foo --space foo-prod
+installer setup --pull oci://… --work-dir /tmp/foo --namespace foo
+installer upload --work-dir /tmp/foo --space foo-prod
 ```
 
 The layout under `<work-dir>` is:
@@ -106,20 +106,20 @@ prior `package/` in an indeterminate state. There is no durable
 `.upgrade/` staging area; if you want a record of the prior package
 source, commit `<work-dir>/package/` to git before re-pulling.
 
-### `install setup`
+### `installer setup`
 
 One-shot install + upgrade. Combines `pull` (optional) + `wizard` +
 `render` into a single command:
 
 ```bash
-install setup [--pull <ref>] [--work-dir <dir>] [wizard flags] [render flags]
+installer setup [--pull <ref>] [--work-dir <dir>] [wizard flags] [render flags]
 ```
 
 - `--pull <ref>` is optional. When present, fetches the package and
   replaces `<work-dir>/package/`. When absent, assumes the package is
   already pulled (use this form to re-render after editing
   `out/spec/inputs.yaml`, or after the package was pulled via a
-  separate `install pull` invocation).
+  separate `installer pull` invocation).
 - Supports every flag the granular `wizard` and `render` commands
   accept: `--namespace`, `--select`, `--input`, `--non-interactive`,
   `--components`, `--set-image`, `--reuse`, `--base`, `--clean`.
@@ -134,7 +134,7 @@ install setup [--pull <ref>] [--work-dir <dir>] [wizard flags] [render flags]
   carries forward values that still apply, adopts new defaults, drops
   removed inputs, prompts (interactive) or fails fast (non-interactive)
   for newly-required inputs without defaults. Same machinery used by
-  the old `install upgrade` command, now applied uniformly to every
+  the old `installer upgrade` command, now applied uniformly to every
   re-run.
 - Even when `--pull <same-version>` is passed (no version change),
   setup still goes through the upgrade flow — re-runs the collector,
@@ -147,37 +147,37 @@ The end-to-end one-time install:
 
 ```bash
 mkdir my-install && cd my-install
-install setup --pull oci://ghcr.io/foo/bar:1.0 --namespace foo \
+installer setup --pull oci://ghcr.io/foo/bar:1.0 --namespace foo \
     --input replicas=3
-install upload --space foo-prod
+installer upload --space foo-prod
 ```
 
 The upgrade (same command, different version):
 
 ```bash
-install setup --pull oci://ghcr.io/foo/bar:2.0
-install upload
+installer setup --pull oci://ghcr.io/foo/bar:2.0
+installer upload
 ```
 
 Re-render after editing inputs:
 
 ```bash
 $EDITOR out/spec/inputs.yaml
-install setup            # no --pull → reuses package, re-renders
-install upload
+installer setup            # no --pull → reuses package, re-renders
+installer upload
 ```
 
 Image-only bump:
 
 ```bash
-install setup --set-image foo=foo:v2
-install upload
+installer setup --set-image foo=foo:v2
+installer upload
 ```
 
-### `install pull`
+### `installer pull`
 
 ```bash
-install pull <ref> [--work-dir <dir>]
+installer pull <ref> [--work-dir <dir>]
 ```
 
 Fetches a package reference and writes it to `<work-dir>/package/`. The
@@ -188,10 +188,10 @@ success; any prior `<work-dir>/package/` is replaced.
 This is the granular form. Most operators don't need it — `setup
 --pull <ref>` runs pull as its first step.
 
-### `install wizard`
+### `installer wizard`
 
 ```bash
-install wizard <ref> [--work-dir <dir>] [--render=false]
+installer wizard <ref> [--work-dir <dir>] [--render=false]
 ```
 
 Pulls the package (same as `pull`) and runs the interactive (or
@@ -206,20 +206,20 @@ positional) and is more explicit about its Q&A role — useful when
 the operator wants the wizard to walk through prompts explicitly
 rather than carry forward silently.
 
-### `install render`
+### `installer render`
 
 ```bash
-install render [--work-dir <dir>] [--clean]
+installer render [--work-dir <dir>] [--clean]
 ```
 
 Reads `<work-dir>/package/` + `<work-dir>/out/spec/` and produces
 `<work-dir>/out/manifests/`. Deterministic — same package + same spec
 + same collector output = byte-identical rendered Units.
 
-### `install upload`
+### `installer upload`
 
 ```bash
-install upload [--work-dir <dir>] [--space <slug> | --space-pattern <tmpl>]
+installer upload [--work-dir <dir>] [--space <slug> | --space-pattern <tmpl>]
                  [--target <slug>] [--annotation k=v] [--label k=v]
                  [--retry] [--yes] [--changeset <slug>]
 ```
@@ -237,7 +237,7 @@ work-dir has been uploaded before:
   intra-Space NeedsProvides link inference. Writes
   `out/spec/upload.yaml` at the end.
 - **Reconcile** — `out/spec/upload.yaml` exists. Re-computes the same
-  plan `install plan` would produce, opens one ChangeSet per Space,
+  plan `installer plan` would produce, opens one ChangeSet per Space,
   runs `cub unit update --merge-external-source --changeset <slug>` for
   updates, `cub unit create` for adds, and for Units that dropped out of
   the rendered output, `cub unit update --merge-external-source` with
@@ -280,10 +280,10 @@ splitting "create" and "reconcile") follows the
 `kubectl apply` model — the operator says "make ConfigHub match this
 work-dir" and the command figures out what that means.
 
-### `install plan`
+### `installer plan`
 
 ```bash
-install plan [--work-dir <dir>]
+installer plan [--work-dir <dir>]
 ```
 
 Read-only diff vs ConfigHub. Same code path as `upload` reconcile, but
@@ -335,7 +335,7 @@ spec:
   organizationID: org_01JDQP70M348Z3M2FK7ZKS9Q1A
 ```
 
-`install upload` writes this file at the end of a successful first
+`installer upload` writes this file at the end of a successful first
 upload, and rewrites it on each successful reconcile (timestamp +
 member list refresh). All subsequent commands read it on entry to
 locate the current Spaces. It is also embedded in the
@@ -360,7 +360,7 @@ install answered. The schema-diff machinery handles the cases:
 - **New input with default**: silently adopted. Logged.
 - **New required input without default**: prompted in interactive
   mode; non-interactive mode fails fast naming each missing input and
-  pointing at running setup interactively (or `install wizard
+  pointing at running setup interactively (or `installer wizard
   <ref>`).
 - **Removed input**: silently dropped from the new `inputs.yaml`.
 - **Type-changed input**: errors with a re-run-interactively hint.
@@ -384,7 +384,7 @@ the recommended path depends on how often the override is expected:
 - **Occasional override (mirror, patch bump)** — package author
   declares a kustomize `images:` transformer in the chosen base.
   Operator passes `--set-image name=ref` (repeatable) to `installer
-  setup` or `install wizard`; the installer runs `kustomize edit set
+  setup` or `installer wizard`; the installer runs `kustomize edit set
   image` against the package's working copy before render. The
   `--set-image` value is recorded in `out/spec/inputs.yaml` under
   `spec.imageOverrides` so the next setup carries it forward without
@@ -394,14 +394,14 @@ the recommended path depends on how often the override is expected:
   Operator answers the input through the wizard.
 - **Post-install one-off** — operator runs `cub function do
   set-container-image` on the uploaded Unit. Survives re-render
-  because `install upload` uses `--merge-external-source`.
+  because `installer upload` uses `--merge-external-source`.
 
-`install plan` and `install upload` print a per-Space `Images:`
+`installer plan` and `installer upload` print a per-Space `Images:`
 footer built from `cub function do --space <slug> get-container-image '*'`
 against the new render (locally, before any update), so the operator
 can see the eventual image set without applying anything.
 
-`install setup --set-image` against a package whose base has no
+`installer setup --set-image` against a package whose base has no
 `images:` transformer fails fast with a useful message: "package's
 base kustomization.yaml has no `images:` block; declare one to use
 --set-image, or use a `spec.transformers` input."
@@ -410,31 +410,31 @@ base kustomization.yaml has no `images:` block; declare one to use
 
 - **Image tag bump** — the day-2 case:
   ```bash
-  install setup --set-image hello=hello:v2
-  install upload
+  installer setup --set-image hello=hello:v2
+  installer upload
   ```
   Plan shows a one-line image change.
 - **Adding a component**:
   ```bash
   $EDITOR out/spec/selection.yaml
-  install setup --non-interactive   # re-renders against edited selection
-  install plan                       # preview
-  install upload                     # materialize
+  installer setup --non-interactive   # re-renders against edited selection
+  installer plan                       # preview
+  installer upload                     # materialize
   ```
 - **Package version bump with new required input**:
   ```bash
-  install setup --pull oci://reg/hello-app:0.2.0
+  installer setup --pull oci://reg/hello-app:0.2.0
   ```
   In interactive mode, prompts for the new required input. In
   non-interactive mode, fails fast with a hint to re-run
   interactively.
 - **Cluster state changed (collector picks up new fact)**:
   ```bash
-  install setup --pull oci://reg/hello-app:<same-version>
-  install upload
+  installer setup --pull oci://reg/hello-app:<same-version>
+  installer upload
   ```
   Re-runs the collector, re-renders, upload reconciles.
-- **Reverting an `install upload` reconcile**:
+- **Reverting an `installer upload` reconcile**:
   ```bash
   cub unit update --restore Before:ChangeSet:<slug> \
       --where "Labels.Package='hello-app'"
@@ -482,7 +482,7 @@ The current shape removes friction:
 ## Open questions
 
 - Should `setup` print the eventual plan it would write to ConfigHub
-  before exiting? Today the operator runs `install plan` separately;
+  before exiting? Today the operator runs `installer plan` separately;
   we could chain the plan readout into setup the way `upgrade` used to
   print plan. Current decision: keep them separate so setup is
   ConfigHub-free (no `cub` call on the local-only path).

--- a/docs/package-management-plan.md
+++ b/docs/package-management-plan.md
@@ -11,13 +11,13 @@ Visible CLI surface, stubs only. Lets later phases land in small PRs without
 touching `root.go` each time.
 
 - New: `internal/cli/{package.go, push.go, inspect.go, list.go, tag.go, login.go, logout.go, deps.go, sign.go, verify.go}` — cobra commands returning "not yet implemented" with `--help` text taken from the spec.
-- Modify: `internal/cli/root.go` — register the new subcommands. Group `deps update|build|tree` under `install deps`.
+- Modify: `internal/cli/root.go` — register the new subcommands. Group `deps update|build|tree` under `installer deps`.
 - Modify: `internal/cli/stubs.go` — remove the stub-only helper once each command moves to its own file.
 - Modify: `README.md` Roadmap — link to the design doc; mark the new commands "planned" until their phase ships.
 
 No tests yet. Acceptance: `installer --help` lists every command in the spec.
 
-## Phase 1 — Deterministic bundler + `install package`
+## Phase 1 — Deterministic bundler + `installer package`
 
 Goal: a `.tgz` of the source tree that is byte-identical across machines.
 
@@ -28,9 +28,9 @@ Goal: a `.tgz` of the source tree that is byte-identical across machines.
   - Include: `installer.yaml` + every directory referenced by `bases[].path`, `components[].path`, `validation.*`, `collector.command` (if relative), plus an opt-in `examples/` (gated by a `package.bundleExamples` field in `installer.yaml`, default true).
 - New: `internal/bundle/bundle_test.go` — two `Bundle` invocations of the same source tree produce equal digests; rename of a single file changes the digest; `.env.secret` triggers a refusal.
 - Modify: `internal/cli/package.go` — `-o`, default output filename `<metadata.name>-<metadata.version>.tgz` in cwd; print the digest on success.
-- Decision deferred: reachability-scan vs ignore-list. v1 ships ignore-list; reachability becomes a `install package --strict` follow-up.
+- Decision deferred: reachability-scan vs ignore-list. v1 ships ignore-list; reachability becomes a `installer package --strict` follow-up.
 
-Acceptance: `install package examples/hello-app` produces a tarball whose `sha256` is reproducible across machines.
+Acceptance: `installer package examples/hello-app` produces a tarball whose `sha256` is reproducible across machines.
 
 ## Phase 2 — OCI publish (`push`, `inspect`, `list`, `tag`, hardened `pull`)
 
@@ -52,7 +52,7 @@ Goal: round-trip native artifacts; existing Helm-OCI pull keeps working.
   - `internal/pkg/oci_test.go` against a `zot` or `registry:2` container started by the test (skip if Docker unavailable).
   - `internal/pkg/pull_test.go` regression: pulling an existing Helm-OCI chart still works.
 
-Acceptance: `install package` → `install push` → `install pull` on a fresh machine yields a byte-identical source tree.
+Acceptance: `installer package` → `installer push` → `installer pull` on a fresh machine yields a byte-identical source tree.
 
 ## Phase 3 — Schema additions (parse-only)
 
@@ -64,12 +64,12 @@ Goal: packages can *declare* dependencies; nothing acts on them yet.
 - New types in `pkg/api/dependency.go`: `Dependency`, `ConflictRef`, `ReplaceRef` (fields per the design doc).
 - New: `pkg/api/lock.go` — `Lock`, `LockedDependency`.
 - Modify: `pkg/api/parse.go` and `parse_test.go` — round-trip tests.
-- Modify: `internal/cli/doc.go` — render `dependencies`, `conflicts`, `replaces`, `kubeVersion`, `installerVersion` in `install doc`.
+- Modify: `internal/cli/doc.go` — render `dependencies`, `conflicts`, `replaces`, `kubeVersion`, `installerVersion` in `installer doc`.
 - No changes to `wizard`, `render`, `upload`.
 
-Acceptance: a fixture package with the new fields parses and `install doc` shows them; the existing examples still parse unchanged.
+Acceptance: a fixture package with the new fields parses and `installer doc` shows them; the existing examples still parse unchanged.
 
-## Phase 4 — Resolver + `install deps update`
+## Phase 4 — Resolver + `installer deps update`
 
 Goal: produce `out/spec/lock.yaml` from `installer.yaml` + the current `Selection`.
 
@@ -104,7 +104,7 @@ Acceptance: re-rendering the same lock + inputs produces byte-identical `out/` t
 
 - **Collectors on dependencies are not supported.** Collectors run via the
   wizard, which is not invoked per-dep — the dep's Selection/Inputs come
-  straight from the lock. `install deps update` rejects any candidate
+  straight from the lock. `installer deps update` rejects any candidate
   whose installer.yaml declares `spec.collector` so the user discovers the
   limit at resolve time, not at render. Lifting the limit means either
   running the collector at render time for deps (and dragging the
@@ -126,13 +126,13 @@ Goal: each package gets its own Space; the lock survives as a Unit.
   - After all Spaces exist, for every dep edge in the lock create a Link from the parent's installer-record Unit to the dep's installer-record Unit (Link slug derived from the edge, idempotent).
 - Decision: the parent's installer-record Unit embeds the full lock; each dep's installer-record Unit holds only its own slice (its `installer.yaml` + `out/<dep>/spec/*`). This makes a dep's Space self-describing.
 
-Acceptance: `install upload` on a fixture multi-package render creates N Spaces, N untargeted installer-record Units, M rendered Units, and the expected cross-Space Links.
+Acceptance: `installer upload` on a fixture multi-package render creates N Spaces, N untargeted installer-record Units, M rendered Units, and the expected cross-Space Links.
 
 ## Phase 7 — Signing
 
 Goal: trust at the artifact level.
 
-- New: `internal/cli/sign.go`, `verify.go`. v1 shells out to the `cosign` binary; the Go SDK is large and re-pulls a lot of sigstore dependencies. Document the requirement in `install doc` output and README.
+- New: `internal/cli/sign.go`, `verify.go`. v1 shells out to the `cosign` binary; the Go SDK is large and re-pulls a lot of sigstore dependencies. Document the requirement in `installer doc` output and README.
 - New: `~/.config/installer/policy.yaml` — list of trusted issuers / keys, plus an `enforce: true|false` flag. Loaded by `pull` and `deps update` to enforce verification before trusting any digest.
 - Tests: integration test gated on `cosign` being on PATH.
 
@@ -156,7 +156,7 @@ Acceptance: signed artifact verifies; tampered artifact fails verification with 
 
 | Cut    | Phases | User-visible value |
 |--------|--------|--------------------|
-| 0.3    | 0, 1   | `install package` produces shippable tarballs. |
+| 0.3    | 0, 1   | `installer package` produces shippable tarballs. |
 | 0.4    | 2      | OCI publish round-trips; existing Helm pull still works. |
 | 0.5    | 3, 4   | Packages can declare deps; lock is generated. No behavior change at render. |
 | 0.6    | 5, 6   | Multi-package render + upload with per-dep Spaces and installer-record Units. |

--- a/docs/package-management.md
+++ b/docs/package-management.md
@@ -27,7 +27,7 @@ none of which are implemented yet beyond `pull`.
   room for both but does not define them.
 - **Helm chart interop as a dependency type.** Helm cannot itself drive this
   installer because Helm packages have no way to specify a post-renderer, so
-  there is no symmetric path. We can still _pull_ a chart with `install pull`
+  there is no symmetric path. We can still _pull_ a chart with `installer pull`
   as a convenience (existing behavior), but `dependencies:` entries cannot
   point at Helm charts.
 - **Kustomizer-style render-on-push.** Kustomizer's `push` renders first; ours
@@ -37,7 +37,7 @@ none of which are implemented yet beyond `pull`.
   variant/environment, but the variant problem itself is out of scope here.
   Bases + components + inputs cover today's needs.
 - **Server-side search/catalog.** OCI `_catalog` support is uneven across
-  registries. Discovery is convention + `install list`. Curated indexes can
+  registries. Discovery is convention + `installer list`. Curated indexes can
   be added later if needed.
 
 ## What a package is
@@ -49,7 +49,7 @@ my-pkg/
 ├── installer.yaml        # the Package manifest (pkg/api.Package)
 ├── bases/
 ├── components/
-├── validation/           # optional, surfaced by `install doc`
+├── validation/           # optional, surfaced by `installer doc`
 ├── collector             # optional executable; produces facts + secrets
 └── examples/
 ```
@@ -87,13 +87,13 @@ bundle:
 manifest: <the parsed installer.yaml>
 ```
 
-Having the manifest in the config blob lets `install inspect <ref>` and the
+Having the manifest in the config blob lets `installer inspect <ref>` and the
 resolver read metadata (dependencies, provides, kubeVersion) without pulling
 the layer.
 
 ### Pull-time discrimination
 
-`install pull` already handles a Helm-OCI shape heuristically (single `.tgz`
+`installer pull` already handles a Helm-OCI shape heuristically (single `.tgz`
 layer named like a chart). Native installer artifacts take a deterministic
 path based on `artifactType`; the Helm fallback remains for convenience but
 must not be exercised when the artifact identifies itself as ours.
@@ -111,19 +111,19 @@ Without this, signing and digest-pinning give weak guarantees.
 ## CLI surface
 
 ```
-install package <dir> [-o file.tgz]
-install push    <pkg.tgz|dir> oci://registry/repo:tag
-install pull    <ref>                                # exists; harden + add --digest
-install inspect <ref>                                # reads config blob only
-install list    oci://registry/repo                  # tags via /tags/list
-install tag     <src-ref> <dst-tag>
-install sign    <ref>                                # cosign keyed or keyless
-install verify  <ref>
-install login   <registry>
-install logout  <registry>
-install deps update <dir>                            # write installer.lock to out/spec/
-install deps build  <dir>                            # pre-fetch locked deps for offline render
-install deps tree   <dir>                            # render the resolved DAG
+installer package <dir> [-o file.tgz]
+installer push    <pkg.tgz|dir> oci://registry/repo:tag
+installer pull    <ref>                                # exists; harden + add --digest
+installer inspect <ref>                                # reads config blob only
+installer list    oci://registry/repo                  # tags via /tags/list
+installer tag     <src-ref> <dst-tag>
+installer sign    <ref>                                # cosign keyed or keyless
+installer verify  <ref>
+installer login   <registry>
+installer logout  <registry>
+installer deps update <dir>                            # write installer.lock to out/spec/
+installer deps build  <dir>                            # pre-fetch locked deps for offline render
+installer deps tree   <dir>                            # render the resolved DAG
 ```
 
 `installer search` is omitted in v1.
@@ -243,11 +243,11 @@ spec:
 
 Workflow:
 
-- `install deps update <dir>` resolves the DAG, writes `out/spec/lock.yaml`.
-- `install render` requires a lock; if absent or stale (root manifest's
+- `installer deps update <dir>` resolves the DAG, writes `out/spec/lock.yaml`.
+- `installer render` requires a lock; if absent or stale (root manifest's
   declared deps disagree with the lock), it errors and instructs the user to
-  re-run `install deps update`.
-- `install deps build <dir>` pre-fetches each locked dep into a local
+  re-run `installer deps update`.
+- `installer deps build <dir>` pre-fetches each locked dep into a local
   `out/vendor/<name>@<version>/` so a subsequent render is fully offline.
 
 ### Resolver
@@ -277,19 +277,19 @@ inter-Space Links; cross-Space ApplyGates enforce it at apply time.
 ### Cluster-side `externalRequires` still apply
 
 Anything in `externalRequires` not satisfied by some dep's `provides` remains
-a cluster precondition checked by `install preflight`. This is what keeps
+a cluster precondition checked by `installer preflight`. This is what keeps
 the model honest: declaring a dep is a _promise_ that the dep provides the
 precondition; preflight verifies leftovers.
 
 ## Bundling rules
 
-`install package` MUST refuse to bundle:
+`installer package` MUST refuse to bundle:
 
 - `*.env.secret` files anywhere in the tree (collector output; never published).
 - Anything under `out/` (rendered artifacts; not source).
 - Anything matched by `.installerignore` (optional, mirrors `.helmignore`).
 
-`install package` MUST include:
+`installer package` MUST include:
 
 - `installer.yaml`, all referenced `bases/` and `components/` trees,
   `validation/`, the `collector` executable if declared, and any files
@@ -305,28 +305,29 @@ bloat artifacts and duplicate immutable upstream blobs.
 ```yaml
 metadata:
   name: my-stack
-  version: 0.3.0
-  kubeVersion: ">= 1.28" # SemVer range, checked at resolve time
-  installerVersion: ">= 0.2.0" # range against the CLI invoking render
   annotations:
     confighub.com/category: gateway
     confighub.com/maintainers: ...
+installerMetadata:
+  version: 0.3.0
+  kubeVersion: ">= 1.28" # SemVer range, checked at resolve time
+  installerVersion: ">= 0.2.0" # range against the CLI invoking render
 ```
 
 The two `*Version` fields are evaluated at resolve time and at render time;
 mismatch is an error with an upgrade hint. Annotations are advisory and
-surfaced in `install inspect` and `install doc`.
+surfaced in `installer inspect` and `installer doc`.
 
 ## Signing
 
-`install sign` and `install verify` use cosign (keyed or keyless).
+`installer sign` and `installer verify` use cosign (keyed or keyless).
 When a local policy file is present (`~/.config/installer/policy.yaml`),
 `pull` and `deps update` enforce verification before trusting an artifact's
 digest.
 
 ## What this design does _not_ answer (yet)
 
-- **Mirroring / air-gap workflows.** `install deps build` produces a
+- **Mirroring / air-gap workflows.** `installer deps build` produces a
   vendor tree, but a `installer mirror oci://src oci://dst` for moving an
   entire dep closure between registries is left for later.
 - **Multi-arch packages.** Installer packages are platform-independent (they
@@ -339,12 +340,12 @@ digest.
 
 ## Implementation order (suggested)
 
-1. Deterministic bundler + `install package` (no network).
-2. `install push` / `inspect` / `list` / `tag` against an OCI registry,
+1. Deterministic bundler + `installer package` (no network).
+2. `installer push` / `inspect` / `list` / `tag` against an OCI registry,
    reusing oras-go.
 3. `installer.yaml` schema additions (`dependencies`, `conflicts`,
    `replaces`, satisfies-link on existing fields) — parse-only.
-4. Resolver + `install deps update` writing `out/spec/lock.yaml`.
+4. Resolver + `installer deps update` writing `out/spec/lock.yaml`.
 5. Render wired to read the lock, fetch deps (cached via `deps build`), and
    render each into its own output subtree (`out/<dep-name>/manifests/`,
    `out/<dep-name>/spec/`).

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -20,7 +20,7 @@ channels:
 update`, ApplyGate-mediated approvals).
 
 Why: a consumer-edited package tree is silently overwritten on the next
-`install setup --pull` (or `install pull`). Worse, the edits are invisible
+`installer setup --pull` (or `installer pull`). Worse, the edits are invisible
 to anyone reading the package source. Routing every override through one
 of the two supported channels keeps changes discoverable and survivable.
 
@@ -51,7 +51,7 @@ plus the package.
 
 - **Install-time** changes are made in spec files and re-render. They
   affect what the installer materializes. They are versioned with the
-  installer's working directory; they survive an `install setup
+  installer's working directory; they survive an `installer setup
   --pull <new-ref>` upgrade (carried forward by the schema-diff
   machinery).
 - **Post-install** changes are made in ConfigHub on the materialized
@@ -109,7 +109,7 @@ recommended pattern, in order of decreasing user friction:
 
 1. **Package author declares a kustomize `images:` transformer** in the
    chosen base's `kustomization.yaml`. Operators override at install or
-   upgrade time with `install setup --set-image name=ref` (which
+   upgrade time with `installer setup --set-image name=ref` (which
    runs `kustomize edit set image` against the package's working copy
    before render). Operators override post-install with `cub function
 do set-container-image` on the uploaded Unit. This is the default
@@ -124,7 +124,7 @@ do set-container-image` on the uploaded Unit. This is the default
    `set-image-reference-by-uri`, `set-image-registry-by-registry` — for
    ad hoc changes that do not warrant re-render.
 
-`install plan` and `install upload` print a per-Space `Images:`
+`installer plan` and `installer upload` print a per-Space `Images:`
 footer (built from `cub function do get-container-image '*'`) so the
 operator can see the eventual image set without applying anything.
 
@@ -138,7 +138,7 @@ time and (3) for post-install one-offs; only edit spec/inputs.yaml for
 The installer materializes Units. Everything downstream — apply,
 ApplyGates, validation Triggers, drift reconciliation, ChangeSets,
 promotion, rollback — is ConfigHub's job. The installer creates a
-ChangeSet for `install upload` reconciles so updates are revertable,
+ChangeSet for `installer upload` reconciles so updates are revertable,
 but it does not run apply, does not author Triggers, and does not
 reconcile cluster drift.
 

--- a/docs/transformer.md
+++ b/docs/transformer.md
@@ -75,7 +75,7 @@ Three constraints from the current setup carry into the new design:
 
 ## Design
 
-### `install transformer` subcommand
+### `installer transformer` subcommand
 
 First-class CLI verb. Reads a KRM `ResourceList` from stdin, joins
 `items` into a YAML doc stream, runs the chain encoded in
@@ -274,10 +274,10 @@ that have a natural ConfigMap (or equivalent) carrier.
 
 Kustomize copies `options.annotations` from a `configMapGenerator`
 entry onto the rendered ConfigMap, so the `toolchain` annotation
-is what reaches the install transformer (running as an exec
+is what reaches the installer transformer (running as an exec
 plugin) and the upload step (reading `out/manifests/`).
 
-The install transformer infers three more annotations from the
+The installer transformer infers three more annotations from the
 rendered carrier and injects them back onto the ConfigMap so
 downstream consumers (upload, drift) see one canonical contract:
 
@@ -471,8 +471,8 @@ We test all of these against AppConfig-bearing ConfigMaps:
    `parseFunctionArguments`, `ValidatorFailure`,
    `FormatValidatorFailures`, `decodeValidatorFailures` from
    `internal/render/chain.go` into a new `internal/chainexec/`
-   package. Render and `install vet` import it.
-2. **`install transformer` subcommand. ✅** Standalone-usable
+   package. Render and `installer vet` import it.
+2. **`installer transformer` subcommand. ✅** Standalone-usable
    KRM Functions exec plugin. Two functionConfig kinds:
    `ConfigHubTransformers` and `ConfigHubValidators`.
 3. **Kustomize-driven render with durable `out/compose/`. ✅**
@@ -490,7 +490,7 @@ We test all of these against AppConfig-bearing ConfigMaps:
    `installer.confighub.com/toolchain` from kustomize-copied
    generator annotations.
 6. **AppConfig transformer round-trip + annotation injection. ✅**
-   `install transformer` runs a pre-pass that derives and injects
+   `installer transformer` runs a pre-pass that derives and injects
    `appconfig-mode` (file/env, from data: shape) and
    `appconfig-source-key`. Function groups with toolchain
    `AppConfig/*` extract from `data:`, invoke, write back. Both

--- a/examples/example-base/installer.yaml
+++ b/examples/example-base/installer.yaml
@@ -2,6 +2,7 @@ apiVersion: installer.confighub.com/v1alpha1
 kind: Package
 metadata:
   name: example-base
+installerMetadata:
   version: 0.1.0
 spec:
   bases:

--- a/examples/example-stack/bases/default/kustomization.yaml
+++ b/examples/example-stack/bases/default/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - deployment.yaml
-# images: declares the names overridable by `install setup
+# images: declares the names overridable by `installer setup
 # --set-image`. The default values match what's hard-coded in
 # deployment.yaml.
 images:

--- a/examples/example-stack/installer.yaml
+++ b/examples/example-stack/installer.yaml
@@ -2,6 +2,7 @@ apiVersion: installer.confighub.com/v1alpha1
 kind: Package
 metadata:
   name: example-stack
+installerMetadata:
   version: 0.1.0
 spec:
   bases:

--- a/examples/gaie/README.md
+++ b/examples/gaie/README.md
@@ -37,13 +37,13 @@ package that templates the chart at install time.
 ## Quick start
 
 ```bash
-bin/install wizard ./examples/gaie \
+bin/installer wizard ./examples/gaie \
   --work-dir /tmp/gaie \
   --non-interactive \
   --select sample-pool \
   --input namespace=inference
 
-bin/install render /tmp/gaie
+bin/installer render /tmp/gaie
 ls /tmp/gaie/out/manifests/
 ```
 

--- a/examples/gaie/installer.yaml
+++ b/examples/gaie/installer.yaml
@@ -2,6 +2,7 @@ apiVersion: installer.confighub.com/v1alpha1
 kind: Package
 metadata:
   name: gaie
+installerMetadata:
   version: 1.5.0
 spec:
   bases:

--- a/examples/hello-app/bases/default/kustomization.yaml
+++ b/examples/hello-app/bases/default/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - namespace.yaml
   - deployment.yaml
   - service.yaml
-# images: declares the names overridable by `install setup
+# images: declares the names overridable by `installer setup
 # --set-image`. The default values match what's hard-coded in
 # deployment.yaml; --set-image rewrites them at render time without
 # editing the source.

--- a/examples/hello-app/installer.yaml
+++ b/examples/hello-app/installer.yaml
@@ -2,6 +2,7 @@ apiVersion: installer.confighub.com/v1alpha1
 kind: Package
 metadata:
   name: hello-app
+installerMetadata:
   version: 0.1.0
 spec:
   bases:

--- a/examples/kuberay/README.md
+++ b/examples/kuberay/README.md
@@ -40,12 +40,12 @@ push to Docker Hub). Fork the package to point at a private mirror.
 ## Quick start
 
 ```bash
-bin/install wizard ./examples/kuberay \
+bin/installer wizard ./examples/kuberay \
   --work-dir /tmp/kuberay \
   --non-interactive \
   --input namespace=kuberay-system
 
-bin/install render /tmp/kuberay
+bin/installer render /tmp/kuberay
 ls /tmp/kuberay/out/manifests/
 ```
 

--- a/examples/kuberay/installer.yaml
+++ b/examples/kuberay/installer.yaml
@@ -2,6 +2,7 @@ apiVersion: installer.confighub.com/v1alpha1
 kind: Package
 metadata:
   name: kuberay
+installerMetadata:
   version: 1.6.1
 spec:
   bases:

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -1,5 +1,8 @@
-// Package bundle produces deterministic, distribution-ready install package
-// tarballs. The output is the input to `install push` and is what an OCI
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+// Package bundle produces deterministic, distribution-ready installer package
+// tarballs. The output is the input to `installer push` and is what an OCI
 // registry stores as a single layer of a native installer artifact.
 //
 // Determinism: same source tree → byte-identical .tgz, regardless of mtimes,

--- a/internal/bundle/bundle_test.go
+++ b/internal/bundle/bundle_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package bundle
 
 import (
@@ -19,6 +22,7 @@ const installerYAML = `apiVersion: installer.confighub.com/v1alpha1
 kind: Package
 metadata:
   name: test
+installerMetadata:
   version: 0.0.1
 spec:
   bases:

--- a/internal/chainexec/chainexec.go
+++ b/internal/chainexec/chainexec.go
@@ -1,6 +1,9 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 // Package chainexec executes ConfigHub FunctionChain and validator groups
-// against config data. It's the shared core consumed by `install render`
-// (after template resolution) and by `install transformer` (which receives
+// against config data. It's the shared core consumed by `installer render`
+// (after template resolution) and by `installer transformer` (which receives
 // already-resolved groups from a KRM ResourceList functionConfig). Template
 // resolution itself lives in internal/render — it depends on installer state
 // that's irrelevant to the kustomize-side caller.

--- a/internal/chainexec/chainexec_test.go
+++ b/internal/chainexec/chainexec_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package chainexec
 
 import (

--- a/internal/changeset/changeset.go
+++ b/internal/changeset/changeset.go
@@ -1,12 +1,15 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 // Package changeset wraps the cub changeset CLI for installer use:
-// per-Space ChangeSets opened by `install update` so the resulting
+// per-Space ChangeSets opened by `installer update` so the resulting
 // updates can be reverted as a unit.
 //
 // Note on revert scope (per docs/lifecycle.md): only update mutations
 // recorded against the ChangeSet are revertable via `cub unit update
 // --restore Before:ChangeSet:<slug>`. Creates and deletes are not
 // reverted by ChangeSet restore — to undo a create, delete the Unit;
-// to undo a delete, re-render and re-run `install update`.
+// to undo a delete, re-render and re-run `installer update`.
 package changeset
 
 import (
@@ -18,7 +21,7 @@ import (
 	"time"
 )
 
-// DefaultSlug returns the conventional slug for an install update
+// DefaultSlug returns the conventional slug for an installer update
 // ChangeSet at the given time. Stable input → stable output (no
 // nondeterminism); callers wanting the live timestamp pass time.Now().
 //

--- a/internal/cli/appconfig.go
+++ b/internal/cli/appconfig.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/internal/cli/appconfig_test.go
+++ b/internal/cli/appconfig_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/internal/cli/deps.go
+++ b/internal/cli/deps.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (
@@ -16,7 +19,7 @@ import (
 func newDepsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deps",
-		Short: "Manage install package dependencies",
+		Short: "Manage installer package dependencies",
 		Long: `Deps resolves the dependency DAG declared in installer.yaml against an OCI
 registry, writes <work-dir>/out/spec/lock.yaml, and optionally vendors
 locked dependencies for offline render.`,

--- a/internal/cli/doc.go
+++ b/internal/cli/doc.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (
@@ -68,14 +71,14 @@ Package references:
 
 func printPackageDoc(p *api.Package) {
 	fmt.Printf("Package: %s\n", p.Metadata.Name)
-	if p.Metadata.Version != "" {
-		fmt.Printf("Version: %s\n", p.Metadata.Version)
+	if p.InstallerMetadata.Version != "" {
+		fmt.Printf("Version: %s\n", p.InstallerMetadata.Version)
 	}
-	if p.Metadata.KubeVersion != "" {
-		fmt.Printf("Kubernetes: %s\n", p.Metadata.KubeVersion)
+	if p.InstallerMetadata.KubeVersion != "" {
+		fmt.Printf("Kubernetes: %s\n", p.InstallerMetadata.KubeVersion)
 	}
-	if p.Metadata.InstallerVersion != "" {
-		fmt.Printf("Installer:  %s\n", p.Metadata.InstallerVersion)
+	if p.InstallerMetadata.InstallerVersion != "" {
+		fmt.Printf("Installer:  %s\n", p.InstallerMetadata.InstallerVersion)
 	}
 	fmt.Println()
 

--- a/internal/cli/edit.go
+++ b/internal/cli/edit.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (
@@ -12,28 +15,28 @@ import (
 	"github.com/confighub/installer/pkg/api"
 )
 
-// `install edit` lets package authors mutate installer.yaml fields
+// `installer edit` lets package authors mutate installer.yaml fields
 // without hand-editing YAML. Mirrors `kustomize edit add/remove/set`
 // shape for inputs / components / dependencies.
 //
 // Scope (v1):
-//   install edit add input <name> --type T [--default V] [--required]
+//   installer edit add input <name> --type T [--default V] [--required]
 //                                   [--prompt P] [--description D]
 //                                   [--option O ...]
-//   install edit remove input <name>
-//   install edit set input <name> [same flags as add]
+//   installer edit remove input <name>
+//   installer edit set input <name> [same flags as add]
 //
-//   install edit add component <name> --path P [--default] [--description D]
+//   installer edit add component <name> --path P [--default] [--description D]
 //                                       [--requires NAME ...] [--conflicts NAME ...]
 //                                       [--valid-for-bases NAME ...]
-//   install edit remove component <name>
-//   install edit set component <name> [same flags as add]
+//   installer edit remove component <name>
+//   installer edit set component <name> [same flags as add]
 //
-//   install edit add dependency <name> --package OCI --version SEMVER
+//   installer edit add dependency <name> --package OCI --version SEMVER
 //                                        [--when-component NAME]
 //                                        [--optional]
-//   install edit remove dependency <name>
-//   install edit set dependency <name> [same flags as add]
+//   installer edit remove dependency <name>
+//   installer edit set dependency <name> [same flags as add]
 //
 // Every leaf reads installer.yaml from --package (default ".") and
 // writes it back through api.MarshalYAML for deterministic output.
@@ -45,17 +48,17 @@ func newEditCmd() *cobra.Command {
 		Long: `Edit walks installer.yaml field-by-field, like kustomize edit.
 
 Subcommands:
-  install edit add input    <name> ...   add an input declaration
-  install edit remove input <name>       remove an input
-  install edit set input    <name> ...   update an existing input
+  installer edit add input    <name> ...   add an input declaration
+  installer edit remove input <name>       remove an input
+  installer edit set input    <name> ...   update an existing input
 
-  install edit add component    <name> ...   add an opt-in component
-  install edit remove component <name>       remove a component
-  install edit set component    <name> ...   update an existing component
+  installer edit add component    <name> ...   add an opt-in component
+  installer edit remove component <name>       remove a component
+  installer edit set component    <name> ...   update an existing component
 
-  install edit add dependency    <name> ...   add a dependency
-  install edit remove dependency <name>       remove a dependency
-  install edit set dependency    <name> ...   update an existing dependency
+  installer edit add dependency    <name> ...   add a dependency
+  installer edit remove dependency <name>       remove a dependency
+  installer edit set dependency    <name> ...   update an existing dependency
 
 Each leaf reads installer.yaml from --package (default ".") and
 writes it back through the deterministic MarshalYAML.`,

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (
@@ -10,7 +13,7 @@ import (
 	"github.com/confighub/installer/pkg/api"
 )
 
-// defaultValidators is the validator chain `install init` seeds new
+// defaultValidators is the validator chain `installer init` seeds new
 // packages with. vet-placeholders is intentionally NOT in the list —
 // some packages exist precisely to ship `confighubplaceholder`-bearing
 // bases that get cloned into variants.
@@ -32,8 +35,8 @@ func newInitCmd() *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "init <dir>",
-		Short: "Scaffold a new install package in <dir>",
-		Long: `Init creates the on-disk skeleton of a new install package:
+		Short: "Scaffold a new installer package in <dir>",
+		Long: `Init creates the on-disk skeleton of a new installer package:
 
   <dir>/
   ├── installer.yaml           # the manifest with default validators
@@ -47,7 +50,7 @@ The seeded installer.yaml declares one default base, no components,
 and the recommended validator chain (vet-schemas, vet-merge-keys,
 vet-format). vet-placeholders is intentionally omitted — packages
 that ship cloneable bases would fail it. Add or remove validators
-later with 'install edit validator add/remove' (when shipped) or
+later with 'installer edit validator add/remove' (when shipped) or
 by hand-editing installer.yaml.
 
 Refuses to overwrite an existing installer.yaml unless --force.`,
@@ -78,7 +81,9 @@ Refuses to overwrite an existing installer.yaml unless --force.`,
 				APIVersion: api.APIVersion,
 				Kind:       api.KindPackage,
 				Metadata: api.Metadata{
-					Name:    name,
+					Name: name,
+				},
+				InstallerMetadata: api.InstallerMetadata{
 					Version: version,
 				},
 				Spec: api.PackageSpec{
@@ -106,7 +111,7 @@ Refuses to overwrite an existing installer.yaml unless --force.`,
 				return err
 			}
 
-			// Seed an empty kustomization.yaml so `install render`
+			// Seed an empty kustomization.yaml so `installer render`
 			// works against the empty base. The author replaces this
 			// with their actual resources.
 			kustPath := filepath.Join(dir, "bases", "default", "kustomization.yaml")

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (
@@ -35,7 +38,7 @@ package layer when only metadata is needed.`,
 				return enc.Encode(res)
 			}
 			cb := res.Config
-			fmt.Printf("Package:  %s@%s\n", cb.Manifest.Metadata.Name, cb.Manifest.Metadata.Version)
+			fmt.Printf("Package:  %s@%s\n", cb.Manifest.Metadata.Name, cb.Manifest.InstallerMetadata.Version)
 			fmt.Printf("Manifest: %s\n", res.ManifestDigest)
 			if cb.Bundle.InstallerVersion != "" {
 				fmt.Printf("Built with installer %s\n", cb.Bundle.InstallerVersion)

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (
@@ -17,7 +20,7 @@ func newListCmd() *cobra.Command {
 the tags.
 
 Example:
-  install list oci://ghcr.io/confighubai/gateway-api`,
+  installer list oci://ghcr.io/confighubai/gateway-api`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (
@@ -25,7 +28,7 @@ func newLoginCmd() *cobra.Command {
 		Short: "Store credentials for a registry",
 		Long: `Login stores a credential for the given registry in the docker-config-style
 credential store (typically ~/.docker/config.json), making it usable by
-install push, pull, inspect, and list — plus any other tool that reads
+installer push, pull, inspect, and list — plus any other tool that reads
 docker config (docker, podman, oras).
 
 If --username is omitted, it is read from stdin. If neither --password nor

--- a/internal/cli/logout.go
+++ b/internal/cli/logout.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (
@@ -22,9 +25,9 @@ import (
 const kubernetesResourcesPackageName = "kubernetes-resources"
 
 // canonicalExample names the kubernetes-resources example template
-// `install new <kind>` clones for each Kubernetes kind. The slug
+// `installer new <kind>` clones for each Kubernetes kind. The slug
 // uses the deterministic <kind-lowercase>-<namespace>-<name> shape
-// produced by render's splitForUnits — `install new` substitutes
+// produced by render's splitForUnits — `installer new` substitutes
 // the bootstrapped namespace at lookup time.
 //
 // origName is the placeholder name in the example (renamed to the
@@ -37,7 +40,7 @@ type canonicalExample struct {
 	origName string
 }
 
-// kindToExample maps the user-facing kind on `install new <kind>`
+// kindToExample maps the user-facing kind on `installer new <kind>`
 // to the canonical example Unit. Aliases included for ergonomics
 // (hpa → horizontalpodautoscaler, etc.).
 var kindToExample = map[string]canonicalExample{
@@ -101,13 +104,13 @@ func newNewCmd() *cobra.Command {
 			"Supported kinds (alphabetical): " + strings.Join(sortedKindNames(), ", ") + ".\n\n" +
 			"The kubernetes-resources package must be installed in the current\n" +
 			"cub organization first. Bootstrap with:\n\n" +
-			"  install wizard <path>/packages/kubernetes-resources \\\n" +
+			"  installer wizard <path>/packages/kubernetes-resources \\\n" +
 			"      --work-dir /tmp/k8s-res \\\n" +
 			"      --non-interactive --namespace kubernetes-resources\n" +
-			"  install render /tmp/k8s-res\n" +
-			"  install upload /tmp/k8s-res --space kubernetes-resources\n\n" +
+			"  installer render /tmp/k8s-res\n" +
+			"  installer upload /tmp/k8s-res --space kubernetes-resources\n\n" +
 			"The upload step records the install in\n" +
-			"~/.confighub/installer/state.yaml; subsequent `install new` calls\n" +
+			"~/.confighub/installer/state.yaml; subsequent `installer new` calls\n" +
 			"read the recorded Space and pull the canonical Unit body via cub.\n\n" +
 			"Output goes to <package>/bases/default/<kind>-<name>.yaml. Pass\n" +
 			"--stdout to print to stdout instead. Pass --update-kustomization\n" +
@@ -142,7 +145,7 @@ func newNewCmd() *cobra.Command {
 			}
 			// --space-slug overrides the recorded Space (useful when
 			// the operator wants to install kubernetes-resources to
-			// a non-default Space and wire `install new` to it).
+			// a non-default Space and wire `installer new` to it).
 			if spaceSlug == "" {
 				spaceSlug = install.SpaceSlug
 			}
@@ -190,7 +193,7 @@ func newNewCmd() *cobra.Command {
 			}
 			baseDir := filepath.Join(abs, "bases", "default")
 			if _, err := os.Stat(filepath.Join(abs, "installer.yaml")); err != nil {
-				return fmt.Errorf("%s does not look like a package (no installer.yaml); run `install init` first or pass --package <dir>", abs)
+				return fmt.Errorf("%s does not look like a package (no installer.yaml); run `installer init` first or pass --package <dir>", abs)
 			}
 			if outFile == "" {
 				outFile = filepath.Join(baseDir, example.kind+"-"+name+".yaml")
@@ -247,10 +250,10 @@ func findKubernetesResourcesInstall(orgID string) (*userconfig.InstallRecord, er
 	}
 	return nil, fmt.Errorf(
 		"kubernetes-resources is not installed for organization %s. Bootstrap with:\n"+
-			"  install wizard <path>/packages/kubernetes-resources --work-dir /tmp/k8s-res --non-interactive --namespace kubernetes-resources\n"+
-			"  install render /tmp/k8s-res\n"+
-			"  install upload /tmp/k8s-res --space kubernetes-resources\n"+
-			"Then re-run `install new`.",
+			"  installer wizard <path>/packages/kubernetes-resources --work-dir /tmp/k8s-res --non-interactive --namespace kubernetes-resources\n"+
+			"  installer render /tmp/k8s-res\n"+
+			"  installer upload /tmp/k8s-res --space kubernetes-resources\n"+
+			"Then re-run `installer new`.",
 		orgID,
 	)
 }

--- a/internal/cli/package.go
+++ b/internal/cli/package.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (
@@ -17,7 +20,7 @@ func newPackageCmd() *cobra.Command {
 		Short: "Bundle a package source tree into a deterministic .tgz",
 		Long: `Package bundles a package source tree (the directory containing installer.yaml,
 bases/, components/, validation/, and an optional collector) into a
-byte-deterministic .tgz suitable for install push.
+byte-deterministic .tgz suitable for installer push.
 
 Refuses to bundle: *.env.secret files, anything under out/, anything matched
 by .installerignore (gitignore syntax). The package is NOT rendered —
@@ -42,7 +45,7 @@ See docs/package-management-plan.md (Phase 1).`,
 			dst := outFile
 			if dst == "" {
 				name := loaded.Package.Metadata.Name
-				ver := loaded.Package.Metadata.Version
+				ver := loaded.Package.InstallerMetadata.Version
 				if name == "" {
 					return fmt.Errorf("installer.yaml is missing metadata.name; pass --out to override")
 				}
@@ -56,7 +59,7 @@ See docs/package-management-plan.md (Phase 1).`,
 			if err != nil {
 				return err
 			}
-			fmt.Printf("Bundled %s@%s\n", loaded.Package.Metadata.Name, loaded.Package.Metadata.Version)
+			fmt.Printf("Bundled %s@%s\n", loaded.Package.Metadata.Name, loaded.Package.InstallerMetadata.Version)
 			fmt.Printf("  output: %s\n", dst)
 			fmt.Printf("  files:  %d\n", len(res.Files))
 			fmt.Printf("  size:   %d bytes\n", res.Size)

--- a/internal/cli/plan.go
+++ b/internal/cli/plan.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (
@@ -21,7 +24,7 @@ func newPlanCmd() *cobra.Command {
 	var workDir string
 	cmd := &cobra.Command{
 		Use:   "plan",
-		Short: "Show what install upload would change in ConfigHub",
+		Short: "Show what installer upload would change in ConfigHub",
 		Long: `Plan diffs the work-dir's rendered output against the corresponding
 ConfigHub Spaces and prints a terraform-style summary of adds, updates,
 and deletes per Space, plus the post-render image set per Space.
@@ -30,7 +33,7 @@ Plan is read-only — it does not mutate ConfigHub. Use 'installer
 upload' to execute the plan.
 
 Plan reads <work-dir>/out/spec/upload.yaml to locate the Spaces; if
-upload.yaml is missing, run 'install upload --space <slug>' first.
+upload.yaml is missing, run 'installer upload --space <slug>' first.
 The active cub organization and server are sanity-checked against the
 recorded values; mismatch fails fast.
 

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (
@@ -34,7 +37,7 @@ prior <work-dir>/package/ intact.`,
 			}
 			fmt.Printf("Pulled %s@%s to %s\n",
 				loaded.Package.Metadata.Name,
-				loaded.Package.Metadata.Version,
+				loaded.Package.InstallerMetadata.Version,
 				loaded.Root)
 			return nil
 		},

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (
@@ -24,7 +27,7 @@ push, which renders before uploading.
 ref must include a tag: oci://host/repo:tag. Digest-only refs are not
 supported because registries cannot accept blob pushes to a digest.
 
-To attach a cosign signature, run "install sign <ref>" after push.`,
+To attach a cosign signature, run "installer sign <ref>" after push.`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,8 +1,11 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 // Package cli wires the installer's cobra commands. It is invoked by
 // cmd/installer/main.go and works identically whether run as `installer ...`
-// standalone or as `cub install ...` via the cub plugin protocol — the only
+// standalone or as `cub installer ...` via the cub plugin protocol — the only
 // difference is cosmetic (the plugin sets CUB_PLUGIN=1 in the env, which we
-// surface in `install doc` output).
+// surface in `installer doc` output).
 package cli
 
 import (
@@ -11,34 +14,34 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// invokedAsPlugin reports whether the binary was launched by `cub install`.
+// invokedAsPlugin reports whether the binary was launched by `cub installer`.
 func invokedAsPlugin() bool {
 	return os.Getenv("CUB_PLUGIN") == "1"
 }
 
 // InvocationName is the command name to print in user-facing follow-up
-// instructions ("Next: ... upload <dir>"). It returns "cub install" when
+// instructions ("Next: ... upload <dir>"). It returns "cub installer" when
 // the binary was launched via the cub plugin protocol so the operator
 // can copy-paste the suggestion back into their shell; otherwise it
-// returns os.Args[0] verbatim (e.g. "bin/install", "install",
-// "/usr/local/bin/install") so the suggestion matches what they
-// actually typed. Falls back to "install" if os.Args is empty.
+// returns os.Args[0] verbatim (e.g. "bin/installer", "installer",
+// "/usr/local/bin/installer") so the suggestion matches what they
+// actually typed. Falls back to "installer" if os.Args is empty.
 func InvocationName() string {
 	if invokedAsPlugin() {
-		return "cub install"
+		return "cub installer"
 	}
 	if len(os.Args) > 0 && os.Args[0] != "" {
 		return os.Args[0]
 	}
-	return "install"
+	return "installer"
 }
 
 // NewRoot builds the root cobra command with all subcommands attached.
 func NewRoot() *cobra.Command {
 	root := &cobra.Command{
-		Use:   "install",
+		Use:   "installer",
 		Short: "Render and install Kubernetes config-as-data packages",
-		Long: `install renders kustomize-based packages — wrapped with an installer.yaml
+		Long: `installer renders kustomize-based packages — wrapped with an installer.yaml
 manifest — into per-resource Kubernetes YAML, customized with ConfigHub functions.
 
 Output is plain YAML files that can be uploaded to ConfigHub for delivery via

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (
@@ -39,7 +42,7 @@ type flowOptions struct {
 	clean     bool
 }
 
-// runFlow is the shared body of `install setup` and `install wizard`.
+// runFlow is the shared body of `installer setup` and `installer wizard`.
 // It pulls (if pullRef is set), loads prior state, builds answers,
 // runs the wizard, optionally re-resolves deps, and optionally renders.
 func runFlow(ctx context.Context, opts flowOptions) error {
@@ -403,7 +406,7 @@ func unwrapErr(err error) error {
 
 // newSetupCmd is the all-in-one consumer entry point: optional pull,
 // wizard (smart re-entry with schema-diff when prior state exists),
-// render. Does not upload — `install upload` is the next step.
+// render. Does not upload — `installer upload` is the next step.
 func newSetupCmd() *cobra.Command {
 	var opts flowOptions
 	opts.runRender = true
@@ -425,7 +428,7 @@ Pull:
                      replaces <work-dir>/package/ atomically (failed
                      pulls leave the prior tree intact). When absent,
                      the work-dir must already contain a package/ tree
-                     (run setup with --pull first, or install pull
+                     (run setup with --pull first, or installer pull
                      <ref> --work-dir <dir>).
 
 Auto-detection:
@@ -440,10 +443,10 @@ against the (possibly newer) package's input + component schema:
 silently carries forward values that still apply, adopts new defaults,
 drops removed inputs, prompts (interactive) or fails fast
 (non-interactive) for newly-required inputs without defaults. Same
-machinery as the prior install upgrade command, applied uniformly
+machinery as the prior installer upgrade command, applied uniformly
 to every re-entry.
 
-Setup does NOT upload. Run install upload to push to ConfigHub.`,
+Setup does NOT upload. Run installer upload to push to ConfigHub.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/internal/cli/sign.go
+++ b/internal/cli/sign.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (
@@ -25,10 +28,10 @@ Requires the cosign binary on PATH (override via INSTALLER_COSIGN_BIN).
 
 Examples:
   # Keyless (interactive OIDC flow):
-  install sign oci://ghcr.io/me/pkg:0.1.0 --yes
+  installer sign oci://ghcr.io/me/pkg:0.1.0 --yes
 
   # Keyed:
-  install sign oci://ghcr.io/me/pkg:0.1.0 --key cosign.key`,
+  installer sign oci://ghcr.io/me/pkg:0.1.0 --key cosign.key`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/internal/cli/stubs.go
+++ b/internal/cli/stubs.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/internal/cli/tag.go
+++ b/internal/cli/tag.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (
@@ -19,7 +22,7 @@ tags are convention-only — installer treats them as mutable aliases that
 authors maintain.
 
 Example:
-  install tag oci://ghcr.io/confighubai/foo:0.3.2 stable`,
+  installer tag oci://ghcr.io/confighubai/foo:0.3.2 stable`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/internal/cli/transformer.go
+++ b/internal/cli/transformer.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (
@@ -103,7 +106,7 @@ is passed through verbatim to the function executor's WhereResource option.
 Usable standalone with raw kustomize: reference this subcommand from your
 kustomization's transformers: list via a KRM function config whose
 config.kubernetes.io/function annotation points at a wrapper that runs
-'install transformer'.`,
+'installer transformer'.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/internal/cli/transformer_test.go
+++ b/internal/cli/transformer_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (
@@ -59,7 +62,7 @@ First upload (no upload.yaml):
   per Space at the end. Writes upload.yaml on success.
 
 Reconcile (upload.yaml exists):
-  Re-computes the same plan install plan would produce. Opens one
+  Re-computes the same plan installer plan would produce. Opens one
   ChangeSet per Space, runs cub unit update --merge-external-source
   --changeset for updates, cub unit create for adds (with --label
   Package=<pkg>), cub unit update with no data for deletes (gated on --yes
@@ -217,7 +220,7 @@ passed again.`,
 
 			// Persist where this work-dir is being uploaded before any
 			// cub calls so the upload.yaml is included in each parent's
-			// installer-record body. Subsequent `install wizard /
+			// installer-record body. Subsequent `installer wizard /
 			// plan / update / upgrade` invocations read it to re-enter
 			// from ConfigHub and to sanity-check the active cub
 			// context.
@@ -239,7 +242,7 @@ passed again.`,
 
 			// Record the parent package's install in the per-user
 			// state file (~/.confighub/installer/state.yaml). Other
-			// commands (notably `install new`) read this to find
+			// commands (notably `installer new`) read this to find
 			// kubernetes-resources without re-asking the operator.
 			// Best-effort: failure here should NOT fail the upload.
 			if err := recordUploadInUserState(cmd.Context(), packages); err != nil {
@@ -271,7 +274,7 @@ passed again.`,
 // runUploadReconcile is the second-and-subsequent-upload code path:
 // reads upload.yaml, computes a diff against ConfigHub, opens a
 // ChangeSet, and applies. Same semantics as the previous standalone
-// `install update` command.
+// `installer update` command.
 func runUploadReconcile(ctx context.Context, workDir string, loaded *ipkg.Loaded, meta spaceMetaInput, unitAnnotations, unitLabels []string, yes bool, changeSetSlug, spaceFlag, spacePatternFlag string) error {
 	if spaceFlag != "" || spacePatternFlag != "" {
 		fmt.Fprintln(os.Stderr, "note: --space / --space-pattern are read from upload.yaml on reconcile; flag value ignored")
@@ -357,7 +360,7 @@ func runUploadReconcile(ctx context.Context, workDir string, loaded *ipkg.Loaded
 	res, err := diff.Apply(ctx, plan, diff.ApplyOptions{
 		Yes:                  yes,
 		ChangeSetSlug:        changeSetSlug,
-		ChangeSetDescription: fmt.Sprintf("install upload (reconcile) from %s@%s", loaded.Package.Metadata.Name, loaded.Package.Metadata.Version),
+		ChangeSetDescription: fmt.Sprintf("installer upload (reconcile) from %s@%s", loaded.Package.Metadata.Name, loaded.Package.InstallerMetadata.Version),
 		Targets:              targets,
 		Annotations:          unitAnnotations,
 		Labels:               unitLabels,

--- a/internal/cli/upload_meta_test.go
+++ b/internal/cli/upload_meta_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/internal/cli/userstate_helpers.go
+++ b/internal/cli/userstate_helpers.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (
@@ -11,7 +14,7 @@ import (
 
 // recordedPackages is the allowlist of package names whose upload
 // gets recorded in ~/.confighub/installer/state.yaml. Only packages
-// `install new` (or another reader) needs to locate later belong
+// `installer new` (or another reader) needs to locate later belong
 // here. Most installs do not — operators would not benefit from a
 // listing of every package they have ever uploaded, and the user-
 // state file should stay scoped to actually-used metadata.
@@ -24,7 +27,7 @@ var recordedPackages = map[string]bool{
 // ~/.confighub/installer/state.yaml IF the package is in
 // recordedPackages. No-op for any other package.
 //
-// Used by `install upload` so `install new` can locate the
+// Used by `installer upload` so `installer new` can locate the
 // kubernetes-resources package without operator intervention.
 func recordUploadInUserState(ctx context.Context, packages []upload.Package) error {
 	if len(packages) == 0 || !packages[0].IsParent {

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/internal/cli/vet.go
+++ b/internal/cli/vet.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (
@@ -53,11 +56,11 @@ wizard' first).`,
 			specDir := filepath.Join(workDir, "out", "spec")
 			sel, err := readSelection(filepath.Join(specDir, "selection.yaml"))
 			if err != nil {
-				return fmt.Errorf("read selection.yaml: %w (run `install wizard` first)", err)
+				return fmt.Errorf("read selection.yaml: %w (run `installer wizard` first)", err)
 			}
 			inputs, err := readInputs(filepath.Join(specDir, "inputs.yaml"))
 			if err != nil {
-				return fmt.Errorf("read inputs.yaml: %w (run `install wizard` first)", err)
+				return fmt.Errorf("read inputs.yaml: %w (run `installer wizard` first)", err)
 			}
 			facts, err := readFactsOptional(filepath.Join(specDir, "facts.yaml"))
 			if err != nil {
@@ -75,7 +78,7 @@ wizard' first).`,
 				return err
 			}
 			if len(body) == 0 {
-				return fmt.Errorf("no manifests found in %s — run `install render` first", manifestsDir)
+				return fmt.Errorf("no manifests found in %s — run `installer render` first", manifestsDir)
 			}
 
 			fmt.Printf("Vetting %d resource(s) under %s against %d validator group(s)...\n",

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (
@@ -70,7 +73,7 @@ Pass --non-interactive to script the wizard with --base, --components,
 	cmd.Flags().BoolVar(&opts.reuse, "reuse", false, "skip prompts and re-use the prior install's selection + inputs (requires prior state)")
 	cmd.Flags().StringVar(&opts.preset, "components", "", "component preset: minimal | default | all | selected. Mutually exclusive with --select.")
 	cmd.Flags().StringSliceVar(&opts.setImage, "set-image", nil, "image override as name=ref (repeatable); applied via `kustomize edit set image` against the chosen base before render. The base's kustomization.yaml must declare an `images:` block.")
-	cmd.Flags().BoolVar(&opts.runRender, "render", true, "render after the wizard writes spec docs; pass --render=false to skip and run install render later")
+	cmd.Flags().BoolVar(&opts.runRender, "render", true, "render after the wizard writes spec docs; pass --render=false to skip and run installer render later")
 	cmd.Flags().BoolVar(&opts.clean, "clean", false, "remove previously rendered out/manifests/ (preserving any kpt Kptfile) and out/secrets/ before rendering")
 	return cmd
 }

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 // Package collector runs a package's bundled fact-collection script during
 // the wizard step. The script discovers install-time facts that depend on
 // runtime state — e.g., the active cub context's server URL, a freshly
@@ -34,7 +37,7 @@ type Inputs struct {
 	// WorkDir is the absolute path to the parent working directory
 	// (PackageDir's parent).
 	WorkDir string
-	// Namespace is the value of `install wizard --namespace`.
+	// Namespace is the value of `installer wizard --namespace`.
 	Namespace string
 	// Base is the selected base name.
 	Base string

--- a/internal/cubctx/cubctx.go
+++ b/internal/cubctx/cubctx.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 // Package cubctx reads the active cub CLI context (organization ID,
 // server URL) and offers a sanity-check helper that compares the live
 // context against values recorded in a work-dir's upload.yaml.

--- a/internal/deps/lock.go
+++ b/internal/deps/lock.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package deps
 
 import (

--- a/internal/deps/resolver.go
+++ b/internal/deps/resolver.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package deps
 
 import (
@@ -60,11 +63,11 @@ func Resolve(ctx context.Context, pkg *api.Package, src Source, opts Options) (*
 	lock := &api.Lock{
 		APIVersion: api.APIVersion,
 		Kind:       api.KindLock,
-		Metadata:   api.Metadata{Name: pkg.Metadata.Name, Version: pkg.Metadata.Version},
+		Metadata:   api.Metadata{Name: pkg.Metadata.Name},
 		Spec: api.LockSpec{
 			Package: api.LockedPackage{
 				Name:    pkg.Metadata.Name,
-				Version: pkg.Metadata.Version,
+				Version: pkg.InstallerMetadata.Version,
 			},
 			Resolved: r.flatten(),
 		},

--- a/internal/deps/resolver_test.go
+++ b/internal/deps/resolver_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package deps
 
 import (
@@ -72,9 +75,10 @@ func hash32(s string) uint32 {
 // pkgWith builds a minimal Package with the supplied name/version/deps.
 func pkgWith(name, version string, deps ...api.Dependency) *api.Package {
 	return &api.Package{
-		APIVersion: api.APIVersion,
-		Kind:       api.KindPackage,
-		Metadata:   api.Metadata{Name: name, Version: version},
+		APIVersion:        api.APIVersion,
+		Kind:              api.KindPackage,
+		Metadata:          api.Metadata{Name: name},
+		InstallerMetadata: api.InstallerMetadata{Version: version},
 		Spec: api.PackageSpec{
 			Bases:        []api.Base{{Name: "default", Path: "bases/default", Default: true}},
 			Dependencies: deps,

--- a/internal/deps/semver.go
+++ b/internal/deps/semver.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package deps
 
 import (

--- a/internal/deps/source.go
+++ b/internal/deps/source.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 // Package deps walks a Package's Dependencies, picks a version per child
 // package satisfying every constraint, and writes a Lock pinning each pick
 // to a manifest digest.

--- a/internal/diff/apply.go
+++ b/internal/diff/apply.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package diff
 
 import (
@@ -33,7 +36,7 @@ type ApplyOptions struct {
 	// changeset.DefaultSlug(time.Now()) when empty.
 	ChangeSetSlug string
 	// ChangeSetDescription is the human-readable description on the
-	// opened ChangeSet. Defaults to a generic "install update" line
+	// opened ChangeSet. Defaults to a generic "installer update" line
 	// when empty.
 	ChangeSetDescription string
 	// Targets maps a Space slug to the target ref forwarded to
@@ -142,7 +145,7 @@ func Apply(ctx context.Context, plan Plan, opts ApplyOptions) (ApplyResult, erro
 		}
 		// Close the ChangeSet by detaching the updated units. The
 		// ChangeSet itself is preserved (for revert); the units are
-		// freed so the next `install update` can open a new
+		// freed so the next `installer update` can open a new
 		// ChangeSet on them. Without this step ConfigHub rejects all
 		// subsequent updates against these units (the ChangeSet acts
 		// as a lock per docs/guide/change-apply.md).
@@ -159,7 +162,7 @@ func Apply(ctx context.Context, plan Plan, opts ApplyOptions) (ApplyResult, erro
 			res.Deleted += deleted
 		}
 		// Re-run link inference now that the Unit set has changed.
-		// No skip set here — `install update` doesn't have the
+		// No skip set here — `installer update` doesn't have the
 		// installer's rendered out/secrets/ context in hand.
 		if err := upload.ReconcileLinks(ctx, sp.SpaceSlug, sp.Package, nil); err != nil {
 			return res, err
@@ -178,9 +181,9 @@ func descriptionOrDefault(d, pkg, ver string) string {
 		return d
 	}
 	if ver != "" {
-		return fmt.Sprintf("install update from %s@%s", pkg, ver)
+		return fmt.Sprintf("installer update from %s@%s", pkg, ver)
 	}
-	return fmt.Sprintf("install update from %s", pkg)
+	return fmt.Sprintf("installer update from %s", pkg)
 }
 
 func createUnit(ctx context.Context, space, pkg, version, target string, a SlugDiff, opts ApplyOptions, stdout, stderr io.Writer) error {
@@ -365,7 +368,7 @@ func emptyUnits(ctx context.Context, space string, deletes []SlugDiff, opts Appl
 		cmd := exec.CommandContext(ctx, "cub", "unit", "update",
 			"--space", space, "--quiet",
 			"--merge-external-source", d.Slug,
-			"--change-desc", fmt.Sprintf("install upload: emptied %s (no longer in rendered output)", d.Slug),
+			"--change-desc", fmt.Sprintf("installer upload: emptied %s (no longer in rendered output)", d.Slug),
 			d.Slug, empty.Name())
 		var combined bytes.Buffer
 		cmd.Stdout = &combined

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,6 +1,9 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 // Package diff computes and renders the diff between a work-dir's
 // rendered manifests and the corresponding ConfigHub Units. Used by
-// `install plan` (read-only) and `install update` (executes the
+// `installer plan` (read-only) and `installer update` (executes the
 // plan).
 //
 // The Package label written by upload (Package=<pkg.Name>) is what
@@ -306,7 +309,7 @@ func listCurrentSlugs(ctx context.Context, space, pkg string) ([]string, error) 
 // Mutations whose only content is ConfigHub bookkeeping (the
 // confighub.com/ResourceMergeID annotation injected by every
 // merge-external-source apply) are dropped — without this filter
-// `install update` does not converge on its second run, because the
+// `installer update` does not converge on its second run, because the
 // new file body lacks the annotation that cub injected on the prior
 // merge.
 func dryRunMutations(ctx context.Context, space, slug, sourceName, path string) (string, error) {

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package diff
 
 import (
@@ -253,8 +256,8 @@ func TestDescriptionOrDefault(t *testing.T) {
 	cases := []struct {
 		d, pkg, ver, want string
 	}{
-		{"", "hello", "0.1.0", "install update from hello@0.1.0"},
-		{"", "hello", "", "install update from hello"},
+		{"", "hello", "0.1.0", "installer update from hello@0.1.0"},
+		{"", "hello", "", "installer update from hello"},
 		{"manual desc", "hello", "0.1.0", "manual desc"},
 	}
 	for _, tc := range cases {

--- a/internal/diff/images.go
+++ b/internal/diff/images.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package diff
 
 import (

--- a/internal/diff/print.go
+++ b/internal/diff/print.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package diff
 
 import (

--- a/internal/pkg/auth.go
+++ b/internal/pkg/auth.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package pkg
 
 import (

--- a/internal/pkg/load.go
+++ b/internal/pkg/load.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 // Package pkg loads installer packages — kustomize trees containing an
 // installer.yaml manifest, distributed as local directories, .tgz archives,
 // or Helm OCI artifacts.

--- a/internal/pkg/oci.go
+++ b/internal/pkg/oci.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package pkg
 
 import (
@@ -123,7 +126,7 @@ func stageAndCopy(ctx context.Context, src, tag string, dst oras.Target) (*PushR
 			ocispec.AnnotationCreated:      "1970-01-01T00:00:00Z",
 			ocispec.AnnotationTitle:        loaded.Package.Metadata.Name,
 			api.AnnotationName:             loaded.Package.Metadata.Name,
-			api.AnnotationVersion:          loaded.Package.Metadata.Version,
+			api.AnnotationVersion:          loaded.Package.InstallerMetadata.Version,
 			api.AnnotationInstallerVersion: version.Version,
 		},
 	})

--- a/internal/pkg/oci_test.go
+++ b/internal/pkg/oci_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package pkg
 
 import (
@@ -18,6 +21,7 @@ const testInstallerYAML = `apiVersion: installer.confighub.com/v1alpha1
 kind: Package
 metadata:
   name: ocitest
+installerMetadata:
   version: 1.2.3
 spec:
   bases:
@@ -79,7 +83,7 @@ func TestStageAndInspectRoundTrip(t *testing.T) {
 		t.Fatalf("manifest digest mismatch: inspect=%s pushed=%s", got.ManifestDigest, pushed.ManifestDigest)
 	}
 	cb := got.Config
-	if cb.Manifest.Metadata.Name != "ocitest" || cb.Manifest.Metadata.Version != "1.2.3" {
+	if cb.Manifest.Metadata.Name != "ocitest" || cb.Manifest.InstallerMetadata.Version != "1.2.3" {
 		t.Fatalf("manifest metadata wrong: %+v", cb.Manifest.Metadata)
 	}
 	if cb.Bundle.LayerDigest != pushed.LayerDigest {

--- a/internal/pkg/pull.go
+++ b/internal/pkg/pull.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package pkg
 
 import (
@@ -129,7 +132,7 @@ func pullLocal(src, dest string) (string, error) {
 	}
 	if info.IsDir() {
 		// For local directories, prefer in-place use unless an explicit dest
-		// is requested. This keeps `install wizard ./examples/hello-app`
+		// is requested. This keeps `installer wizard ./examples/hello-app`
 		// fast and avoids copying.
 		if dest == "" {
 			return abs, nil

--- a/internal/render/chain.go
+++ b/internal/render/chain.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package render
 
 import (
@@ -83,7 +86,7 @@ func templateFuncs(packageRoot string) template.FuncMap {
 //
 // Template context:
 //
-//	{{ .Namespace }}      — value of `install wizard --namespace`
+//	{{ .Namespace }}      — value of `installer wizard --namespace`
 //	{{ .Inputs.<name> }}  — value from inputs.yaml
 //	{{ .Facts.<name> }}   — value from facts.yaml (nil if no collector ran)
 //	{{ .Selection.* }}    — chosen base + components
@@ -102,7 +105,7 @@ func resolveChainTemplate(pkg *api.Package, inputs *api.Inputs, sel *api.Selecti
 			Metadata:   api.Metadata{Name: pkg.Metadata.Name + "-function-chain"},
 			Spec: api.FunctionChainSpec{
 				Package:        pkg.Metadata.Name,
-				PackageVersion: pkg.Metadata.Version,
+				PackageVersion: pkg.InstallerMetadata.Version,
 			},
 		}, nil
 	}
@@ -149,7 +152,7 @@ func resolveChainTemplate(pkg *api.Package, inputs *api.Inputs, sel *api.Selecti
 		},
 		Spec: api.FunctionChainSpec{
 			Package:        pkg.Metadata.Name,
-			PackageVersion: pkg.Metadata.Version,
+			PackageVersion: pkg.InstallerMetadata.Version,
 			Groups:         resolved,
 		},
 	}, nil
@@ -218,7 +221,7 @@ func resolveValidatorTemplate(pkg *api.Package, inputs *api.Inputs, sel *api.Sel
 	return resolved, nil
 }
 
-// RunValidators is the public entry point used by `install vet`. Resolves
+// RunValidators is the public entry point used by `installer vet`. Resolves
 // the package's spec.validators template against inputs + selection + facts
 // and runs each group against data (the concatenated rendered manifests).
 // packageRoot is the directory loadJSON/other template helpers anchor

--- a/internal/render/clean.go
+++ b/internal/render/clean.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package render
 
 import (

--- a/internal/render/clean_test.go
+++ b/internal/render/clean_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package render_test
 
 import (

--- a/internal/render/component_chain_test.go
+++ b/internal/render/component_chain_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package render_test
 
 import (
@@ -82,7 +85,8 @@ func writeMixinPackage(t *testing.T) string {
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "installer.yaml"), `apiVersion: installer.confighub.com/v1alpha1
 kind: Package
-metadata: {name: mixin, version: 0.1.0}
+metadata: {name: mixin}
+installerMetadata: {version: 0.1.0}
 spec:
   bases:
     - {name: default, path: bases/default, default: true}

--- a/internal/render/compose.go
+++ b/internal/render/compose.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 // Package render takes a loaded package + Selection + Inputs and produces
 // rendered Kubernetes manifests by:
 //
@@ -9,7 +12,7 @@
 //     Inputs (Go templates) and writing them to
 //     out/compose/{transformers,validators}.yaml as KRM function configs.
 //  3. Shelling out to `kustomize build --enable-exec --enable-alpha-plugins`,
-//     which invokes `install transformer` (via a wrapper script in
+//     which invokes `installer transformer` (via a wrapper script in
 //     out/compose/) to run each function group in process.
 //  4. Splitting the resulting multi-doc YAML into per-resource files with
 //     deterministic naming, written to out/manifests/.
@@ -140,7 +143,7 @@ func composeKustomization(in composeInputs, composeDir string) error {
 	// directly and runs them via chainexec.RunValidators against the
 	// kustomize output. Standalone kustomize users who want ConfigHub
 	// validators can wire ConfigHubValidators into their own
-	// kustomization's validators: list — `install transformer`
+	// kustomization's validators: list — `installer transformer`
 	// supports it.
 	if needsWrapper {
 		if err := writeTransformerWrapper(composeDir, in.TransformerBinary); err != nil {
@@ -185,7 +188,7 @@ type krmFunctionConfigMeta struct {
 // plugin recognizes for the kustomization's transformers: list. The
 // matching ConfigHubValidators kind exists in internal/cli/transformer.go
 // for standalone-kustomize users wiring it into their own validators:
-// list — `install render` runs validators in-process after kustomize
+// list — `installer render` runs validators in-process after kustomize
 // (see render.go and post_validate.go) and doesn't emit a ConfigHubValidators
 // config into the synthesized kustomization.
 const kindConfigHubTransformers = "ConfigHubTransformers"

--- a/internal/render/e2e_test.go
+++ b/internal/render/e2e_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package render_test
 
 import (

--- a/internal/render/images.go
+++ b/internal/render/images.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package render
 
 import (
@@ -17,7 +20,7 @@ import (
 // applyImageOverrides runs `kustomize edit set image <name>=<ref>` for
 // each entry in overrides against the chosen base's
 // kustomization.yaml. Mutates the package working copy in place; the
-// next `install pull` / `install upgrade` re-fetches and starts
+// next `installer pull` / `installer upgrade` re-fetches and starts
 // clean, so the mutation is non-persistent at the package source
 // level. Allowed by Principle 1's carve-out for the installer's own
 // `--set-image` mutations.

--- a/internal/render/images_test.go
+++ b/internal/render/images_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package render
 
 import (

--- a/internal/render/kustomize.go
+++ b/internal/render/kustomize.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package render
 
 import (

--- a/internal/render/multipkg.go
+++ b/internal/render/multipkg.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package render
 
 import (
@@ -159,7 +162,7 @@ func buildDepWizardAnswers(pkg *api.Package, d api.LockedDependency, parent *api
 	// Carry the locked dep's identity onto Selection so re-render is keyed
 	// to the right package.
 	sel.Spec.Package = pkg.Metadata.Name
-	sel.Spec.PackageVersion = pkg.Metadata.Version
+	sel.Spec.PackageVersion = pkg.InstallerMetadata.Version
 
 	namespace := parent.Spec.Namespace
 	values := map[string]any{}
@@ -189,7 +192,7 @@ func buildDepWizardAnswers(pkg *api.Package, d api.LockedDependency, parent *api
 		Metadata:   api.Metadata{Name: pkg.Metadata.Name + "-inputs"},
 		Spec: api.InputsSpec{
 			Package:        pkg.Metadata.Name,
-			PackageVersion: pkg.Metadata.Version,
+			PackageVersion: pkg.InstallerMetadata.Version,
 			Namespace:      namespace,
 			Values:         values,
 		},

--- a/internal/render/multipkg_test.go
+++ b/internal/render/multipkg_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package render_test
 
 import (
@@ -16,7 +19,8 @@ import (
 
 const depPackageYAML = `apiVersion: installer.confighub.com/v1alpha1
 kind: Package
-metadata: {name: dep, version: 0.1.0}
+metadata: {name: dep}
+installerMetadata: {version: 0.1.0}
 spec:
   bases:
     - {name: default, path: bases/default, default: true}
@@ -39,7 +43,8 @@ metadata:
 
 const parentPackageYAML = `apiVersion: installer.confighub.com/v1alpha1
 kind: Package
-metadata: {name: parent, version: 0.1.0}
+metadata: {name: parent}
+installerMetadata: {version: 0.1.0}
 spec:
   bases:
     - {name: default, path: bases/default, default: true}

--- a/internal/render/post_validate.go
+++ b/internal/render/post_validate.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package render
 
 import (

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package render
 
 import (
@@ -43,7 +46,7 @@ type Result struct {
 }
 
 // Render reads the package + selection + inputs, drives kustomize (which
-// invokes `install transformer` as an exec plugin to apply the function
+// invokes `installer transformer` as an exec plugin to apply the function
 // chain and validators), and writes per-resource files plus the spec docs
 // to outDir.
 //
@@ -96,7 +99,7 @@ func Render(ctx context.Context, opts Options, outDir string) (*Result, error) {
 	}
 
 	// 2. Compose out/compose/ and run kustomize against it. Kustomize
-	//    invokes the wrapper, which execs `install transformer`,
+	//    invokes the wrapper, which execs `installer transformer`,
 	//    which runs each transformer group through chainexec in-process.
 	composeDir := filepath.Join(outDir, "compose")
 	if err := composeKustomization(composeInputs{
@@ -251,7 +254,7 @@ func writeManifestIndex(path string, pkg *api.Package, files []File) error {
 		Metadata:   api.Metadata{Name: pkg.Metadata.Name + "-manifest-index"},
 		Spec: manifestIndexSpec{
 			Package:        pkg.Metadata.Name,
-			PackageVersion: pkg.Metadata.Version,
+			PackageVersion: pkg.InstallerMetadata.Version,
 		},
 	}
 	for _, f := range files {

--- a/internal/render/split.go
+++ b/internal/render/split.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package render
 
 import (
@@ -29,7 +32,7 @@ type File struct {
 	Namespace  string
 	// Sensitive marks resources that must never be uploaded as Units.
 	// Currently set for any v1/Secret. Routed to out/secrets/ instead of
-	// out/manifests/ and skipped by `install upload`.
+	// out/manifests/ and skipped by `installer upload`.
 	Sensitive bool
 }
 

--- a/internal/render/testmain_test.go
+++ b/internal/render/testmain_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package render_test
 
 import (
@@ -11,7 +14,7 @@ import (
 // installerBin is the path to a freshly-built installer binary, set by
 // TestMain and consumed by Render-driven tests via Options.TransformerBinary.
 // We can't use the go-test binary directly because it doesn't implement the
-// `install transformer` subcommand kustomize invokes through the wrapper
+// `installer transformer` subcommand kustomize invokes through the wrapper
 // script in out/compose/.
 var installerBin string
 

--- a/internal/selection/solver.go
+++ b/internal/selection/solver.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 // Package selection resolves a user's raw component picks against the package
 // manifest: closes the set under Requires, rejects Conflicts, validates
 // against the chosen Base via ValidForBases, and picks a Base when the user
@@ -88,7 +91,7 @@ func Resolve(pkg *api.Package, baseName string, picks []string) (*api.Selection,
 		},
 		Spec: api.SelectionSpec{
 			Package:        pkg.Metadata.Name,
-			PackageVersion: pkg.Metadata.Version,
+			PackageVersion: pkg.InstallerMetadata.Version,
 			Base:           base,
 			Components:     out,
 		},

--- a/internal/selection/solver_test.go
+++ b/internal/selection/solver_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package selection_test
 
 import (

--- a/internal/sign/cosign_integration_test.go
+++ b/internal/sign/cosign_integration_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package sign_test
 
 import (
@@ -177,7 +180,8 @@ func writeMinimalPackage(t *testing.T) string {
 	}
 	must("installer.yaml", `apiVersion: installer.confighub.com/v1alpha1
 kind: Package
-metadata: {name: signtest, version: 0.1.0}
+metadata: {name: signtest}
+installerMetadata: {version: 0.1.0}
 spec:
   bases:
     - {name: default, path: bases/default, default: true}

--- a/internal/sign/sign.go
+++ b/internal/sign/sign.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 // Package sign shells out to the cosign binary to sign and verify installer
 // OCI artifacts. Cosign's Go SDK is large and pulls a lot of sigstore
 // dependencies; for v1 we keep the installer binary small by invoking
@@ -73,7 +76,7 @@ func Sign(ctx context.Context, ref string, opts SignOptions) error {
 }
 
 // VerifyOptions tune one Verify call. Caller usually loads a Policy and
-// passes the matching entries; for ad-hoc `install verify`, a single
+// passes the matching entries; for ad-hoc `installer verify`, a single
 // TrustedKey or TrustedKeyless is constructed from CLI flags.
 type VerifyOptions struct {
 	// TrustedKey forces a keyed verification against this public key.

--- a/internal/sign/sign_test.go
+++ b/internal/sign/sign_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package sign
 
 import (

--- a/internal/upload/appconfig.go
+++ b/internal/upload/appconfig.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package upload
 
 import (
@@ -100,7 +103,7 @@ func DetectAppConfigManifest(path string) (*AppConfigManifest, error) {
 	}
 	mode := shape.Metadata.Annotations[annoMode]
 	if mode == "" {
-		return nil, fmt.Errorf("%s: %s missing — the transformer should have injected it during render; re-run `install render`",
+		return nil, fmt.Errorf("%s: %s missing — the transformer should have injected it during render; re-run `installer render`",
 			path, annoMode)
 	}
 	sourceKey := shape.Metadata.Annotations[annoSourceKey]

--- a/internal/upload/appconfig_test.go
+++ b/internal/upload/appconfig_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package upload
 
 import (
@@ -236,7 +239,7 @@ data:
 	if !strings.Contains(err.Error(), "appconfig-mode") {
 		t.Errorf("error should name the missing annotation: %v", err)
 	}
-	if !strings.Contains(err.Error(), "install render") {
+	if !strings.Contains(err.Error(), "installer render") {
 		t.Errorf("error should suggest re-rendering: %v", err)
 	}
 }

--- a/internal/upload/links.go
+++ b/internal/upload/links.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package upload
 
 import (
@@ -32,8 +35,8 @@ import (
 // would otherwise dominate the reminder for any package that ships a
 // RoleBinding.
 //
-// Used by `install upload` (after the per-package Unit creation
-// loop) and by `install update` (after Apply mutates the Unit set).
+// Used by `installer upload` (after the per-package Unit creation
+// loop) and by `installer update` (after Apply mutates the Unit set).
 // The two paths share an implementation so behavior cannot drift.
 func ReconcileLinks(ctx context.Context, space, pkgName string, skipUnmatched map[string]struct{}) error {
 	resources, err := loadResources(ctx, space)
@@ -91,7 +94,7 @@ func UnmatchedKey(targetType, targetName string) string {
 // managed by ConfigHub (e.g., a Secret created out-of-band, a Namespace
 // owned by the platform team, a ServiceAccount provided by a base
 // install). The installer can't verify those from here — we don't assume
-// the operator running `install upload` has cluster access — so we
+// the operator running `installer upload` has cluster access — so we
 // surface the list for the operator to confirm rather than failing.
 //
 // Two classes of references are always suppressed:
@@ -129,7 +132,7 @@ func reportUnmatchedReferences(unmatched []UnmatchedReference, skipUnmatched map
 }
 
 // LinkEdge is one inferred edge between two Units in the same Space.
-// Exposed so callers (e.g., a future install plan extension) can
+// Exposed so callers (e.g., a future installer plan extension) can
 // inspect the inference output without re-creating the links.
 type LinkEdge struct {
 	FromUnit string

--- a/internal/upload/links_test.go
+++ b/internal/upload/links_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package upload
 
 import (

--- a/internal/upload/rbac_builtins.go
+++ b/internal/upload/rbac_builtins.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package upload
 
 import "strings"

--- a/internal/upload/rbac_builtins_test.go
+++ b/internal/upload/rbac_builtins_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package upload
 
 import "testing"

--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 // Package upload turns a rendered work-dir into the inputs the cub CLI
 // needs to materialize ConfigHub Spaces, Units, and Links — without itself
 // shelling out. The CLI layer in internal/cli/upload.go orchestrates the
@@ -119,14 +122,14 @@ func Discover(in DiscoverInput) ([]Package, error) {
 
 	parentSlug, err := RenderSpaceSlug(pattern, Vars{
 		PackageName:    in.ParentPackage.Metadata.Name,
-		PackageVersion: in.ParentPackage.Metadata.Version,
+		PackageVersion: in.ParentPackage.InstallerMetadata.Version,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("parent space slug: %w", err)
 	}
 	out = append(out, Package{
 		Name:         in.ParentPackage.Metadata.Name,
-		Version:      in.ParentPackage.Metadata.Version,
+		Version:      in.ParentPackage.InstallerMetadata.Version,
 		PackageDir:   filepath.Join(in.WorkDir, "package"),
 		ManifestsDir: filepath.Join(in.WorkDir, "out", "manifests"),
 		SpecDir:      filepath.Join(in.WorkDir, "out", "spec"),
@@ -141,7 +144,7 @@ func Discover(in DiscoverInput) ([]Package, error) {
 	for _, d := range in.Lock.Spec.Resolved {
 		vendor := filepath.Join(in.WorkDir, "out", "vendor", vendorSlug(d.Name, d.Version), "package")
 		if _, err := os.Stat(filepath.Join(vendor, "installer.yaml")); err != nil {
-			return nil, fmt.Errorf("dep %s vendor missing — run `install render %s` first: %w", d.Name, in.WorkDir, err)
+			return nil, fmt.Errorf("dep %s vendor missing — run `installer render %s` first: %w", d.Name, in.WorkDir, err)
 		}
 		// Read just enough metadata. We pulled this dep ourselves, so the
 		// lock's Name/Version are authoritative; we still re-read
@@ -157,14 +160,14 @@ func Discover(in DiscoverInput) ([]Package, error) {
 		}
 		slug, err := RenderSpaceSlug(pattern, Vars{
 			PackageName:    depPkg.Metadata.Name,
-			PackageVersion: depPkg.Metadata.Version,
+			PackageVersion: depPkg.InstallerMetadata.Version,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("dep %s space slug: %w", d.Name, err)
 		}
 		out = append(out, Package{
 			Name:         depPkg.Metadata.Name,
-			Version:      depPkg.Metadata.Version,
+			Version:      depPkg.InstallerMetadata.Version,
 			LocalHandle:  d.Name,
 			PackageDir:   vendor,
 			ManifestsDir: filepath.Join(in.WorkDir, "out", d.Name, "manifests"),
@@ -335,7 +338,7 @@ func setMappingScalar(m *yaml.Node, key, value string) {
 
 // RefreshInstallerRecord rebuilds the installer-record Unit body from
 // pkg's local files and uploads it to ConfigHub. Used after
-// `install update` / `install upgrade-apply` mutates the local
+// `installer update` / `installer upgrade-apply` mutates the local
 // spec so the cub-side record stays in sync — without this refresh,
 // a subsequent upgrade reads stale inputs (notably ImageOverrides)
 // from ConfigHub via wizard.LoadPriorState.
@@ -446,7 +449,7 @@ func SplitInstallerRecord(body []byte) (*RecordContents, error) {
 // discovered package set. Reads the active cub context to record the
 // organization ID and server URL alongside the resolved Space slugs.
 //
-// Called by the CLI at the end of a successful `install upload`. Safe
+// Called by the CLI at the end of a successful `installer upload`. Safe
 // to call when packages contains only the parent (no deps).
 func WriteUploadDoc(ctx context.Context, workDir, spacePattern string, packages []Package) error {
 	if len(packages) == 0 || !packages[0].IsParent {

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package upload
 
 import (
@@ -303,7 +306,8 @@ func TestPlanCrossSpaceLinksEmpty(t *testing.T) {
 
 const minimalParentYAML = `apiVersion: installer.confighub.com/v1alpha1
 kind: Package
-metadata: {name: parent, version: 0.1.0}
+metadata: {name: parent}
+installerMetadata: {version: 0.1.0}
 spec:
   bases:
     - {name: default, path: bases/default, default: true}
@@ -311,7 +315,8 @@ spec:
 
 const parentWithDepYAML = `apiVersion: installer.confighub.com/v1alpha1
 kind: Package
-metadata: {name: parent, version: 0.1.0}
+metadata: {name: parent}
+installerMetadata: {version: 0.1.0}
 spec:
   bases:
     - {name: default, path: bases/default, default: true}
@@ -323,7 +328,8 @@ spec:
 
 const depPackageYAML = `apiVersion: installer.confighub.com/v1alpha1
 kind: Package
-metadata: {name: dep-pkg, version: 0.2.0}
+metadata: {name: dep-pkg}
+installerMetadata: {version: 0.2.0}
 spec:
   bases:
     - {name: default, path: bases/default, default: true}

--- a/internal/userconfig/userconfig.go
+++ b/internal/userconfig/userconfig.go
@@ -1,8 +1,11 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 // Package userconfig reads and writes the installer's per-user state
 // file at ~/.confighub/installer/state.yaml. The file records which
 // "bootstrap" packages (notably kubernetes-resources) the user has
 // already installed into ConfigHub, keyed by organization, so
-// `install new` can pull from them without re-installing on every
+// `installer new` can pull from them without re-installing on every
 // invocation.
 //
 // The file is scoped to one operator, not one organization — entries
@@ -33,7 +36,7 @@ type Metadata struct {
 
 type StateSpec struct {
 	// Installs records each (organizationID, package) → Space slug
-	// the operator has bootstrapped. `install new` consults this
+	// the operator has bootstrapped. `installer new` consults this
 	// before pulling so the kubernetes-resources package only gets
 	// uploaded once per org.
 	Installs []InstallRecord `yaml:"installs,omitempty" json:"installs,omitempty"`

--- a/internal/userconfig/userconfig_test.go
+++ b/internal/userconfig/userconfig_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package userconfig
 
 import (

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 // Package version exposes the installer build version. The default is "dev";
 // release builds set it via -ldflags:
 //

--- a/internal/wizard/interactive.go
+++ b/internal/wizard/interactive.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package wizard
 
 import (
@@ -410,13 +413,13 @@ func ask(p survey.Prompt, response any, opts AskOptions, extra ...survey.AskOpt)
 }
 
 // StringifyAny is the exported wrapper around stringifyAny — used by
-// `install upgrade` to round-trip prior typed values back through
+// `installer upgrade` to round-trip prior typed values back through
 // RawAnswers.
 func StringifyAny(v any) string { return stringifyAny(v) }
 
 // AskOneInput prompts interactively for a single input declaration
 // using the same widget the wizard uses inline (text / select / bool).
-// Used by `install upgrade` to ask for new required inputs that the
+// Used by `installer upgrade` to ask for new required inputs that the
 // prior install did not answer.
 func AskOneInput(in api.Input) (string, error) {
 	out := RawAnswers{Inputs: map[string]string{}}

--- a/internal/wizard/interactive_test.go
+++ b/internal/wizard/interactive_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package wizard
 
 import (

--- a/internal/wizard/prior.go
+++ b/internal/wizard/prior.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package wizard
 
 import (

--- a/internal/wizard/prior_test.go
+++ b/internal/wizard/prior_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package wizard
 
 import (
@@ -45,7 +48,8 @@ spec:
 `)
 	mustWrite(t, filepath.Join(pkgDir, "installer.yaml"), `apiVersion: installer.confighub.com/v1alpha1
 kind: Package
-metadata: {name: hello, version: 0.1.0}
+metadata: {name: hello}
+installerMetadata: {version: 0.1.0}
 spec:
   bases:
     - {name: default, path: bases/default, default: true}

--- a/internal/wizard/schemadiff.go
+++ b/internal/wizard/schemadiff.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package wizard
 
 import (
@@ -217,7 +220,7 @@ func stringSet(ss []string) map[string]struct{} {
 }
 
 // FormatNewRequiredHint renders a multiline message naming each new
-// required input — used by `install upgrade` in non-interactive
+// required input — used by `installer upgrade` in non-interactive
 // mode to fail fast with actionable detail.
 func FormatNewRequiredHint(workDir string, ins []api.Input) string {
 	if len(ins) == 0 {
@@ -235,7 +238,7 @@ func FormatNewRequiredHint(workDir string, ins []api.Input) string {
 			msg += fmt.Sprintf("  - %s (%s): %s\n", in.Name, displayType(in), prompt)
 		}
 	}
-	msg += fmt.Sprintf("re-run interactively or run `install wizard %s` to answer them, then re-run `install upgrade`.", workDir)
+	msg += fmt.Sprintf("re-run interactively or run `installer wizard %s` to answer them, then re-run `installer upgrade`.", workDir)
 	return msg
 }
 

--- a/internal/wizard/schemadiff_test.go
+++ b/internal/wizard/schemadiff_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package wizard
 
 import (
@@ -137,7 +140,7 @@ func TestFormatNewRequiredHint(t *testing.T) {
 	if hint == "" {
 		t.Fatal("expected non-empty hint")
 	}
-	for _, want := range []string{"license", "port", "Your license key", "/tmp/wd", "install wizard"} {
+	for _, want := range []string{"license", "port", "Your license key", "/tmp/wd", "installer wizard"} {
 		if !contains(hint, want) {
 			t.Errorf("hint missing %q\n%s", want, hint)
 		}

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 // Package wizard collects user answers (currently non-interactive only),
 // validates them against the package's Inputs schema, runs the package's
 // optional Collector to discover install-time facts, and emits Selection +
@@ -79,7 +82,7 @@ func Run(ctx context.Context, pkg *api.Package, raw RawAnswers, packageDir, outD
 		},
 		Spec: api.InputsSpec{
 			Package:        pkg.Metadata.Name,
-			PackageVersion: pkg.Metadata.Version,
+			PackageVersion: pkg.InstallerMetadata.Version,
 			Namespace:      raw.Namespace,
 			Values:         values,
 			ImageOverrides: mergeImageOverrides(raw.PriorImageOverrides, raw.ImageOverrides),
@@ -109,7 +112,7 @@ func Run(ctx context.Context, pkg *api.Package, raw RawAnswers, packageDir, outD
 			},
 			Spec: api.FactsSpec{
 				Package:        pkg.Metadata.Name,
-				PackageVersion: pkg.Metadata.Version,
+				PackageVersion: pkg.InstallerMetadata.Version,
 				Values:         factsValues,
 			},
 		}

--- a/packages/argocd/README.md
+++ b/packages/argocd/README.md
@@ -21,7 +21,7 @@ under `upstream/`:
 upstream trees the same way upstream's own `cluster-install/`,
 `namespace-install/`, `ha/cluster-install/`, `ha/namespace-install/`
 kustomizations do, but they also declare the version-pinned `images:`
-block so `install setup --set-image` works. Resource counts match
+block so `installer setup --set-image` works. Resource counts match
 upstream's pre-rendered `install.yaml` / `namespace-install.yaml` /
 `ha/install.yaml` / `ha/namespace-install.yaml` byte-for-byte (modulo
 namespace and image).
@@ -36,8 +36,8 @@ everything else is post-install ConfigHub mutation (`set-replicas`,
 | --- | --- |
 | install scope (cluster-admin vs namespace-only) | base selection: `cluster-install` vs `namespace-install` |
 | HA or single-replica | base selection: `ha-cluster-install` / `ha-namespace-install` vs the non-HA pair |
-| target namespace | `install setup --namespace <name>` (defaults to `argocd` per upstream convention) |
-| image / version override | `install setup --set-image quay.io/argoproj/argocd=<ref>` |
+| target namespace | `installer setup --namespace <name>` (defaults to `argocd` per upstream convention) |
+| image / version override | `installer setup --set-image quay.io/argoproj/argocd=<ref>` |
 | include CRDs | implicit in base choice — the `cluster-install` bases include them, the `namespace-install` bases don't |
 
 Decisions explicitly deferred to post-install:
@@ -66,11 +66,11 @@ The HA bases bundle [DandyDeveloper/charts redis-ha](https://github.com/DandyDev
 
 | name | default | notes |
 | --- | --- | --- |
-| (namespace) | `argocd` | passed via `install setup --namespace argocd` |
+| (namespace) | `argocd` | passed via `installer setup --namespace argocd` |
 
 No declared inputs — namespace + the four-base choice + the optional
 `--set-image` flag cover the install-time decisions. Operators who
-want to tune anything else should `install upload` first and then
+want to tune anything else should `installer upload` first and then
 edit the resulting ConfigHub Units.
 
 ## Quick start
@@ -78,7 +78,7 @@ edit the resulting ConfigHub Units.
 ```bash
 # Render against the default cluster-install base.
 mkdir -p /tmp/argocd && cd /tmp/argocd
-install setup \
+installer setup \
   --pull ~/ConfigHub/installer/packages/argocd \
   --non-interactive \
   --namespace argocd
@@ -94,14 +94,14 @@ kubectl -n argocd get pods -w
 For HA on a multi-node cluster:
 
 ```bash
-install setup --pull ~/ConfigHub/installer/packages/argocd \
+installer setup --pull ~/ConfigHub/installer/packages/argocd \
   --base ha-cluster-install --namespace argocd --non-interactive
 ```
 
 To pin a different image (e.g. mirror or patch version):
 
 ```bash
-install setup --pull ~/ConfigHub/installer/packages/argocd \
+installer setup --pull ~/ConfigHub/installer/packages/argocd \
   --non-interactive --namespace argocd \
   --set-image quay.io/argoproj/argocd=quay.io/argoproj/argocd:v3.4.2
 ```

--- a/packages/argocd/installer.yaml
+++ b/packages/argocd/installer.yaml
@@ -2,6 +2,7 @@ apiVersion: installer.confighub.com/v1alpha1
 kind: Package
 metadata:
   name: argocd
+installerMetadata:
   version: 3.4.2
   kubeVersion: ">= 1.28"
 spec:

--- a/packages/kubernetes-resources/bases/default/kustomization.yaml
+++ b/packages/kubernetes-resources/bases/default/kustomization.yaml
@@ -7,7 +7,7 @@ kind: Kustomization
 # may declare one or more resources; render's per-resource split
 # lands one Unit per top-level resource.
 #
-# `install new` (in the installer CLI) looks these up by their
+# `installer new` (in the installer CLI) looks these up by their
 # rendered Unit slugs and pulls each as a starting template for
 # operator-authored resources.
 resources:

--- a/packages/kubernetes-resources/installer.yaml
+++ b/packages/kubernetes-resources/installer.yaml
@@ -2,6 +2,7 @@ apiVersion: installer.confighub.com/v1alpha1
 kind: Package
 metadata:
   name: kubernetes-resources
+installerMetadata:
   version: 0.1.0
 spec:
   bases:
@@ -14,7 +15,7 @@ spec:
         DaemonSet, Job, CronJob, Ingress, NetworkPolicy pair, RBAC
         bundle, HPA, PDB. Each is rendered with the recommended
         defaults applied via per-type ConfigHub function groups.
-        `install new <kind> <name>` pulls these as starting
+        `installer new <kind> <name>` pulls these as starting
         templates so operators don't author Kubernetes YAML from
         scratch.
 

--- a/packages/worker/collector.sh
+++ b/packages/worker/collector.sh
@@ -2,7 +2,7 @@
 #
 # ConfigHub worker installer — fact collector.
 #
-# Invoked by `install wizard` with the package working copy as cwd. The
+# Invoked by `installer wizard` with the package working copy as cwd. The
 # installer passes:
 #
 #   INSTALLER_PACKAGE_DIR          absolute path to this package on disk

--- a/packages/worker/installer.yaml
+++ b/packages/worker/installer.yaml
@@ -2,6 +2,7 @@ apiVersion: installer.confighub.com/v1alpha1
 kind: Package
 metadata:
   name: confighub-worker
+installerMetadata:
   version: 0.1.0
 spec:
   bases:
@@ -49,7 +50,7 @@ spec:
         cub space that holds the BridgeWorker entity. When empty (the
         default), the collector relies on the active context's default
         space. This is independent of the destination space passed to
-        `install upload --space`; the two may differ when the worker
+        `installer upload --space`; the two may differ when the worker
         lives in a platform space but applies Units in env-specific spaces.
 
   validation:

--- a/packages/worker/validation/README.md
+++ b/packages/worker/validation/README.md
@@ -1,7 +1,7 @@
 # validation/
 
 Machine-readable documentation of the worker container, generated from the
-worker image itself. These files are not consumed by `install render` —
+worker image itself. These files are not consumed by `installer render` —
 they exist so a consumer (human operator or AI agent) can determine what
 env vars the workload accepts and what runtime contract it expects without
 re-pulling the image.

--- a/pkg/api/chain.go
+++ b/pkg/api/chain.go
@@ -1,17 +1,28 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package api
 
 // FunctionChain is the resolved (template-expanded) function chain that the
 // render step actually executes. Persisted as a Unit alongside the rendered
 // output so the exact transforms applied are inspectable and replayable.
 type FunctionChain struct {
-	APIVersion string            `yaml:"apiVersion" json:"apiVersion"`
-	Kind       string            `yaml:"kind" json:"kind"`
-	Metadata   Metadata          `yaml:"metadata" json:"metadata"`
-	Spec       FunctionChainSpec `yaml:"spec" json:"spec"`
+	// APIVersion is the installer API group/version.
+	APIVersion string `yaml:"apiVersion" json:"apiVersion"`
+	// Kind is "FunctionChain".
+	Kind string `yaml:"kind" json:"kind"`
+	// Metadata is the doc's ObjectMeta-shaped metadata block.
+	Metadata Metadata `yaml:"metadata" json:"metadata"`
+	// Spec carries the resolved function-group list that ran during render.
+	Spec FunctionChainSpec `yaml:"spec" json:"spec"`
 }
 
 type FunctionChainSpec struct {
-	Package        string          `yaml:"package" json:"package"`
-	PackageVersion string          `yaml:"packageVersion,omitempty" json:"packageVersion,omitempty"`
-	Groups         []FunctionGroup `yaml:"groups" json:"groups"`
+	// Package is the source package name the chain was resolved from.
+	Package string `yaml:"package" json:"package"`
+	// PackageVersion is the source package's SemVer at resolve time.
+	PackageVersion string `yaml:"packageVersion,omitempty" json:"packageVersion,omitempty"`
+	// Groups is the resolved (template-expanded) function-group list that
+	// render executed in order.
+	Groups []FunctionGroup `yaml:"groups" json:"groups"`
 }

--- a/pkg/api/configblob.go
+++ b/pkg/api/configblob.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package api
 
 // ConfigBlob is the JSON-encoded config blob attached to a native installer
@@ -7,8 +10,13 @@ package api
 // Field naming uses JSON tags only — the blob is always serialized as JSON
 // (mediaType ConfigMediaType).
 type ConfigBlob struct {
-	Bundle   BundleInfo `json:"bundle"`
-	Manifest *Package   `json:"manifest"`
+	// Bundle is the computed-at-bundle-time header (digests, file list,
+	// installer-CLI version that produced the artifact).
+	Bundle BundleInfo `json:"bundle"`
+	// Manifest is the parsed installer.yaml from the bundled .tgz, included
+	// here so `installer inspect` and the resolver can read it without
+	// pulling the layer.
+	Manifest *Package `json:"manifest"`
 }
 
 // BundleInfo is the computed-at-bundle-time header.

--- a/pkg/api/dependency.go
+++ b/pkg/api/dependency.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package api
 
 // Dependency declares another installer package this package composes with.
@@ -49,7 +52,10 @@ type Dependency struct {
 // the resolver fills in (package name, version), so DependencySelection
 // keeps the authored surface small.
 type DependencySelection struct {
-	Base       string   `yaml:"base,omitempty" json:"base,omitempty"`
+	// Base is the dep's Base.Name the parent pre-picks.
+	Base string `yaml:"base,omitempty" json:"base,omitempty"`
+	// Components is the dep's Component names the parent pre-picks. Closure
+	// under Requires is computed by the dep's solver at render time.
 	Components []string `yaml:"components,omitempty" json:"components,omitempty"`
 }
 
@@ -69,6 +75,9 @@ type ConflictRef struct {
 // treats a dependency on the named package matching the version range as
 // satisfied by the package declaring the replacement.
 type ReplaceRef struct {
+	// Package is the OCI ref (oci://host/repo) of the superseded package.
 	Package string `yaml:"package" json:"package"`
+	// Version is a SemVer range; empty or "*" matches any version of the
+	// superseded package.
 	Version string `yaml:"version,omitempty" json:"version,omitempty"`
 }

--- a/pkg/api/doc.go
+++ b/pkg/api/doc.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 // Package api defines the schemas the installer reads and writes:
 //
 //   - Package        (installer.yaml inside a package, hand-authored)
@@ -23,24 +26,45 @@ const (
 	KindUpload        = "Upload"
 )
 
-// Metadata is the common metadata block on every installer doc.
-//
-// KubeVersion and InstallerVersion are only meaningful on a Package, but
-// live here so the same block round-trips through MarshalYAML for every
-// kind. Both are SemVer range strings (e.g. ">= 1.28"); empty means
-// unconstrained.
+// Metadata is the common metadata block on every installer doc. The shape
+// matches Kubernetes ObjectMeta (name + labels + annotations) so the docs
+// look familiar to anyone reading Kubernetes YAML.
 type Metadata struct {
-	Name             string            `yaml:"name" json:"name"`
-	Version          string            `yaml:"version,omitempty" json:"version,omitempty"`
-	KubeVersion      string            `yaml:"kubeVersion,omitempty" json:"kubeVersion,omitempty"`
-	InstallerVersion string            `yaml:"installerVersion,omitempty" json:"installerVersion,omitempty"`
-	Labels           map[string]string `yaml:"labels,omitempty" json:"labels,omitempty"`
-	Annotations      map[string]string `yaml:"annotations,omitempty" json:"annotations,omitempty"`
+	// Name identifies the doc within its kind. Required.
+	Name string `yaml:"name" json:"name"`
+	// Labels are short key/value pairs used for selection and grouping.
+	Labels map[string]string `yaml:"labels,omitempty" json:"labels,omitempty"`
+	// Annotations are arbitrary key/value pairs carrying out-of-band
+	// metadata. Used by the installer for things like the
+	// PackageVersion= annotation written onto uploaded Units.
+	Annotations map[string]string `yaml:"annotations,omitempty" json:"annotations,omitempty"`
 }
 
-// Header pairs APIVersion + Kind for sniffing.
+// InstallerMetadata carries Package-level version metadata. Only meaningful
+// on a Package (not on Inputs / Selection / Lock / etc.). Both *Version
+// fields are SemVer range strings (e.g. ">= 1.28"); empty means
+// unconstrained.
+type InstallerMetadata struct {
+	// Version is the package's own SemVer version (e.g. "0.3.0"). Used as
+	// the right-hand side of `<package>@<version>` everywhere the
+	// installer prints, labels, or annotates with package identity.
+	Version string `yaml:"version,omitempty" json:"version,omitempty"`
+	// KubeVersion is a SemVer range the cluster must satisfy
+	// (e.g. ">= 1.28"). Empty means unconstrained.
+	KubeVersion string `yaml:"kubeVersion,omitempty" json:"kubeVersion,omitempty"`
+	// InstallerVersion is a SemVer range the installer CLI must satisfy
+	// (e.g. ">= 0.2.0"). Empty means unconstrained.
+	InstallerVersion string `yaml:"installerVersion,omitempty" json:"installerVersion,omitempty"`
+}
+
+// Header pairs APIVersion + Kind for sniffing the leading bytes of an
+// installer doc without parsing its full body.
 type Header struct {
-	APIVersion string   `yaml:"apiVersion" json:"apiVersion"`
-	Kind       string   `yaml:"kind" json:"kind"`
-	Metadata   Metadata `yaml:"metadata" json:"metadata"`
+	// APIVersion is the installer API group/version (e.g.
+	// "installer.confighub.com/v1alpha1").
+	APIVersion string `yaml:"apiVersion" json:"apiVersion"`
+	// Kind is one of KindPackage / KindInputs / KindSelection / etc.
+	Kind string `yaml:"kind" json:"kind"`
+	// Metadata is the doc's ObjectMeta-shaped metadata block.
+	Metadata Metadata `yaml:"metadata" json:"metadata"`
 }

--- a/pkg/api/facts.go
+++ b/pkg/api/facts.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package api
 
 // Facts holds the values produced by the package's Collector script — install-
@@ -13,14 +16,22 @@ package api
 // by a kustomize secretGenerator, and the rendered Secret is routed to
 // out/secrets/ (never uploaded as a Unit).
 type Facts struct {
-	APIVersion string    `yaml:"apiVersion" json:"apiVersion"`
-	Kind       string    `yaml:"kind" json:"kind"`
-	Metadata   Metadata  `yaml:"metadata" json:"metadata"`
-	Spec       FactsSpec `yaml:"spec" json:"spec"`
+	// APIVersion is the installer API group/version.
+	APIVersion string `yaml:"apiVersion" json:"apiVersion"`
+	// Kind is "Facts".
+	Kind string `yaml:"kind" json:"kind"`
+	// Metadata is the doc's ObjectMeta-shaped metadata block.
+	Metadata Metadata `yaml:"metadata" json:"metadata"`
+	// Spec carries the collected fact values.
+	Spec FactsSpec `yaml:"spec" json:"spec"`
 }
 
 type FactsSpec struct {
-	Package        string         `yaml:"package" json:"package"`
-	PackageVersion string         `yaml:"packageVersion,omitempty" json:"packageVersion,omitempty"`
-	Values         map[string]any `yaml:"values" json:"values"`
+	// Package is the source package name the facts were collected for.
+	Package string `yaml:"package" json:"package"`
+	// PackageVersion is the source package's SemVer at collection time.
+	PackageVersion string `yaml:"packageVersion,omitempty" json:"packageVersion,omitempty"`
+	// Values is the YAML map the collector wrote to stdout. Each key is
+	// referenced from function-chain templates as `{{ .Facts.<name> }}`.
+	Values map[string]any `yaml:"values" json:"values"`
 }

--- a/pkg/api/inputs.go
+++ b/pkg/api/inputs.go
@@ -1,18 +1,26 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package api
 
 // Inputs holds the user's wizard answers, persisted as a Unit alongside the
 // rendered output so re-render is reproducible. The wizard authors this from
 // CLI flags (--input k=v); the user may also hand-edit before re-render.
 type Inputs struct {
-	APIVersion string     `yaml:"apiVersion" json:"apiVersion"`
-	Kind       string     `yaml:"kind" json:"kind"`
-	Metadata   Metadata   `yaml:"metadata" json:"metadata"`
-	Spec       InputsSpec `yaml:"spec" json:"spec"`
+	// APIVersion is the installer API group/version.
+	APIVersion string `yaml:"apiVersion" json:"apiVersion"`
+	// Kind is "Inputs".
+	Kind string `yaml:"kind" json:"kind"`
+	// Metadata is the doc's ObjectMeta-shaped metadata block.
+	Metadata Metadata `yaml:"metadata" json:"metadata"`
+	// Spec carries the wizard answers.
+	Spec InputsSpec `yaml:"spec" json:"spec"`
 }
 
 type InputsSpec struct {
 	// Package identifies the source package (name@version) these inputs answer.
-	Package        string `yaml:"package" json:"package"`
+	Package string `yaml:"package" json:"package"`
+	// PackageVersion is the source package's SemVer at wizard time.
 	PackageVersion string `yaml:"packageVersion,omitempty" json:"packageVersion,omitempty"`
 	// Namespace is the Kubernetes namespace into which the package will install.
 	// Captured at wizard time via --namespace so that every package does not

--- a/pkg/api/lock.go
+++ b/pkg/api/lock.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package api
 
 // Lock pins every dependency of a package to a specific OCI digest. The
@@ -9,10 +12,14 @@ package api
 // metadata to reproduce its own render — without keeping a separate file
 // under version control.
 type Lock struct {
-	APIVersion string   `yaml:"apiVersion" json:"apiVersion"`
-	Kind       string   `yaml:"kind" json:"kind"`
-	Metadata   Metadata `yaml:"metadata" json:"metadata"`
-	Spec       LockSpec `yaml:"spec" json:"spec"`
+	// APIVersion is the installer API group/version.
+	APIVersion string `yaml:"apiVersion" json:"apiVersion"`
+	// Kind is "Lock".
+	Kind string `yaml:"kind" json:"kind"`
+	// Metadata is the doc's ObjectMeta-shaped metadata block.
+	Metadata Metadata `yaml:"metadata" json:"metadata"`
+	// Spec carries the resolved dependency DAG.
+	Spec LockSpec `yaml:"spec" json:"spec"`
 }
 
 type LockSpec struct {
@@ -26,7 +33,9 @@ type LockSpec struct {
 
 // LockedPackage describes the root package the lock was computed against.
 type LockedPackage struct {
-	Name    string `yaml:"name" json:"name"`
+	// Name is the root package's metadata.name.
+	Name string `yaml:"name" json:"name"`
+	// Version is the root package's installerMetadata.version.
 	Version string `yaml:"version,omitempty" json:"version,omitempty"`
 	// Digest is the OCI manifest digest of the root package, if it was
 	// pulled from a registry. Empty for in-tree (un-published) root

--- a/pkg/api/oci.go
+++ b/pkg/api/oci.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package api
 
 // OCI media types and annotation keys for native installer artifacts.

--- a/pkg/api/package.go
+++ b/pkg/api/package.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package api
 
 // Package is the installer.yaml document a package author writes by hand.
@@ -5,10 +8,21 @@ package api
 // should ask for, what external preconditions the package needs, and what the
 // function chain template looks like.
 type Package struct {
-	APIVersion string      `yaml:"apiVersion" json:"apiVersion"`
-	Kind       string      `yaml:"kind" json:"kind"`
-	Metadata   Metadata    `yaml:"metadata" json:"metadata"`
-	Spec       PackageSpec `yaml:"spec" json:"spec"`
+	// APIVersion is the installer API group/version
+	// ("installer.confighub.com/v1alpha1"). Required.
+	APIVersion string `yaml:"apiVersion" json:"apiVersion"`
+	// Kind is "Package". Required.
+	Kind string `yaml:"kind" json:"kind"`
+	// Metadata is the Kubernetes-style ObjectMeta block. Only Name is
+	// required.
+	Metadata Metadata `yaml:"metadata" json:"metadata"`
+	// InstallerMetadata carries the package's SemVer (version) plus the
+	// optional KubeVersion / InstallerVersion ranges. Hand-authored at
+	// the top level of installer.yaml alongside metadata.
+	InstallerMetadata InstallerMetadata `yaml:"installerMetadata,omitempty" json:"installerMetadata,omitempty"`
+	// Spec carries the package's authored declarations: bases, components,
+	// inputs, dependencies, transformers, etc.
+	Spec PackageSpec `yaml:"spec" json:"spec"`
 }
 
 type PackageSpec struct {
@@ -177,8 +191,11 @@ const (
 )
 
 type ExternalRequire struct {
+	// Kind is the precondition category (see ExternalRequireKind constants).
 	Kind ExternalRequireKind `yaml:"kind" json:"kind"`
-	Name string              `yaml:"name,omitempty" json:"name,omitempty"`
+	// Name optionally pins the requirement to a specific instance (e.g.,
+	// a particular CRD or operator name). Empty matches any instance of Kind.
+	Name string `yaml:"name,omitempty" json:"name,omitempty"`
 	// Version is a constraint expression (e.g., ">= v0.4.0").
 	Version string `yaml:"version,omitempty" json:"version,omitempty"`
 	// Capability is used with GatewayClass to require a specific feature
@@ -206,12 +223,17 @@ const (
 )
 
 type Provide struct {
+	// Kind is the provided-resource category (see ProvideKind constants).
 	Kind ProvideKind `yaml:"kind" json:"kind"`
-	Name string      `yaml:"name" json:"name"`
+	// Name identifies the specific resource provided (e.g., a CRD name).
+	Name string `yaml:"name" json:"name"`
 }
 
 type SingletonClaim struct {
-	Lease     string `yaml:"lease" json:"lease"`
+	// Lease is the leader-election lease name this package claims.
+	Lease string `yaml:"lease" json:"lease"`
+	// Namespace scopes the lease to a specific namespace; empty means
+	// cluster-scoped.
 	Namespace string `yaml:"namespace,omitempty" json:"namespace,omitempty"`
 }
 
@@ -252,6 +274,8 @@ type Input struct {
 }
 
 type Phase struct {
+	// Name is the phase label written onto each rendered Unit that
+	// matches WhereResource.
 	Name string `yaml:"name" json:"name"`
 	// WhereResource is a ConfigHub function-executor filter expression. The
 	// first phase whose filter matches is assigned to a resource. The last
@@ -277,8 +301,14 @@ type FunctionGroup struct {
 	Description string `yaml:"description,omitempty" json:"description,omitempty"`
 }
 
+// FunctionInvocation is one call within a FunctionGroup.
 type FunctionInvocation struct {
-	Name string   `yaml:"name" json:"name"`
+	// Name is the function name (matches the ConfigHub function registry,
+	// e.g., "set-namespace", "set-container-image", "vet-schemas").
+	Name string `yaml:"name" json:"name"`
+	// Args is the positional argument list passed to the function. Values
+	// may contain Go-template expressions resolved at render time
+	// ({{ .Namespace }}, {{ .Inputs.* }}, {{ .Facts.* }}, ...).
 	Args []string `yaml:"args,omitempty" json:"args,omitempty"`
 }
 

--- a/pkg/api/parse.go
+++ b/pkg/api/parse.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package api
 
 import (

--- a/pkg/api/parse_test.go
+++ b/pkg/api/parse_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package api_test
 
 import (
@@ -113,6 +116,7 @@ const validPackageWithDeps = `apiVersion: installer.confighub.com/v1alpha1
 kind: Package
 metadata:
   name: stack
+installerMetadata:
   version: 0.3.0
   kubeVersion: ">= 1.28"
   installerVersion: ">= 0.2.0"
@@ -156,11 +160,14 @@ func TestParsePackageWithDeps(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParsePackage: %v", err)
 	}
-	if p.Metadata.KubeVersion != ">= 1.28" {
-		t.Errorf("kubeVersion = %q", p.Metadata.KubeVersion)
+	if p.InstallerMetadata.Version != "0.3.0" {
+		t.Errorf("version = %q", p.InstallerMetadata.Version)
 	}
-	if p.Metadata.InstallerVersion != ">= 0.2.0" {
-		t.Errorf("installerVersion = %q", p.Metadata.InstallerVersion)
+	if p.InstallerMetadata.KubeVersion != ">= 1.28" {
+		t.Errorf("kubeVersion = %q", p.InstallerMetadata.KubeVersion)
+	}
+	if p.InstallerMetadata.InstallerVersion != ">= 0.2.0" {
+		t.Errorf("installerVersion = %q", p.InstallerMetadata.InstallerVersion)
 	}
 	if len(p.Spec.Dependencies) != 2 {
 		t.Fatalf("dependencies = %d, want 2", len(p.Spec.Dependencies))

--- a/pkg/api/policy.go
+++ b/pkg/api/policy.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package api
 
 // SigningPolicy declares which signatures the installer trusts when
@@ -7,10 +10,14 @@ package api
 // When Enforce is true and a ref's signature does not satisfy at least one
 // entry in TrustedKeys or TrustedKeyless, the operation fails.
 type SigningPolicy struct {
-	APIVersion string            `yaml:"apiVersion" json:"apiVersion"`
-	Kind       string            `yaml:"kind" json:"kind"`
-	Metadata   Metadata          `yaml:"metadata,omitempty" json:"metadata,omitempty"`
-	Spec       SigningPolicySpec `yaml:"spec" json:"spec"`
+	// APIVersion is the installer API group/version.
+	APIVersion string `yaml:"apiVersion" json:"apiVersion"`
+	// Kind is "SigningPolicy".
+	Kind string `yaml:"kind" json:"kind"`
+	// Metadata is the doc's ObjectMeta-shaped metadata block.
+	Metadata Metadata `yaml:"metadata,omitempty" json:"metadata,omitempty"`
+	// Spec carries the enforce flag and the trusted-signer lists.
+	Spec SigningPolicySpec `yaml:"spec" json:"spec"`
 }
 
 const KindSigningPolicy = "SigningPolicy"

--- a/pkg/api/selection.go
+++ b/pkg/api/selection.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package api
 
 // Selection records the chosen base + components after the wizard's solver
@@ -5,15 +8,20 @@ package api
 // Conflicts. Persisted as a Unit alongside the rendered output; user-editable
 // for re-render ("add cache-server", "switch to knative base").
 type Selection struct {
-	APIVersion string        `yaml:"apiVersion" json:"apiVersion"`
-	Kind       string        `yaml:"kind" json:"kind"`
-	Metadata   Metadata      `yaml:"metadata" json:"metadata"`
-	Spec       SelectionSpec `yaml:"spec" json:"spec"`
+	// APIVersion is the installer API group/version.
+	APIVersion string `yaml:"apiVersion" json:"apiVersion"`
+	// Kind is "Selection".
+	Kind string `yaml:"kind" json:"kind"`
+	// Metadata is the doc's ObjectMeta-shaped metadata block.
+	Metadata Metadata `yaml:"metadata" json:"metadata"`
+	// Spec carries the chosen base + closure-resolved components.
+	Spec SelectionSpec `yaml:"spec" json:"spec"`
 }
 
 type SelectionSpec struct {
 	// Package identifies the source package this selection is against.
-	Package        string `yaml:"package" json:"package"`
+	Package string `yaml:"package" json:"package"`
+	// PackageVersion is the source package's SemVer at selection time.
 	PackageVersion string `yaml:"packageVersion,omitempty" json:"packageVersion,omitempty"`
 	// Base is the chosen Base.Name from the package.
 	Base string `yaml:"base" json:"base"`

--- a/pkg/api/upload_doc.go
+++ b/pkg/api/upload_doc.go
@@ -1,3 +1,6 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
 package api
 
 // Upload records where a work-dir's spec was last uploaded so the wizard
@@ -7,10 +10,14 @@ package api
 // installer-record Unit body so a freshly cloned work-dir can be
 // recovered from ConfigHub alone.
 type Upload struct {
-	APIVersion string     `yaml:"apiVersion" json:"apiVersion"`
-	Kind       string     `yaml:"kind" json:"kind"`
-	Metadata   Metadata   `yaml:"metadata" json:"metadata"`
-	Spec       UploadSpec `yaml:"spec" json:"spec"`
+	// APIVersion is the installer API group/version.
+	APIVersion string `yaml:"apiVersion" json:"apiVersion"`
+	// Kind is "Upload".
+	Kind string `yaml:"kind" json:"kind"`
+	// Metadata is the doc's ObjectMeta-shaped metadata block.
+	Metadata Metadata `yaml:"metadata" json:"metadata"`
+	// Spec carries the destination Space(s) and the cub context used.
+	Spec UploadSpec `yaml:"spec" json:"spec"`
 }
 
 type UploadSpec struct {
@@ -36,9 +43,16 @@ type UploadSpec struct {
 	OrganizationID string `yaml:"organizationID,omitempty" json:"organizationID,omitempty"`
 }
 
+// UploadedSpace records one (package, resolved Space slug) pair from an
+// upload. Each parent or locked dependency uploads into its own Space.
 type UploadedSpace struct {
-	Package  string `yaml:"package" json:"package"`
-	Version  string `yaml:"version,omitempty" json:"version,omitempty"`
-	Slug     string `yaml:"slug" json:"slug"`
-	IsParent bool   `yaml:"isParent,omitempty" json:"isParent,omitempty"`
+	// Package is the package's metadata.name.
+	Package string `yaml:"package" json:"package"`
+	// Version is the package's installerMetadata.version at upload time.
+	Version string `yaml:"version,omitempty" json:"version,omitempty"`
+	// Slug is the resolved ConfigHub Space slug (from SpacePattern).
+	Slug string `yaml:"slug" json:"slug"`
+	// IsParent flags the entry for the parent (root) package as opposed to
+	// a locked dependency.
+	IsParent bool `yaml:"isParent,omitempty" json:"isParent,omitempty"`
 }

--- a/test/e2e/package-and-deps.sh
+++ b/test/e2e/package-and-deps.sh
@@ -58,8 +58,8 @@ trap cleanup EXIT
 
 # 1. Build.
 log "build installer"
-( cd "$REPO_ROOT" && go build -o bin/install ./cmd/installer )
-BIN="$REPO_ROOT/bin/install"
+( cd "$REPO_ROOT" && go build -o bin/installer ./cmd/installer )
+BIN="$REPO_ROOT/bin/installer"
 
 # 2. Registry.
 log "start registry:2 on :$REGISTRY_PORT"
@@ -96,11 +96,18 @@ lock="$WORK_TMP/out/spec/lock.yaml"
 [[ -d "$WORK_TMP/package" ]] || fail "setup --pull should produce $WORK_TMP/package/"
 [[ ! -d "$WORK_TMP/.upgrade" ]] || fail "setup should NOT create .upgrade/ (atomic pull replaces package/)"
 
-# Parent should render exactly the Deployment.
+# Parent should render the Deployment plus the auto-injected Namespace
+# (example-stack does not declare a Namespace of its own, so the
+# render-time namespace guarantee adds one).
 parent_count=$(find "$parent_manifests" -type f -name '*.yaml' | wc -l | tr -d ' ')
-[[ "$parent_count" = "1" ]] || fail "parent has $parent_count manifests, want 1"
-grep -q 'kind: Deployment' "$parent_manifests"/*.yaml || fail "parent manifest is not a Deployment"
-grep -q '^  namespace: e2e-ns' "$parent_manifests"/*.yaml || fail "parent Deployment missing namespace: e2e-ns"
+[[ "$parent_count" = "2" ]] || fail "parent has $parent_count manifests, want 2 (Deployment + injected Namespace)"
+parent_dep="$parent_manifests/deployment-e2e-ns-example-stack.yaml"
+parent_ns="$parent_manifests/namespace-e2e-ns.yaml"
+[[ -f "$parent_dep" ]] || fail "missing $parent_dep"
+[[ -f "$parent_ns"  ]] || fail "missing $parent_ns (namespace-guarantee should inject one)"
+grep -q 'kind: Deployment' "$parent_dep" || fail "parent deployment manifest is not a Deployment"
+grep -q '^  namespace: e2e-ns' "$parent_dep" || fail "parent Deployment missing namespace: e2e-ns"
+grep -q '^  name: e2e-ns$' "$parent_ns" || fail "parent Namespace not named e2e-ns"
 
 # Dep should render exactly Namespace + ConfigMap, both in e2e-ns.
 dep_count=$(find "$dep_manifests" -type f -name '*.yaml' | wc -l | tr -d ' ')
@@ -115,7 +122,7 @@ grep -q '^  name: e2e-ns$' "$ns_file" || fail "Namespace not renamed to e2e-ns"
 grep -q 'name: base' "$lock" || fail "lock missing dep entry"
 grep -q '^      digest: sha256:' "$lock" || fail "lock missing pinned digest"
 
-echo "render assertions passed: parent=1 manifest, dep=2 manifests, lock has pinned digest"
+echo "render assertions passed: parent=2 manifests (Deployment + injected Namespace), dep=2 manifests, lock has pinned digest"
 
 # 6. Determinism: re-run setup --pull into a fresh dir and confirm
 #    every output file's sha256 matches.

--- a/test/e2e/setup-flow.sh
+++ b/test/e2e/setup-flow.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# setup-flow.sh — end-to-end smoke for the consolidated `install setup`
+# setup-flow.sh — end-to-end smoke for the consolidated `installer setup`
 # command. Exercises the local pipeline (no ConfigHub required):
 #
 #   first install via setup --pull
@@ -43,9 +43,9 @@ cleanup() {
 trap cleanup EXIT
 
 # 1. Build.
-log "build install"
-( cd "$REPO_ROOT" && go build -o bin/install ./cmd/installer )
-BIN="$REPO_ROOT/bin/install"
+log "build installer"
+( cd "$REPO_ROOT" && go build -o bin/installer ./cmd/installer )
+BIN="$REPO_ROOT/bin/installer"
 
 # 2. Stage two versions of hello-app to drive an upgrade flow against
 #    local paths (no OCI registry needed). v2 adds a new input with a
@@ -146,18 +146,18 @@ log "setup --pull (no --set-image) — override carries forward"
 grep -q 'plain-text-v2' "$WORK_TMP/out/manifests"/*.yaml \
   || fail "image override should still be in the rendered manifest after re-pull"
 
-# 9. install pull --work-dir into a fresh dir.
+# 9. installer pull --work-dir into a fresh dir.
 PULL_WD=$(mktemp -d -t setup-flow-pull.XXXXXX)
-log "install pull --work-dir writes to <work-dir>/package/"
+log "installer pull --work-dir writes to <work-dir>/package/"
 "$BIN" pull "$PKG_V1" --work-dir "$PULL_WD" >/dev/null
 [[ -f "$PULL_WD/package/installer.yaml" ]] \
-  || fail "install pull should produce $PULL_WD/package/installer.yaml"
+  || fail "installer pull should produce $PULL_WD/package/installer.yaml"
 [[ ! -d "$PULL_WD/.tmp-pull-"* ]] \
-  || fail "install pull should not leave .tmp-pull-* staging behind on success"
+  || fail "installer pull should not leave .tmp-pull-* staging behind on success"
 
-# 10. install pull --work-dir on an existing dir replaces the package
+# 10. installer pull --work-dir on an existing dir replaces the package
 #     atomically.
-log "install pull --work-dir replaces existing package/ atomically"
+log "installer pull --work-dir replaces existing package/ atomically"
 sentinel="$PULL_WD/package/installer.yaml.sentinel"
 touch "$sentinel"
 "$BIN" pull "$PKG_V2" --work-dir "$PULL_WD" >/dev/null

--- a/test/e2e/upload-reconcile.sh
+++ b/test/e2e/upload-reconcile.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# upload-reconcile.sh — end-to-end smoke for `install upload` against a
+# upload-reconcile.sh — end-to-end smoke for `installer upload` against a
 # live ConfigHub server, driven by the worker package so the test
 # exercises BOTH the standard Unit pathway and the AppConfig pathway
 # (render-configmap Invocation + AppConfig Unit + placeholder + Upsert
@@ -10,7 +10,7 @@
 #
 #   setup --pull   — pulls worker, runs collector (writes facts), renders
 #   pin image      — edits facts.yaml to a known release tag, re-renders
-#                    via `install render` (bypasses setup's collector,
+#                    via `installer render` (bypasses setup's collector,
 #                    which would overwrite facts back to :latest)
 #   make Target    — creates a Target in its own Space so the upload can
 #                    bind Units to it via cross-Space <space>/<target>
@@ -48,7 +48,7 @@
 #
 # (Never deletes the `default` Space.)
 #
-# Full output of every `install` and `cub` invocation is written to a
+# Full output of every `installer` and `cub` invocation is written to a
 # per-step log file under the work-dir so debugging a failure does not
 # require re-running the (slow) flow.
 #
@@ -165,9 +165,9 @@ if cub space list 2>/dev/null | awk '{print $1}' | grep -qx "$SPACE"; then
 fi
 
 # 2. Build.
-log "build install"
-( cd "$REPO_ROOT" && go build -o bin/install ./cmd/installer )
-BIN="$REPO_ROOT/bin/install"
+log "build installer"
+( cd "$REPO_ROOT" && go build -o bin/installer ./cmd/installer )
+BIN="$REPO_ROOT/bin/installer"
 
 # 3. Pre-create the destination Space so the worker collector can
 #    create the BridgeWorker entity in it (--input space=$SPACE).
@@ -198,12 +198,12 @@ run setup "$BIN" setup --pull "$REPO_ROOT/packages/worker" \
 [[ -d "$WORK_TMP/out/secrets" ]] || fail "expected $WORK_TMP/out/secrets/ (rendered Secret routed off the upload path)"
 
 # 5. Pin the image to a known release tag by editing facts.yaml and
-#    re-rendering via `install render` (NOT setup, which would re-run
+#    re-rendering via `installer render` (NOT setup, which would re-run
 #    the collector and revert image back to whatever the server
 #    reports — :latest, locally). This both demonstrates that .Facts
 #    is a supported override point and gives us a stable image string
 #    to assert against downstream.
-log "pin worker image to $PINNED_IMAGE (edit facts.yaml + install render)"
+log "pin worker image to $PINNED_IMAGE (edit facts.yaml + installer render)"
 note "collector-reported image was:"
 grep -E '^[[:space:]]+image:' "$WORK_TMP/out/spec/facts.yaml" | sed 's/^/      /'
 # Use python for a safe in-place YAML update — preserves other fact keys.
@@ -264,7 +264,7 @@ note "Target $TARGET_SPACE/$TARGET_SLUG → TargetID $TARGET_ID"
 #    free-form --space-label / --space-annotation pairs, the --unit-label
 #    / --unit-annotation pairs on every Unit, and binding Units to the
 #    cross-Space Target (whose TargetID is recorded as a Space annotation).
-log "install upload --space $SPACE (first upload — exercises AppConfig pathway + Space/Unit metadata + cross-Space --target)"
+log "installer upload --space $SPACE (first upload — exercises AppConfig pathway + Space/Unit metadata + cross-Space --target)"
 run upload-first "$BIN" upload --work-dir "$WORK_TMP" --space "$SPACE" \
   --component my-component \
   --layer App \
@@ -346,14 +346,14 @@ appcfg_tid=$(unit_jq confighub-worker-env .Unit.TargetID)
 note "AppConfig Unit confighub-worker-env has no Target (pure data source)"
 
 # 7. plan against unchanged work-dir → No changes.
-log "install plan (clean) — expect No changes"
+log "installer plan (clean) — expect No changes"
 run plan-clean "$BIN" plan --work-dir "$WORK_TMP" || fail "plan failed (see $WORK_TMP/plan-clean.log)"
 grep -q "^No changes\\.$" "$WORK_TMP/plan-clean.log" \
   || fail "plan against just-uploaded work-dir should report No changes (see $WORK_TMP/plan-clean.log)"
 
 # 8. AppConfig round-trip FIRST (before the Deployment-edit step):
 #    change a real value in the env carrier locally, re-render via
-#    install render (NOT setup — which would re-run the collector and
+#    installer render (NOT setup — which would re-run the collector and
 #    revert the pinned image), then reconcile via upload. Proves the
 #    AppConfig pathway picks up source-format changes AND that the
 #    diff's AppConfig-aware path (UnitSlug detection + raw-content
@@ -396,7 +396,7 @@ grep -q "^CONFIGHUB_WORKER_HTTP_SERVER_PORT=9093$" "$WORK_TMP/confighub-worker-e
 note "AppConfig Unit body now has CONFIGHUB_WORKER_HTTP_SERVER_PORT=9093"
 
 # 9. Second upload — converges, no ChangeSet opened.
-log "install upload (no changes after AppConfig edit) — re-run is a no-op"
+log "installer upload (no changes after AppConfig edit) — re-run is a no-op"
 run upload-converge-1 "$BIN" upload --work-dir "$WORK_TMP" || fail "converge upload failed (see $WORK_TMP/upload-converge-1.log)"
 grep -q "^No changes\\.$" "$WORK_TMP/upload-converge-1.log" \
   || fail "upload on the same work-dir after AppConfig reconcile should be No changes (see $WORK_TMP/upload-converge-1.log)"
@@ -441,7 +441,7 @@ note "set-once verified: Environment→Staging; Component/Layer/Region + TargetI
 # 10. Edit a rendered Kubernetes manifest (the Deployment) → plan
 #     surfaces the diff. This exercises the standard (non-AppConfig)
 #     update path. The marker is injected into out/manifests/ AFTER
-#     render, so a subsequent install render would strip it — but we
+#     render, so a subsequent installer render would strip it — but we
 #     don't re-render here, so the marker stays for the reconcile
 #     dry-run.
 log "edit rendered Deployment, plan surfaces diff"
@@ -469,7 +469,7 @@ grep -q "~ $EDIT_SLUG" "$WORK_TMP/plan-edited.log" \
   || fail "plan after edit should name the edited slug ($EDIT_SLUG) (see $WORK_TMP/plan-edited.log)"
 
 # 11. upload reconcile — applies the diff inside a ChangeSet.
-log "install upload (reconcile Deployment marker) — applies 1 change"
+log "installer upload (reconcile Deployment marker) — applies 1 change"
 run upload-reconcile "$BIN" upload --work-dir "$WORK_TMP" --yes || fail "upload reconcile failed (see $WORK_TMP/upload-reconcile.log)"
 grep -q "^Applied: 0 created, 1 updated, 0 emptied\\.$" "$WORK_TMP/upload-reconcile.log" \
   || fail "upload reconcile should apply 1 change (see $WORK_TMP/upload-reconcile.log)"
@@ -489,7 +489,7 @@ grep -q "installer-test-marker: 'true'" "$WORK_TMP/deployment.after.txt" \
 note "Deployment Unit body now has the installer-test-marker label"
 
 # 12. Second upload — converges, no ChangeSet opened.
-log "install upload (no changes after Deployment edit) — re-run is a no-op"
+log "installer upload (no changes after Deployment edit) — re-run is a no-op"
 run upload-converge-2 "$BIN" upload --work-dir "$WORK_TMP" || fail "converge upload failed (see $WORK_TMP/upload-converge-2.log)"
 grep -q "^No changes\\.$" "$WORK_TMP/upload-converge-2.log" \
   || fail "upload on the same work-dir after Deployment reconcile should be No changes (see $WORK_TMP/upload-converge-2.log)"


### PR DESCRIPTION
## Summary

Four cleanups in the installer repo:

- **Rename the command back to `installer`.** Per feedback that the noun reads more naturally than the verb, the binary is `bin/installer` again, the cobra root command is `installer`, and the cub plugin entrypoint exposes it as `cub installer ...`. Updated every reference in Makefile, docs, end-to-end tests, examples/, packages/, and Go source.
- **MIT copyright headers on every Go file.** `// Copyright (C) ConfigHub, Inc.` + `// SPDX-License-Identifier: MIT` prepended to all 104 Go files under `cmd/`, `internal/`, `pkg/`. Done in one shot — no pre-commit framework dependency.
- **Split `Metadata` into Kubernetes-shaped `Metadata` + `InstallerMetadata`.** `pkg/api/Metadata` now only carries `Name`, `Labels`, `Annotations`, matching Kubernetes `ObjectMeta`. `Version`, `KubeVersion`, `InstallerVersion` moved to a new `InstallerMetadata` type carried at the top level of `Package` (so `installer.yaml` now has parallel `metadata:` and `installerMetadata:` blocks). Updated every fixture in `examples/`, `packages/`, and inline test YAML.
- **Field comments on every `pkg/api` struct field.** Audited `chain.go`, `dependency.go`, `facts.go`, `inputs.go`, `lock.go`, `selection.go`, `upload_doc.go`, `policy.go`, `configblob.go`, `doc.go`, and `package.go` and filled in every uncommented field.

Plus one drive-by fix: `test/e2e/package-and-deps.sh` was failing on `main` (pre-existing, before this branch) because commit 8848271 added an auto-injected Namespace to every render but the assertion still expected the parent to produce exactly 1 manifest. Updated to expect Deployment + injected Namespace.

## Test plan

- [x] `make build` produces `bin/installer`
- [x] `make test` (unit tests) green across all packages
- [x] `make vet` clean
- [x] `bin/installer --help` shows root command as `installer`
- [x] `bin/installer init /tmp/foo` writes installer.yaml with new `installerMetadata:` block
- [x] `bin/installer doc ./examples/hello-app` parses the migrated fixtures
- [x] `test/e2e/setup-flow.sh` — local pipeline (pull, wizard, render, schema-diff, image override)
- [x] `test/e2e/package-and-deps.sh` — multi-package + deps + determinism
- [x] `test/e2e/upload-reconcile.sh` — full live-server flow (upload, plan, AppConfig round-trip, Deployment reconcile, DestroyGate refusal, empty-on-drop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)