### PR TITLE
Read legacy installer package versions

### DIFF
--- a/pkg/api/parse.go
+++ b/pkg/api/parse.go
@@ -28,6 +28,20 @@ func ParsePackage(data []byte) (*Package, error) {
 	if err := yaml.Unmarshal(data, &p); err != nil {
 		return nil, fmt.Errorf("parse Package: %w", err)
 	}
+	// Packages published before installerMetadata was introduced stored the
+	// package version under metadata.version. Continue to read that field so
+	// package identity and rendered OCI provenance remain complete.
+	if p.InstallerMetadata.Version == "" {
+		var legacy struct {
+			Metadata struct {
+				Version string `yaml:"version"`
+			} `yaml:"metadata"`
+		}
+		if err := yaml.Unmarshal(data, &legacy); err != nil {
+			return nil, fmt.Errorf("parse legacy Package metadata: %w", err)
+		}
+		p.InstallerMetadata.Version = legacy.Metadata.Version
+	}
 	if p.APIVersion == "" {
 		p.APIVersion = APIVersion
 	}

--- a/pkg/api/parse_test.go
+++ b/pkg/api/parse_test.go
@@ -47,6 +47,9 @@ func TestParsePackage(t *testing.T) {
 	if p.Metadata.Name != "test" {
 		t.Errorf("name = %q, want test", p.Metadata.Name)
 	}
+	if p.InstallerMetadata.Version != "1.0.0" {
+		t.Errorf("legacy metadata.version = %q, want 1.0.0", p.InstallerMetadata.Version)
+	}
 	if len(p.Spec.Bases) != 1 || p.Spec.Bases[0].Name != "default" {
 		t.Errorf("bases mismatch: %+v", p.Spec.Bases)
 	}
@@ -59,6 +62,22 @@ func TestParsePackage(t *testing.T) {
 	if len(p.Spec.Transformers) != 1 ||
 		p.Spec.Transformers[0].Toolchain != "Kubernetes/YAML" {
 		t.Errorf("function chain mismatch: %+v", p.Spec.Transformers)
+	}
+}
+
+func TestParsePackageCanonicalVersionWinsOverLegacyVersion(t *testing.T) {
+	withBoth := strings.Replace(
+		validPackage,
+		"spec:\n",
+		"installerMetadata:\n  version: 2.0.0\nspec:\n",
+		1,
+	)
+	p, err := api.ParsePackage([]byte(withBoth))
+	if err != nil {
+		t.Fatalf("ParsePackage: %v", err)
+	}
+	if p.InstallerMetadata.Version != "2.0.0" {
+		t.Errorf("version = %q, want canonical 2.0.0", p.InstallerMetadata.Version)
 	}
 }
 


### PR DESCRIPTION
## Summary
- accept existing packages that store their version under `metadata.version`
- keep `installerMetadata.version` canonical and authoritative when both fields exist
- preserve complete package identity and rendered OCI provenance for the published helm-expt catalog

## Verification
- `go test ./...`
- actual Calico package bundles as `projectcalico-tigera-operator@v3.32.0` with its expected deterministic digest
- `git diff --check`