### PR TITLE
ci: only match an open PR when updating the SDK branch

### DIFF
--- a/.github/workflows/update-sdk.yml
+++ b/.github/workflows/update-sdk.yml
@@ -66,7 +66,9 @@ jobs:
           git commit -am "deps: update ConfigHub SDK modules"
           git push -f origin chore/update-sdk
 
-          number="$(gh pr view chore/update-sdk --json number -q .number 2>/dev/null || true)"
+          # --state open matters: gh also resolves the branch to a merged PR,
+          # which would send this week's update to last week's merged one.
+          number="$(gh pr list --head chore/update-sdk --state open --json number --jq '.[0].number // empty')"
           if [ -z "$number" ]; then
             gh pr create \
               --base main \


### PR DESCRIPTION
Without this, next Monday's SDK bump would be pushed to `chore/update-sdk` with no pull request opened for it — the update would sit on a branch nobody is looking at.

Now that the first `chore/update-sdk` PR has merged, `gh pr view chore/update-sdk` resolves the branch to that **merged** PR rather than reporting no PR:

```
$ gh pr view chore/update-sdk --json number,state
{"number":195,"state":"MERGED"}
```

So the workflow would take its "a PR already exists" path and patch the body of the merged PR, and never call `gh pr create`.

Querying open PRs only returns empty, which is the create path:

```
$ gh pr list --head chore/update-sdk --state open --json number --jq '.[0].number // empty'

```

The same one-line fix is going into `confighub/installer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
