### PR TITLE
feat(packages): namespace-envelope base package

### DIFF
--- a/packages/namespace-envelope/bases/default/default-deny.yaml
+++ b/packages/namespace-envelope/bases/default/default-deny.yaml
@@ -1,0 +1,37 @@
+# default-deny-all isolates every pod for both ingress and egress. The
+# allow-dns-egress policy re-permits cluster DNS so the deny doesn't break
+# name resolution (NetworkPolicy is additive-OR: the two policies combine).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: confighubplaceholder
+  labels:
+    app.kubernetes.io/managed-by: confighub-namespace-manager
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: confighubplaceholder
+  labels:
+    app.kubernetes.io/managed-by: confighub-namespace-manager
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/packages/namespace-envelope/bases/default/kustomization.yaml
+++ b/packages/namespace-envelope/bases/default/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# The namespace policy envelope, rendered as a set: render's per-resource
+# split lands one Unit per top-level resource (Namespace, the two
+# NetworkPolicies, and the three RBAC objects = six Units).
+resources:
+  - namespace.yaml
+  - default-deny.yaml
+  - rbac.yaml

--- a/packages/namespace-envelope/bases/default/namespace.yaml
+++ b/packages/namespace-envelope/bases/default/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: confighubplaceholder
+  labels:
+    app.kubernetes.io/managed-by: confighub-namespace-manager

--- a/packages/namespace-envelope/bases/default/rbac.yaml
+++ b/packages/namespace-envelope/bases/default/rbac.yaml
@@ -1,0 +1,40 @@
+# Baseline namespace RBAC: a ServiceAccount for the namespace's workloads
+# (token automounting off by default — defense in depth), a least-privilege
+# Role, and the binding. A starting template; widen the Role per component
+# as the workloads in the namespace actually require.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: namespace-baseline
+  namespace: confighubplaceholder
+  labels:
+    app.kubernetes.io/managed-by: confighub-namespace-manager
+automountServiceAccountToken: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: namespace-baseline
+  namespace: confighubplaceholder
+  labels:
+    app.kubernetes.io/managed-by: confighub-namespace-manager
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-baseline
+  namespace: confighubplaceholder
+  labels:
+    app.kubernetes.io/managed-by: confighub-namespace-manager
+subjects:
+  - kind: ServiceAccount
+    name: namespace-baseline
+    namespace: confighubplaceholder
+roleRef:
+  kind: Role
+  name: namespace-baseline
+  apiGroup: rbac.authorization.k8s.io

--- a/packages/namespace-envelope/installer.yaml
+++ b/packages/namespace-envelope/installer.yaml
@@ -1,0 +1,51 @@
+apiVersion: installer.confighub.com/v1alpha1
+kind: Package
+metadata:
+  name: namespace-envelope
+installerMetadata:
+  version: 0.1.0
+spec:
+  bases:
+    - name: default
+      path: bases/default
+      default: true
+      description: |
+        The namespace policy envelope — a v1/Namespace, a default-deny
+        NetworkPolicy pair (deny-all ingress+egress plus an allow for
+        cluster DNS egress), and baseline RBAC (ServiceAccount + Role +
+        RoleBinding). The cloneable foundation a Namespace Manager stamps
+        out per component, then carries across every variant
+        (environment / region / cluster). Rendered with the namespace
+        set from `{{ .Namespace }}` and pod-security labels applied.
+
+  transformers:
+    # 1. Set the namespace on every namespaced resource. set-namespace
+    #    also renames the v1/Namespace object and rewrites RBAC
+    #    subjects[*].namespace for ServiceAccount subjects, so the whole
+    #    envelope is re-homed by this one invocation. The base ships
+    #    `confighubplaceholder` everywhere a namespace appears; this
+    #    replaces it (and vet-placeholders below guards an unrendered base).
+    - toolchain: Kubernetes/YAML
+      description: Set the namespace on every namespaced resource and on RBAC subjects.
+      invocations:
+        - name: set-namespace
+          args: ["{{ .Namespace }}"]
+
+    # 2. Pod-security labels on the Namespace (Pod Security Admission).
+    - toolchain: Kubernetes/YAML
+      whereResource: ConfigHub.ResourceType = 'v1/Namespace'
+      description: Apply pod-security labels to the Namespace.
+      invocations:
+        - name: set-pod-security-defaults
+
+  validators:
+    # vet-placeholders is the guard that keeps an unrendered base
+    # (namespace still `confighubplaceholder`) from deploying; the rest
+    # are the standard schema/format checks applied at the end of render.
+    - toolchain: Kubernetes/YAML
+      description: Default validators applied at the end of every render.
+      invocations:
+        - name: vet-placeholders
+        - name: vet-schemas
+        - name: vet-merge-keys
+        - name: vet-format


### PR DESCRIPTION
Adds a **namespace-envelope** installer Package — the cloneable namespace policy envelope.

## What
`packages/namespace-envelope/` with a `default` base:
- `namespace.yaml` — `v1/Namespace` (placeholder name + managed-by marker)
- `default-deny.yaml` — default-deny-all + allow-DNS-egress NetworkPolicy pair
- `rbac.yaml` — baseline ServiceAccount (token automounting off) + Role + RoleBinding

**Transformers**: `set-namespace "{{ .Namespace }}"` then `set-pod-security-defaults` (Namespace only).
**Validators**: `vet-placeholders`, `vet-schemas`, `vet-merge-keys`, `vet-format`.

## Why
It's the greenfield foundation for the `namespace-manager` example (confighub/examples): `installer new`/`upload` stamps it out per component/variant, and the manager backfills its members into existing Spaces.

## Validation
`installer package` bundles; `installer render` with `namespace: payments` produces 6 Units, renames the Namespace, rewrites the RBAC subject namespace, stamps PSA labels (enforce=baseline, warn=restricted), and passes `vet-placeholders`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)