### PR TITLE
Document the canonical installer package version field

### DIFF
--- a/docs/author-tutorial.md
+++ b/docs/author-tutorial.md
@@ -494,7 +494,7 @@ pull.
 
 ## Step 9: release a 0.2.0
 
-When you change the package, bump `metadata.version` to 0.2.0,
+When you change the package, bump `installerMetadata.version` to 0.2.0,
 re-package, re-push. Operators upgrade by re-running setup with
 `--pull` pointed at the new ref:
 

--- a/docs/package-management-plan.md
+++ b/docs/package-management-plan.md
@@ -27,7 +27,7 @@ Goal: a `.tgz` of the source tree that is byte-identical across machines.
   - Reject: `*.env.secret` anywhere; anything under `out/`; anything matched by `.installerignore` (gitignore syntax via `go-git/go-billy`'s gitignore or a small in-tree matcher).
   - Include: `installer.yaml` + every directory referenced by `bases[].path`, `components[].path`, `validation.*`, `collector.command` (if relative), plus an opt-in `examples/` (gated by a `package.bundleExamples` field in `installer.yaml`, default true).
 - New: `internal/bundle/bundle_test.go` — two `Bundle` invocations of the same source tree produce equal digests; rename of a single file changes the digest; `.env.secret` triggers a refusal.
-- Modify: `internal/cli/package.go` — `-o`, default output filename `<metadata.name>-<metadata.version>.tgz` in cwd; print the digest on success.
+- Modify: `internal/cli/package.go` — `-o`, default output filename `<metadata.name>-<installerMetadata.version>.tgz` in cwd; print the digest on success.
 - Decision deferred: reachability-scan vs ignore-list. v1 ships ignore-list; reachability becomes a `installer package --strict` follow-up.
 
 Acceptance: `installer package examples/hello-app` produces a tarball whose `sha256` is reproducible across machines.

--- a/docs/package-management.md
+++ b/docs/package-management.md
@@ -134,7 +134,7 @@ operators who want pinned installs.
 
 ## Versioning and channels
 
-- `metadata.version` is required and parsed as SemVer 2.0. Tag-per-version
+- `installerMetadata.version` is required and parsed as SemVer 2.0. Tag-per-version
   artifacts are immutable.
 - Channel tags (`stable`, `latest`, `0`, `0.3`) are allowed by convention only.
   No registry-side mechanism enforces them; they are mutable aliases that

--- a/examples/gaie/README.md
+++ b/examples/gaie/README.md
@@ -60,4 +60,4 @@ for f in inference.networking.k8s.io_inferencepools.yaml \
 done
 ```
 
-Bump `installer.yaml`'s `metadata.version` to match.
+Bump `installer.yaml`'s `installerMetadata.version` to match.

--- a/examples/kuberay/README.md
+++ b/examples/kuberay/README.md
@@ -71,6 +71,6 @@ curl -sfL $BASE/samples/ray-cluster.sample.yaml \
   -o components/sample-cluster/raycluster.yaml
 ```
 
-After refreshing, update `installer.yaml`'s `metadata.version` and the
+After refreshing, update `installer.yaml`'s `installerMetadata.version` and the
 hardcoded operator image tag in the `set-container-image` invocation to match
 the new release. The vendored YAML doesn't need any post-fetch edits.

--- a/examples/kuberay/installer.yaml
+++ b/examples/kuberay/installer.yaml
@@ -48,7 +48,7 @@ spec:
     # Rewrite the operator image to a fully-qualified, version-pinned ref.
     # Upstream manager.yaml ships `image: kuberay/operator` (no registry, no
     # tag); the kuberay project publishes to quay.io, not Docker Hub. Bump
-    # the tag in lockstep with metadata.version above when refreshing.
+    # the tag in lockstep with installerMetadata.version above when refreshing.
     - toolchain: Kubernetes/YAML
       whereResource: "ConfigHub.ResourceType = 'apps/v1/Deployment'"
       description: Set the kuberay-operator container image.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -146,7 +146,7 @@ resources: []
 		},
 	}
 	cmd.Flags().StringVar(&name, "name", "", "package metadata.name (default: basename of <dir>)")
-	cmd.Flags().StringVar(&version, "version", "0.1.0", "package metadata.version (SemVer)")
+	cmd.Flags().StringVar(&version, "version", "0.1.0", "package installerMetadata.version (SemVer)")
 	cmd.Flags().BoolVar(&force, "force", false, "overwrite an existing installer.yaml")
 	return cmd
 }

--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -43,7 +43,7 @@ const localConfigAnnotation = "config.kubernetes.io/local-config"
 type Package struct {
 	// Name is metadata.name from installer.yaml.
 	Name string
-	// Version is metadata.version from installer.yaml.
+	// Version is installerMetadata.version from installer.yaml.
 	Version string
 	// LocalHandle is the name the parent used for this dep in its
 	// installer.yaml + lock. Empty for the parent itself. Used to derive

--- a/packages/argocd/README.md
+++ b/packages/argocd/README.md
@@ -129,7 +129,7 @@ for b in cluster-install namespace-install ha-cluster-install ha-namespace-insta
   sed -i '' "s/newTag: v.*/newTag: $TAG/" $DST/bases/$b/kustomization.yaml
 done
 
-# Bump metadata.version in installer.yaml to match.
+# Bump installerMetadata.version in installer.yaml to match.
 ```
 
 After refresh, re-run `kustomize build` against each base to confirm


### PR DESCRIPTION
## Summary
- consistently tell package authors to use `installerMetadata.version`
- correct CLI help, API comments, author docs, and maintained example refresh notes
- retain `metadata.version` references only in the explicit legacy compatibility parser and tests

## Verification
- `go test ./...`
- `rg -n "metadata\.version"` returns only the compatibility implementation and test
- `git diff --check`