### PR TITLE
Add optional rendered OCI output to setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Working:
   non-interactive. Prior-state re-entry from ConfigHub (via the
   persisted `installer-record` Unit) or local `out/spec/`,
   organization + server sanity-check against the active cub context.
+  `setup --output-oci` can also write the rendered non-secret objects
+  to a local OCI image layout or push them to a registry without a
+  ConfigHub account.
 - **Day-2 lifecycle.** `installer setup` and `installer upload`
   auto-detect first-install vs upgrade vs reconcile via the presence
   of prior spec files / `out/spec/upload.yaml`. Re-running `setup`

--- a/docs/consumer-guide.md
+++ b/docs/consumer-guide.md
@@ -118,6 +118,34 @@ ls out/manifests/
 # service-statusboard-statusboard.yaml
 ```
 
+You can also make an OCI artifact from those exact files without a
+ConfigHub account. A local path writes an OCI image layout:
+
+```bash
+installer setup \
+    --pull oci://ghcr.io/myorg/statusboard:0.1.0 \
+    --namespace statusboard \
+    --output-oci ./statusboard-rendered.oci
+```
+
+An OCI reference pushes the rendered artifact to a registry:
+
+```bash
+installer setup \
+    --pull oci://ghcr.io/myorg/statusboard:0.1.0 \
+    --namespace statusboard \
+    --output-oci oci://ghcr.io/myorg/statusboard-rendered:0.1.0
+```
+
+The OCI layer contains the non-secret Kubernetes files and a root
+`kustomization.yaml`, so Argo CD, Flux, or another OCI-aware tool can
+consume the same files you inspected. The OCI config records the source
+reference and digest, chosen base, namespace, input and function-chain
+digests, validator results, and the rendered object-set digest. Input
+values and files under `out/secrets/` are not published. After writing
+or pushing the artifact, the installer reads it back and compares the
+recorded object-set digest before reporting success.
+
 You can edit these files directly — the next `plan` / `upload` will
 diff your edits against ConfigHub. But editing rendered output is
 usually the wrong layer; prefer editing `out/spec/inputs.yaml` and
@@ -584,6 +612,8 @@ want to refresh ConfigHub from local state, re-run `installer upload
 | Read the package's surface | `installer doc <dir>` |
 | Install (interactive) | `installer setup --pull <ref> --namespace <ns>` |
 | Install (scripted) | `installer setup --pull <ref> --non-interactive --namespace <ns> --components default` |
+| Render to a local OCI layout | `installer setup --pull <ref> --namespace <ns> --output-oci ./rendered.oci` |
+| Render and push OCI | `installer setup --pull <ref> --namespace <ns> --output-oci oci://host/repo:tag` |
 | Re-render after editing inputs | `installer setup --non-interactive` |
 | Push to ConfigHub | `installer upload --space <slug>` |
 | Preview cub-side changes | `installer plan` |

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -56,9 +56,22 @@ func runFlow(ctx context.Context, opts flowOptions) error {
 	}
 
 	pkgDir := filepath.Join(absWork, "package")
-	if opts.pullRef != "" {
-		if _, err := ipkg.PullToWorkDir(ctx, opts.pullRef, absWork); err != nil {
-			return fmt.Errorf("pull %s: %w", opts.pullRef, err)
+	sourceReference := ""
+	sourceDigest := ""
+	pullRef := opts.pullRef
+	if opts.outputOCI != "" && strings.HasPrefix(opts.pullRef, "oci://") {
+		sourceReference = opts.pullRef
+		sourceDigest, err = ipkg.ResolveManifestDigest(ctx, opts.pullRef)
+		if err != nil {
+			return fmt.Errorf("resolve source package digest: %w", err)
+		}
+		if !strings.Contains(pullRef, "@") {
+			pullRef += "@" + sourceDigest
+		}
+	}
+	if pullRef != "" {
+		if _, err := ipkg.PullToWorkDir(ctx, pullRef, absWork); err != nil {
+			return fmt.Errorf("pull %s: %w", pullRef, err)
 		}
 	}
 	loaded, err := ipkg.Load(pkgDir)
@@ -129,14 +142,6 @@ func runFlow(ctx context.Context, opts flowOptions) error {
 	}
 
 	if opts.outputOCI != "" {
-		sourceDigest, err := ipkg.ResolveManifestDigest(ctx, opts.pullRef)
-		if err != nil {
-			return fmt.Errorf("resolve source package digest: %w", err)
-		}
-		sourceReference := ""
-		if strings.HasPrefix(opts.pullRef, "oci://") {
-			sourceReference = opts.pullRef
-		}
 		published, err := ipkg.PublishRenderedOCI(ctx, ipkg.RenderedOCIOptions{
 			WorkDir:         absWork,
 			Destination:     opts.outputOCI,

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -40,6 +40,7 @@ type flowOptions struct {
 	// Render controls.
 	runRender bool
 	clean     bool
+	outputOCI string
 }
 
 // runFlow is the shared body of `installer setup` and `installer wizard`.
@@ -125,6 +126,33 @@ func runFlow(ctx context.Context, opts flowOptions) error {
 
 	if err := runRenderInWorkDir(ctx, absWork, loaded, res, opts.clean); err != nil {
 		return err
+	}
+
+	if opts.outputOCI != "" {
+		sourceDigest, err := ipkg.ResolveManifestDigest(ctx, opts.pullRef)
+		if err != nil {
+			return fmt.Errorf("resolve source package digest: %w", err)
+		}
+		sourceReference := ""
+		if strings.HasPrefix(opts.pullRef, "oci://") {
+			sourceReference = opts.pullRef
+		}
+		published, err := ipkg.PublishRenderedOCI(ctx, ipkg.RenderedOCIOptions{
+			WorkDir:         absWork,
+			Destination:     opts.outputOCI,
+			SourceReference: sourceReference,
+			SourceDigest:    sourceDigest,
+			Package:         loaded.Package,
+			Selection:       res.Selection,
+			Inputs:          res.Inputs,
+		})
+		if err != nil {
+			return fmt.Errorf("write rendered OCI: %w", err)
+		}
+		fmt.Printf("Wrote rendered OCI %s\n", published.Ref)
+		fmt.Printf("  manifest:  %s\n", published.ManifestDigest)
+		fmt.Printf("  objects:   %s (%d manifest files)\n", published.ObjectSetDigest, published.ManifestCount)
+		fmt.Printf("  pull-back: verified\n")
 	}
 
 	fmt.Printf("Next: %s upload --work-dir %s --space <slug>\n", InvocationName(), absWork)
@@ -423,6 +451,14 @@ Working directory:
                      <work-dir>/package/; spec docs to <work-dir>/out/spec/;
                      manifests to <work-dir>/out/manifests/.
 
+Rendered OCI output:
+  --output-oci <dest> optional. After a successful render, write those exact
+                      non-secret manifests as an OCI artifact. Use a local
+                      path for an OCI image layout, or oci://host/repo:tag to
+                      push to a registry. The command reads the artifact back
+                      and compares its recorded object-set digest before
+                      reporting success.
+
 Pull:
   --pull <ref>       optional. When present, fetches the package and
                      replaces <work-dir>/package/ atomically (failed
@@ -467,5 +503,6 @@ Setup does NOT upload. Run installer upload to push to ConfigHub.`,
 	cmd.Flags().StringVar(&opts.preset, "components", "", "component preset: minimal | default | all | selected. Mutually exclusive with --select.")
 	cmd.Flags().StringSliceVar(&opts.setImage, "set-image", nil, "image override as name=ref (repeatable); applied via `kustomize edit set image` against the chosen base before render. The base's kustomization.yaml must declare an `images:` block.")
 	cmd.Flags().BoolVar(&opts.clean, "clean", false, "remove previously rendered out/manifests/ (preserving any kpt Kptfile) and out/secrets/ before rendering")
+	cmd.Flags().StringVar(&opts.outputOCI, "output-oci", "", "write rendered manifests to a local OCI layout path or push them to oci://host/repo:tag")
 	return cmd
 }

--- a/internal/pkg/rendered_oci.go
+++ b/internal/pkg/rendered_oci.go
@@ -1,0 +1,581 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package pkg
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content/memory"
+	"oras.land/oras-go/v2/content/oci"
+
+	"github.com/confighub/installer/internal/version"
+	"github.com/confighub/installer/pkg/api"
+)
+
+// RenderedOCIOptions describes a rendered artifact produced by setup.
+type RenderedOCIOptions struct {
+	WorkDir         string
+	Destination     string
+	SourceReference string
+	SourceDigest    string
+	Package         *api.Package
+	Selection       *api.Selection
+	Inputs          *api.Inputs
+}
+
+// RenderedOCIResult describes a verified local write or registry push.
+type RenderedOCIResult struct {
+	Ref             string
+	ManifestDigest  string
+	LayerDigest     string
+	ObjectSetDigest string
+	LayerSize       int64
+	ManifestCount   int
+	Files           []string
+	Verified        bool
+}
+
+type renderedFile struct {
+	path string
+	body []byte
+}
+
+// PublishRenderedOCI writes the non-secret rendered manifests as an OCI
+// artifact. An oci:// destination is pushed to a registry. Any other
+// destination is written as a local OCI image layout tagged "latest".
+func PublishRenderedOCI(ctx context.Context, opts RenderedOCIOptions) (*RenderedOCIResult, error) {
+	if opts.WorkDir == "" {
+		return nil, fmt.Errorf("rendered OCI: work-dir is required")
+	}
+	if opts.Destination == "" {
+		return nil, fmt.Errorf("rendered OCI: destination is required")
+	}
+	if opts.Package == nil || opts.Selection == nil || opts.Inputs == nil {
+		return nil, fmt.Errorf("rendered OCI: package, selection, and inputs are required")
+	}
+
+	var (
+		target oras.Target
+		tag    string
+		ref    string
+	)
+	if strings.HasPrefix(opts.Destination, "oci://") {
+		repoRef, parsedTag, _, err := parseRef(opts.Destination, true)
+		if err != nil {
+			return nil, err
+		}
+		repo, err := newRepo(repoRef)
+		if err != nil {
+			return nil, err
+		}
+		target = repo
+		tag = parsedTag
+		ref = "oci://" + repoRef + ":" + tag
+	} else {
+		layoutPath, err := filepath.Abs(opts.Destination)
+		if err != nil {
+			return nil, err
+		}
+		store, err := oci.New(layoutPath)
+		if err != nil {
+			return nil, fmt.Errorf("create OCI layout %s: %w", layoutPath, err)
+		}
+		target = store
+		tag = "latest"
+		ref = layoutPath + ":latest"
+	}
+
+	result, err := stageAndCopyRendered(ctx, opts, tag, target)
+	if err != nil {
+		return nil, err
+	}
+	result.Ref = ref
+	return result, nil
+}
+
+// ResolveManifestDigest resolves an OCI reference without pulling its layers.
+func ResolveManifestDigest(ctx context.Context, ref string) (string, error) {
+	if !strings.HasPrefix(ref, "oci://") {
+		return "", nil
+	}
+	repoRef, tag, want, err := parseRef(ref, false)
+	if err != nil {
+		return "", err
+	}
+	repo, err := newRepo(repoRef)
+	if err != nil {
+		return "", err
+	}
+	resolveRef := tag
+	if resolveRef == "" {
+		resolveRef = want.String()
+	}
+	desc, err := repo.Resolve(ctx, resolveRef)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s: %w", ref, err)
+	}
+	if want != "" && desc.Digest != want {
+		return "", fmt.Errorf("digest mismatch on %s: pinned %s but registry returned %s", ref, want, desc.Digest)
+	}
+	return desc.Digest.String(), nil
+}
+
+func stageAndCopyRendered(ctx context.Context, opts RenderedOCIOptions, tag string, dst oras.Target) (*RenderedOCIResult, error) {
+	manifestFiles, err := collectRenderedFiles(opts.WorkDir)
+	if err != nil {
+		return nil, err
+	}
+	layerFiles := append([]renderedFile{{
+		path: "kustomization.yaml",
+		body: renderedKustomization(manifestFiles),
+	}}, manifestFiles...)
+	layerData, err := renderedTarGz(layerFiles)
+	if err != nil {
+		return nil, err
+	}
+	layerDigest := digest.FromBytes(layerData)
+	layerDesc := ocispec.Descriptor{
+		MediaType: api.RenderedLayerMediaType,
+		Digest:    layerDigest,
+		Size:      int64(len(layerData)),
+		Annotations: map[string]string{
+			ocispec.AnnotationTitle: api.RenderedLayerTitle,
+		},
+	}
+	objectSetDigest := renderedObjectSetDigest(manifestFiles)
+
+	config, err := renderedConfig(opts, manifestFiles, layerFiles, layerDigest.String(), int64(len(layerData)), objectSetDigest)
+	if err != nil {
+		return nil, err
+	}
+	configData, err := json.Marshal(config)
+	if err != nil {
+		return nil, err
+	}
+	configDesc := ocispec.Descriptor{
+		MediaType: api.RenderedConfigMediaType,
+		Digest:    digest.FromBytes(configData),
+		Size:      int64(len(configData)),
+	}
+
+	staging := memory.New()
+	if err := staging.Push(ctx, layerDesc, bytes.NewReader(layerData)); err != nil {
+		return nil, fmt.Errorf("stage rendered layer: %w", err)
+	}
+	if err := staging.Push(ctx, configDesc, bytes.NewReader(configData)); err != nil {
+		return nil, fmt.Errorf("stage rendered config: %w", err)
+	}
+	annotations := map[string]string{
+		ocispec.AnnotationCreated:      "1970-01-01T00:00:00Z",
+		ocispec.AnnotationTitle:        opts.Package.Metadata.Name,
+		api.AnnotationName:             opts.Package.Metadata.Name,
+		api.AnnotationVersion:          opts.Package.InstallerMetadata.Version,
+		api.AnnotationInstallerVersion: version.Version,
+		api.AnnotationBase:             opts.Selection.Spec.Base,
+		api.AnnotationObjectSetDigest:  objectSetDigest,
+	}
+	if opts.SourceReference != "" {
+		annotations[api.AnnotationSourceReference] = opts.SourceReference
+	}
+	if opts.SourceDigest != "" {
+		annotations[api.AnnotationSourceDigest] = opts.SourceDigest
+	}
+	manifestDesc, err := oras.PackManifest(ctx, staging, oras.PackManifestVersion1_1, api.RenderedArtifactType, oras.PackManifestOptions{
+		Layers:              []ocispec.Descriptor{layerDesc},
+		ConfigDescriptor:    &configDesc,
+		ManifestAnnotations: annotations,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("pack rendered manifest: %w", err)
+	}
+	if err := staging.Tag(ctx, manifestDesc, tag); err != nil {
+		return nil, err
+	}
+	if _, err := oras.Copy(ctx, staging, tag, dst, tag, oras.DefaultCopyOptions); err != nil {
+		return nil, fmt.Errorf("copy rendered OCI: %w", err)
+	}
+
+	verified, err := inspectRenderedFromTarget(ctx, dst, tag)
+	if err != nil {
+		return nil, fmt.Errorf("verify rendered OCI: %w", err)
+	}
+	if verified.manifestDigest != manifestDesc.Digest.String() {
+		return nil, fmt.Errorf("verify rendered OCI: manifest digest changed: wrote %s, read %s", manifestDesc.Digest, verified.manifestDigest)
+	}
+	if verified.objectSetDigest != objectSetDigest {
+		return nil, fmt.Errorf("verify rendered OCI: object-set digest changed: wrote %s, read %s", objectSetDigest, verified.objectSetDigest)
+	}
+
+	files := make([]string, 0, len(layerFiles))
+	for _, file := range layerFiles {
+		files = append(files, file.path)
+	}
+	return &RenderedOCIResult{
+		ManifestDigest:  manifestDesc.Digest.String(),
+		LayerDigest:     layerDigest.String(),
+		ObjectSetDigest: objectSetDigest,
+		LayerSize:       int64(len(layerData)),
+		ManifestCount:   len(manifestFiles),
+		Files:           files,
+		Verified:        true,
+	}, nil
+}
+
+func collectRenderedFiles(workDir string) ([]renderedFile, error) {
+	outDir := filepath.Join(workDir, "out")
+	var manifestDirs []string
+	root := filepath.Join(outDir, "manifests")
+	if info, err := os.Stat(root); err == nil && info.IsDir() {
+		manifestDirs = append(manifestDirs, root)
+	}
+	entries, err := os.ReadDir(outDir)
+	if err != nil {
+		return nil, fmt.Errorf("read rendered output %s: %w", outDir, err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Name() == "manifests" || entry.Name() == "vendor" {
+			continue
+		}
+		dir := filepath.Join(outDir, entry.Name(), "manifests")
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			manifestDirs = append(manifestDirs, dir)
+		}
+	}
+	sort.Strings(manifestDirs)
+
+	var files []renderedFile
+	for _, dir := range manifestDirs {
+		err := filepath.Walk(dir, func(path string, info os.FileInfo, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if info.IsDir() {
+				return nil
+			}
+			if !info.Mode().IsRegular() {
+				return fmt.Errorf("rendered OCI: non-regular manifest file %s", path)
+			}
+			ext := strings.ToLower(filepath.Ext(info.Name()))
+			if ext != ".yaml" && ext != ".yml" {
+				return nil
+			}
+			rel, err := filepath.Rel(outDir, path)
+			if err != nil {
+				return err
+			}
+			body, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			files = append(files, renderedFile{path: filepath.ToSlash(rel), body: body})
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].path < files[j].path })
+	if len(files) == 0 {
+		return nil, fmt.Errorf("rendered OCI: no YAML manifests found under %s", outDir)
+	}
+	return files, nil
+}
+
+func renderedConfig(
+	opts RenderedOCIOptions,
+	manifestFiles []renderedFile,
+	layerFiles []renderedFile,
+	layerDigest string,
+	layerSize int64,
+	objectSetDigest string,
+) (*api.RenderedConfigBlob, error) {
+	selectionDigest, err := sha256Path(filepath.Join(opts.WorkDir, "out", "spec", "selection.yaml"))
+	if err != nil {
+		return nil, err
+	}
+	inputsDigest, err := sha256Path(filepath.Join(opts.WorkDir, "out", "spec", "inputs.yaml"))
+	if err != nil {
+		return nil, err
+	}
+	chainDigest, err := sha256Path(filepath.Join(opts.WorkDir, "out", "spec", "function-chain.yaml"))
+	if err != nil {
+		return nil, err
+	}
+	checks := []api.RenderedCheck{{Name: "render", Result: "passed"}}
+	for _, name := range selectedValidatorNames(opts.Package, opts.Selection) {
+		checks = append(checks, api.RenderedCheck{Name: name, Result: "passed"})
+	}
+	files := make([]string, 0, len(layerFiles))
+	for _, file := range layerFiles {
+		files = append(files, file.path)
+	}
+	return &api.RenderedConfigBlob{
+		SchemaVersion:    "v1",
+		InstallerVersion: version.Version,
+		Source: api.RenderedSource{
+			Reference:      opts.SourceReference,
+			ManifestDigest: opts.SourceDigest,
+			Package:        opts.Package.Metadata.Name,
+			PackageVersion: opts.Package.InstallerMetadata.Version,
+		},
+		Render: api.RenderedContext{
+			Base:                opts.Selection.Spec.Base,
+			Components:          append([]string(nil), opts.Selection.Spec.Components...),
+			Namespace:           opts.Inputs.Spec.Namespace,
+			SelectionSHA256:     selectionDigest,
+			InputsSHA256:        inputsDigest,
+			FunctionChainSHA256: chainDigest,
+		},
+		Checks: checks,
+		Output: api.RenderedBundleInfo{
+			ManifestCount:   len(manifestFiles),
+			ObjectSetDigest: objectSetDigest,
+			LayerDigest:     layerDigest,
+			LayerSize:       layerSize,
+			Files:           files,
+		},
+	}, nil
+}
+
+func selectedValidatorNames(pkg *api.Package, selection *api.Selection) []string {
+	selected := make(map[string]bool, len(selection.Spec.Components))
+	for _, name := range selection.Spec.Components {
+		selected[name] = true
+	}
+	var names []string
+	appendGroups := func(groups []api.FunctionGroup) {
+		for _, group := range groups {
+			for _, invocation := range group.Invocations {
+				names = append(names, invocation.Name)
+			}
+		}
+	}
+	appendGroups(pkg.Spec.Validators)
+	for _, component := range pkg.Spec.Components {
+		if selected[component.Name] {
+			appendGroups(component.Validators)
+		}
+	}
+	return names
+}
+
+func renderedKustomization(files []renderedFile) []byte {
+	var b strings.Builder
+	b.WriteString("apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n")
+	for _, file := range files {
+		fmt.Fprintf(&b, "  - %s\n", file.path)
+	}
+	return []byte(b.String())
+}
+
+func renderedObjectSetDigest(files []renderedFile) string {
+	h := sha256.New()
+	for _, file := range files {
+		h.Write([]byte(file.path))
+		h.Write([]byte{0})
+		h.Write(file.body)
+		h.Write([]byte{0})
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil))
+}
+
+func sha256Path(path string) (string, error) {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("hash %s: %w", path, err)
+	}
+	sum := sha256.Sum256(body)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func renderedTarGz(files []renderedFile) ([]byte, error) {
+	var buf bytes.Buffer
+	gw, err := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+	if err != nil {
+		return nil, err
+	}
+	gw.Name = ""
+	gw.Comment = ""
+	gw.ModTime = time.Time{}
+	gw.OS = 255
+	tw := tar.NewWriter(gw)
+	for _, file := range files {
+		header := &tar.Header{
+			Name:     file.path,
+			Mode:     0o644,
+			Size:     int64(len(file.body)),
+			Typeflag: tar.TypeReg,
+			ModTime:  time.Time{},
+			Uid:      0,
+			Gid:      0,
+			Format:   tar.FormatPAX,
+		}
+		if err := tw.WriteHeader(header); err != nil {
+			return nil, err
+		}
+		if _, err := tw.Write(file.body); err != nil {
+			return nil, err
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	if err := gw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+type renderedInspection struct {
+	manifestDigest  string
+	objectSetDigest string
+	config          api.RenderedConfigBlob
+}
+
+func inspectRenderedFromTarget(ctx context.Context, target oras.Target, ref string) (*renderedInspection, error) {
+	desc, err := target.Resolve(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	manifestReader, err := target.Fetch(ctx, desc)
+	if err != nil {
+		return nil, err
+	}
+	defer manifestReader.Close()
+	manifestData, err := io.ReadAll(manifestReader)
+	if err != nil {
+		return nil, err
+	}
+	var manifest ocispec.Manifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		return nil, err
+	}
+	if manifest.ArtifactType != api.RenderedArtifactType {
+		return nil, fmt.Errorf("unexpected rendered artifact type %q", manifest.ArtifactType)
+	}
+	if len(manifest.Layers) != 1 || manifest.Layers[0].MediaType != api.RenderedLayerMediaType {
+		return nil, fmt.Errorf("rendered OCI must contain one %s layer", api.RenderedLayerMediaType)
+	}
+	layerReader, err := target.Fetch(ctx, manifest.Layers[0])
+	if err != nil {
+		return nil, err
+	}
+	defer layerReader.Close()
+	layerData, err := io.ReadAll(layerReader)
+	if err != nil {
+		return nil, err
+	}
+	if actual := digest.FromBytes(layerData); actual != manifest.Layers[0].Digest {
+		return nil, fmt.Errorf("rendered layer digest mismatch: manifest says %s, fetched %s", manifest.Layers[0].Digest, actual)
+	}
+	layerFiles, err := renderedFilesFromTarGz(layerData)
+	if err != nil {
+		return nil, err
+	}
+	var manifestFiles []renderedFile
+	for _, file := range layerFiles {
+		if file.path != "kustomization.yaml" {
+			manifestFiles = append(manifestFiles, file)
+		}
+	}
+	objectSetDigest := renderedObjectSetDigest(manifestFiles)
+
+	configReader, err := target.Fetch(ctx, manifest.Config)
+	if err != nil {
+		return nil, err
+	}
+	defer configReader.Close()
+	configData, err := io.ReadAll(configReader)
+	if err != nil {
+		return nil, err
+	}
+	var config api.RenderedConfigBlob
+	if err := json.Unmarshal(configData, &config); err != nil {
+		return nil, err
+	}
+	if config.Output.LayerDigest != manifest.Layers[0].Digest.String() {
+		return nil, fmt.Errorf("rendered layer digest metadata mismatch: config says %s, manifest says %s", config.Output.LayerDigest, manifest.Layers[0].Digest)
+	}
+	if config.Output.LayerSize != manifest.Layers[0].Size {
+		return nil, fmt.Errorf("rendered layer size metadata mismatch: config says %d, manifest says %d", config.Output.LayerSize, manifest.Layers[0].Size)
+	}
+	if config.Output.ManifestCount != len(manifestFiles) {
+		return nil, fmt.Errorf("rendered manifest count mismatch: config says %d, layer contains %d", config.Output.ManifestCount, len(manifestFiles))
+	}
+	actualFiles := make([]string, 0, len(layerFiles))
+	for _, file := range layerFiles {
+		actualFiles = append(actualFiles, file.path)
+	}
+	if !sameRenderedPaths(config.Output.Files, actualFiles) {
+		return nil, fmt.Errorf("rendered file list mismatch: config says %v, layer contains %v", config.Output.Files, actualFiles)
+	}
+	if config.Output.ObjectSetDigest != objectSetDigest {
+		return nil, fmt.Errorf("rendered object-set digest mismatch: config says %s, layer contains %s", config.Output.ObjectSetDigest, objectSetDigest)
+	}
+	return &renderedInspection{
+		manifestDigest:  desc.Digest.String(),
+		objectSetDigest: objectSetDigest,
+		config:          config,
+	}, nil
+}
+
+func renderedFilesFromTarGz(body []byte) ([]renderedFile, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	var files []renderedFile
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		clean := filepath.ToSlash(filepath.Clean(header.Name))
+		if clean == "." || strings.HasPrefix(clean, "../") || filepath.IsAbs(header.Name) {
+			return nil, fmt.Errorf("rendered OCI contains unsafe path %q", header.Name)
+		}
+		if header.Typeflag != tar.TypeReg {
+			return nil, fmt.Errorf("rendered OCI contains non-regular entry %q", header.Name)
+		}
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, renderedFile{path: clean, body: data})
+	}
+	return files, nil
+}
+
+func sameRenderedPaths(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/pkg/rendered_oci_test.go
+++ b/internal/pkg/rendered_oci_test.go
@@ -1,0 +1,150 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package pkg
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"oras.land/oras-go/v2/content/memory"
+
+	"github.com/confighub/installer/pkg/api"
+)
+
+func TestStageRenderedOCIRoundTrip(t *testing.T) {
+	opts := testRenderedOCIOptions(t)
+	ctx := context.Background()
+	target := memory.New()
+
+	result, err := stageAndCopyRendered(ctx, opts, "v1", target)
+	if err != nil {
+		t.Fatalf("stageAndCopyRendered: %v", err)
+	}
+	if !result.Verified {
+		t.Fatal("rendered OCI was not verified after write")
+	}
+	if result.ManifestCount != 2 {
+		t.Fatalf("manifest count: got %d want 2", result.ManifestCount)
+	}
+	wantFiles := []string{
+		"kustomization.yaml",
+		"dependency/manifests/service.yaml",
+		"manifests/deployment.yaml",
+	}
+	if !slices.Equal(result.Files, wantFiles) {
+		t.Fatalf("files: got %v want %v", result.Files, wantFiles)
+	}
+	for _, file := range result.Files {
+		if strings.Contains(file, "secret") {
+			t.Fatalf("rendered Secret leaked into OCI layer: %s", file)
+		}
+	}
+
+	inspection, err := inspectRenderedFromTarget(ctx, target, "v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := inspection.config
+	if config.Source.Reference != opts.SourceReference || config.Source.ManifestDigest != opts.SourceDigest {
+		t.Fatalf("source provenance mismatch: %+v", config.Source)
+	}
+	if config.Render.Base != "default" || config.Render.Namespace != "demo" {
+		t.Fatalf("render context mismatch: %+v", config.Render)
+	}
+	if len(config.Checks) != 2 || config.Checks[0].Name != "render" || config.Checks[1].Name != "vet-schemas" {
+		t.Fatalf("checks mismatch: %+v", config.Checks)
+	}
+	if config.Output.ObjectSetDigest != result.ObjectSetDigest {
+		t.Fatalf("object-set digest mismatch: config=%s result=%s", config.Output.ObjectSetDigest, result.ObjectSetDigest)
+	}
+}
+
+func TestStageRenderedOCIIsDeterministic(t *testing.T) {
+	opts := testRenderedOCIOptions(t)
+	ctx := context.Background()
+	first, err := stageAndCopyRendered(ctx, opts, "v1", memory.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := stageAndCopyRendered(ctx, opts, "v1", memory.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.ManifestDigest != second.ManifestDigest {
+		t.Fatalf("manifest digest is not deterministic: %s vs %s", first.ManifestDigest, second.ManifestDigest)
+	}
+	if first.ObjectSetDigest != second.ObjectSetDigest {
+		t.Fatalf("object-set digest is not deterministic: %s vs %s", first.ObjectSetDigest, second.ObjectSetDigest)
+	}
+}
+
+func TestPublishRenderedOCILocalLayout(t *testing.T) {
+	opts := testRenderedOCIOptions(t)
+	opts.Destination = filepath.Join(t.TempDir(), "rendered.oci")
+
+	result, err := PublishRenderedOCI(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Verified {
+		t.Fatal("local OCI layout did not pass pull-back verification")
+	}
+	for _, name := range []string{"oci-layout", "index.json"} {
+		if _, err := os.Stat(filepath.Join(opts.Destination, name)); err != nil {
+			t.Fatalf("local OCI layout missing %s: %v", name, err)
+		}
+	}
+}
+
+func testRenderedOCIOptions(t *testing.T) RenderedOCIOptions {
+	t.Helper()
+	workDir := t.TempDir()
+	writeTestFile := func(rel, body string, mode os.FileMode) {
+		t.Helper()
+		path := filepath.Join(workDir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(body), mode); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeTestFile("out/manifests/deployment.yaml", "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: app\n", 0o644)
+	writeTestFile("out/dependency/manifests/service.yaml", "apiVersion: v1\nkind: Service\nmetadata:\n  name: dependency\n", 0o644)
+	writeTestFile("out/secrets/secret.yaml", "apiVersion: v1\nkind: Secret\nmetadata:\n  name: private\n", 0o600)
+	writeTestFile("out/spec/selection.yaml", "kind: Selection\nspec:\n  base: default\n", 0o644)
+	writeTestFile("out/spec/inputs.yaml", "kind: Inputs\nspec:\n  namespace: demo\n  values:\n    token: do-not-publish\n", 0o644)
+	writeTestFile("out/spec/function-chain.yaml", "kind: FunctionChain\nspec:\n  groups: []\n", 0o644)
+
+	return RenderedOCIOptions{
+		WorkDir:         workDir,
+		Destination:     filepath.Join(t.TempDir(), "unused"),
+		SourceReference: "oci://registry.example/test/demo:1.2.3",
+		SourceDigest:    "sha256:" + strings.Repeat("a", 64),
+		Package: &api.Package{
+			Metadata:          api.Metadata{Name: "demo"},
+			InstallerMetadata: api.InstallerMetadata{Version: "1.2.3"},
+			Spec: api.PackageSpec{
+				Validators: []api.FunctionGroup{{
+					Toolchain: "Kubernetes/YAML",
+					Invocations: []api.FunctionInvocation{{
+						Name: "vet-schemas",
+					}},
+				}},
+			},
+		},
+		Selection: &api.Selection{Spec: api.SelectionSpec{
+			Base:       "default",
+			Components: []string{"dependency"},
+		}},
+		Inputs: &api.Inputs{Spec: api.InputsSpec{
+			Namespace: "demo",
+			Values:    map[string]any{"token": "do-not-publish"},
+		}},
+	}
+}

--- a/pkg/api/rendered_oci.go
+++ b/pkg/api/rendered_oci.go
@@ -1,0 +1,64 @@
+// Copyright (C) ConfigHub, Inc.
+// SPDX-License-Identifier: MIT
+
+package api
+
+// Media types for OCI artifacts containing rendered Kubernetes objects.
+//
+// The layer uses the standard OCI image-layer media type so Argo CD, Flux,
+// ORAS, and other OCI consumers can unpack it without installer-specific
+// support. Installer provenance and check results live in the config blob,
+// outside the Kubernetes files consumed by delivery controllers.
+const (
+	RenderedArtifactType    = "application/vnd.confighub.installer.rendered.v1+json"
+	RenderedConfigMediaType = "application/vnd.confighub.installer.rendered.config.v1+json"
+	RenderedLayerMediaType  = "application/vnd.oci.image.layer.v1.tar+gzip"
+	RenderedLayerTitle      = "rendered-manifests.tar.gz"
+)
+
+const (
+	AnnotationSourceReference = "installer.confighub.com/source-reference"
+	AnnotationSourceDigest    = "installer.confighub.com/source-digest"
+	AnnotationBase            = "installer.confighub.com/base"
+	AnnotationObjectSetDigest = "installer.confighub.com/object-set-digest"
+)
+
+// RenderedConfigBlob records how a rendered OCI artifact was produced without
+// embedding input values or rendered Secrets in registry metadata.
+type RenderedConfigBlob struct {
+	SchemaVersion    string             `json:"schemaVersion"`
+	InstallerVersion string             `json:"installerVersion,omitempty"`
+	Source           RenderedSource     `json:"source"`
+	Render           RenderedContext    `json:"render"`
+	Checks           []RenderedCheck    `json:"checks,omitempty"`
+	Output           RenderedBundleInfo `json:"output"`
+}
+
+type RenderedSource struct {
+	Reference      string `json:"reference,omitempty"`
+	ManifestDigest string `json:"manifestDigest,omitempty"`
+	Package        string `json:"package"`
+	PackageVersion string `json:"packageVersion,omitempty"`
+}
+
+type RenderedContext struct {
+	Base                string   `json:"base"`
+	Components          []string `json:"components,omitempty"`
+	Namespace           string   `json:"namespace,omitempty"`
+	SelectionSHA256     string   `json:"selectionSHA256"`
+	InputsSHA256        string   `json:"inputsSHA256"`
+	FunctionChainSHA256 string   `json:"functionChainSHA256"`
+}
+
+type RenderedCheck struct {
+	Name   string `json:"name"`
+	Result string `json:"result"`
+}
+
+type RenderedBundleInfo struct {
+	ManifestCount   int      `json:"manifestCount"`
+	ObjectSetDigest string   `json:"objectSetDigest"`
+	LayerDigest     string   `json:"layerDigest"`
+	LayerSize       int64    `json:"layerSize"`
+	Files           []string `json:"files"`
+}

--- a/test/e2e/setup-flow.sh
+++ b/test/e2e/setup-flow.sh
@@ -75,7 +75,8 @@ with open(p, 'w') as f: yaml.safe_dump(d, f, sort_keys=False)
 WORK_TMP=$(mktemp -d -t setup-flow-wd.XXXXXX)
 log "setup --pull (v1) — first install"
 "$BIN" setup --pull "$PKG_V1" --work-dir "$WORK_TMP" \
-  --non-interactive --namespace setup-test --select monitoring 2>&1 \
+  --non-interactive --namespace setup-test --select monitoring \
+  --output-oci "$WORK_TMP/rendered.oci" 2>&1 \
   | tee "$WORK_TMP/setup-v1.out"
 
 [[ -d "$WORK_TMP/package" ]] || fail "expected $WORK_TMP/package/ after setup --pull"
@@ -84,6 +85,10 @@ log "setup --pull (v1) — first install"
 [[ -d "$WORK_TMP/out/manifests" ]] || fail "expected out/manifests/"
 [[ ! -d "$WORK_TMP/.upgrade" ]] || fail "setup should NOT create .upgrade/ (atomic pull)"
 [[ ! -d "$WORK_TMP/.upgrade-prev" ]] || fail "setup should NOT create .upgrade-prev/"
+[[ -f "$WORK_TMP/rendered.oci/oci-layout" ]] || fail "expected local rendered OCI layout"
+[[ -f "$WORK_TMP/rendered.oci/index.json" ]] || fail "expected rendered OCI index"
+grep -q "pull-back: verified" "$WORK_TMP/setup-v1.out" \
+  || fail "setup should verify the rendered OCI after writing it"
 
 if ! grep -q "Loaded prior install state" "$WORK_TMP/setup-v1.out"; then
   : # fresh install — no prior state expected


### PR DESCRIPTION
## What this adds

`installer setup --output-oci <destination>` now writes the exact non-secret manifests produced by setup as an OCI artifact.

- A filesystem destination writes a local OCI image layout tagged `latest`.
- An `oci://host/repo:tag` destination pushes directly to a registry.
- The layer uses the standard OCI gzip layer media type and includes a root `kustomization.yaml` plus the rendered Kubernetes files.
- For an OCI input, setup resolves the source digest first and pins the pull to it, so a moving tag cannot make the recorded provenance disagree with what was rendered.
- The OCI config records the source package ref/digest, chosen base/components/namespace, safe document digests, validator results, and exact object-set digest.
- `out/secrets/` and raw input values are not published.
- Setup fetches the written layer back, recomputes the object-set digest from its YAML bytes, and refuses to report success if it differs.

This makes the no-ConfigHub path self-contained: installer package in, local review/checks, rendered OCI out. It does not upload to ConfigHub or apply to a cluster.

## Example

```sh
cub installer setup \
  --pull oci://europe-west1-docker.pkg.dev/nth-fort-499605-q5/helm-expt/bitnami-redis:25.5.3 \
  --base reuse-existing-secret \
  --namespace redis \
  --non-interactive \
  --output-oci oci://registry.example/team/redis-rendered:25.5.3
```

## Verification

- `go test ./...`
- `go vet ./...`
- `bash test/e2e/setup-flow.sh`
- Built and installed a working local `cub installer` plugin binary.
- Pushed a 14-manifest Redis artifact to Google Artifact Registry from a digest-pinned source pull.
- The command fetched its layer back and recomputed the object-set digest before reporting `pull-back: verified`.
- Fetched the published manifest anonymously; it exposes `application/vnd.oci.image.layer.v1.tar+gzip`.
- Pulled and extracted the layer, then successfully ran `kustomize build` over its generated root kustomization.

An actual Argo CD and Flux reconciliation of this new artifact is intentionally left as the next live proof; this PR does not claim that controller receipt yet.
