### PR TITLE
ci: weekly PR to update the ConfigHub SDK

### DIFF
--- a/.github/workflows/update-sdk.yml
+++ b/.github/workflows/update-sdk.yml
@@ -1,0 +1,80 @@
+name: Update ConfigHub SDK
+
+# Weekly bump of every github.com/confighub/sdk/* requirement to the latest SDK
+# release, as a single pull request. If the bump does not build, go.mod is left
+# untouched and the run summary says so; fixing that is a code change, not a
+# dependency bump.
+#
+# The PR is always branch `chore/update-sdk`, force-pushed, so at most one is
+# open at a time. Requires "Allow GitHub Actions to create and approve pull
+# requests" in the repository's Actions settings.
+
+on:
+  schedule:
+    # Mondays, 14:00 UTC
+    - cron: '0 14 * * 1'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'SDK version to pin to (default: latest release)'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache: true
+
+      - name: Bump SDK modules
+        env:
+          SUMMARY_FILE: ${{ runner.temp }}/sdk-update.md
+          VERSION: ${{ inputs.version }}
+        run: |
+          scripts/update-sdk.sh $VERSION
+          cat "$SUMMARY_FILE" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Vet and test against the new SDK
+        run: |
+          go vet ./...
+          go test ./...
+
+      - name: Open or update the pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SUMMARY_FILE: ${{ runner.temp }}/sdk-update.md
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            echo "Every module is already on the latest SDK; nothing to open."
+            exit 0
+          fi
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git switch -C chore/update-sdk
+          git commit -am "deps: update ConfigHub SDK modules"
+          git push -f origin chore/update-sdk
+
+          number="$(gh pr view chore/update-sdk --json number -q .number 2>/dev/null || true)"
+          if [ -z "$number" ]; then
+            gh pr create \
+              --base main \
+              --head chore/update-sdk \
+              --title 'deps: update ConfigHub SDK modules' \
+              --body-file "$SUMMARY_FILE"
+          else
+            # gh pr edit trips over this org's classic Projects; patch via the REST API.
+            gh api -X PATCH "repos/$GITHUB_REPOSITORY/pulls/$number" \
+              -f body="$(cat "$SUMMARY_FILE")" >/dev/null
+          fi

--- a/scripts/update-sdk.sh
+++ b/scripts/update-sdk.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Bump every github.com/confighub/sdk/* requirement in the repo to one SDK
+# release. The SDK modules are tagged in lockstep, so a single version applies
+# to all of them; moving them together avoids the mixed-version state that a
+# per-module bump would leave behind.
+#
+# Usage: scripts/update-sdk.sh [version]     # default: latest release of sdk/core
+#
+# Env:
+#   SUMMARY_FILE  write a markdown summary here (for the PR body)
+#   SKIP_BUILD=1  skip the `go build ./...` verification
+#
+# A module whose tidy or build fails after the bump is restored to its previous
+# go.mod/go.sum and reported as skipped, so one stale example does not hold back
+# the rest.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+cd "${repo_root}"
+
+version="${1:-}"
+if [[ -z "${version}" ]]; then
+  version="$(curl -fsSL https://proxy.golang.org/github.com/confighub/sdk/core/@latest |
+    sed -n 's/.*"Version":"\([^"]*\)".*/\1/p')"
+fi
+if [[ ! "${version}" =~ ^v[0-9] ]]; then
+  echo "Could not determine an SDK version (got: '${version}')" >&2
+  exit 1
+fi
+echo "==> Target SDK version: ${version}"
+
+updated=()
+skipped=()
+unchanged=()
+
+while IFS= read -r modfile; do
+  dir="$(dirname "${modfile}")"
+  name="${dir#./}"
+  [[ "${name}" == "." ]] && name="$(basename "${repo_root}") (root module)"
+
+  sdk_mods="$(grep -oE 'github\.com/confighub/sdk/[A-Za-z0-9_./-]+' "${modfile}" | sort -u || true)"
+  [[ -n "${sdk_mods}" ]] || continue
+
+  targets=()
+  for mod in ${sdk_mods}; do
+    targets+=("${mod}@${version}")
+  done
+
+  echo "==> ${name}"
+  cp "${dir}/go.mod" "${dir}/go.mod.orig"
+  if [[ -f "${dir}/go.sum" ]]; then
+    cp "${dir}/go.sum" "${dir}/go.sum.orig"
+  fi
+
+  failure=""
+  (
+    cd "${dir}"
+    go get "${targets[@]}" && go mod tidy
+  ) || failure="go get / go mod tidy"
+
+  if [[ -z "${failure}" && "${SKIP_BUILD:-}" != "1" ]]; then
+    (cd "${dir}" && go build ./...) || failure="go build"
+  fi
+
+  if [[ -n "${failure}" ]]; then
+    echo "    skipped: ${failure} failed"
+    mv "${dir}/go.mod.orig" "${dir}/go.mod"
+    if [[ -f "${dir}/go.sum.orig" ]]; then
+      mv "${dir}/go.sum.orig" "${dir}/go.sum"
+    fi
+    skipped+=("${name} (${failure} failed)")
+    continue
+  fi
+
+  if cmp -s "${dir}/go.mod" "${dir}/go.mod.orig"; then
+    unchanged+=("${name}")
+  else
+    updated+=("${name}")
+  fi
+  rm -f "${dir}/go.mod.orig" "${dir}/go.sum.orig"
+done < <(find . -name go.mod -not -path '*/vendor/*' | sort)
+
+summary_lines=()
+summary_lines+=("Bumped \`github.com/confighub/sdk/*\` to \`${version}\`.")
+summary_lines+=("")
+if [[ ${#updated[@]} -gt 0 ]]; then
+  summary_lines+=("Updated (${#updated[@]}):")
+  for m in "${updated[@]}"; do summary_lines+=("- \`${m}\`"); done
+  summary_lines+=("")
+fi
+if [[ ${#skipped[@]} -gt 0 ]]; then
+  summary_lines+=("Left alone — the bump did not build, so these still need a code change (${#skipped[@]}):")
+  for m in "${skipped[@]}"; do summary_lines+=("- ${m}"); done
+  summary_lines+=("")
+fi
+if [[ ${#unchanged[@]} -gt 0 ]]; then
+  summary_lines+=("Already current (${#unchanged[@]}): ${unchanged[*]}")
+fi
+
+printf '%s\n' "" "${summary_lines[@]}"
+if [[ -n "${SUMMARY_FILE:-}" ]]; then
+  printf '%s\n' "${summary_lines[@]}" > "${SUMMARY_FILE}"
+fi


### PR DESCRIPTION
Every Monday, a PR moves this repo to the latest ConfigHub SDK release. The module is currently on `v0.1.61` while the SDK is at `v0.2.19`, and nothing pulls it forward.

## What lands

- `.github/workflows/update-sdk.yml` — Mondays at 14:00 UTC, plus `workflow_dispatch` with an optional version input to pin a specific release.
- `scripts/update-sdk.sh` — the bump itself, runnable locally: `scripts/update-sdk.sh [version]`.

The script moves all `github.com/confighub/sdk/*` requirements to one version, then runs `go mod tidy` and `go build ./...`; the workflow adds `go vet ./...` and `go test ./...`, matching what `release.yml` gates a release on. If the bump does not build, `go.mod` is restored and the run summary says so rather than opening a broken PR.

The PR is always the branch `chore/update-sdk`, force-pushed, so there is at most one open at a time. The same script and workflow are going into `confighub/examples`.

## Why a workflow rather than Dependabot

Dependabot has no way to hold the SDK family (`core`, `function-impl`, the nine `configkit/*` modules) to a single release — it would bump `core` in one PR and `yqkit` in another. This produces one coherent, verified PR.

## Verified

Ran against a clone: `v0.1.61` → `v0.2.19` across all eleven SDK requirements, tidy and build clean.

## One setup step

Enable **Settings → Actions → General → Allow GitHub Actions to create and approve pull requests**, or the PR step fails with a 403.

Note that `GITHUB_TOKEN`-pushed branches do not trigger other workflows, and `release.yml` only runs on tags — so the vet/test verification lives inside this workflow rather than in a check on the PR it opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
