### PR TITLE
Say ValidationErrors, not ApplyGates

### DIFF
--- a/docs/package-management.md
+++ b/docs/package-management.md
@@ -272,7 +272,7 @@ ConfigHub Links + automatic apply-ordering (Roadmap item in the README) handle
 ordering inside a Space. Across Spaces, the dep tree implies an order: a Space
 is applied only after the Spaces of packages it depends on have converged. The
 installer's upload step records this in the installer-record Unit and in
-inter-Space Links; cross-Space ApplyGates enforce it at apply time.
+inter-Space Links; cross-Space ValidationErrors enforce it at apply time.
 
 ### Cluster-side `externalRequires` still apply
 

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -17,7 +17,7 @@ channels:
   inputs, and (via re-running the collector) facts.
 - **Post-install**: ConfigHub mutations on the uploaded Units (e.g.,
   `cub function do set-container-image`, hand-edits via `cub unit
-update`, ApplyGate-mediated approvals).
+update`, approvals that clear a ValidationError).
 
 Why: a consumer-edited package tree is silently overwritten on the next
 `installer setup --pull` (or `installer pull`). Worse, the edits are invisible
@@ -136,11 +136,11 @@ time and (3) for post-install one-offs; only edit spec/inputs.yaml for
 ## 6. Defer to ConfigHub for what ConfigHub does well
 
 The installer materializes Units. Everything downstream — apply,
-ApplyGates, validation Triggers, drift reconciliation, ChangeSets,
-promotion, rollback — is ConfigHub's job. The installer creates a
-ChangeSet for `installer upload` reconciles so updates are revertable,
-but it does not run apply, does not author Triggers, and does not
-reconcile cluster drift.
+validation Triggers and the ValidationErrors they record, drift
+reconciliation, ChangeSets, promotion, rollback — is ConfigHub's job.
+The installer creates a ChangeSet for `installer upload` reconciles so
+updates are revertable, but it does not run apply, does not author
+Triggers, and does not reconcile cluster drift.
 
 How to apply: when a feature request lands ("add a Trigger that blocks
 :latest"), route it to the right ConfigHub skill rather than building it


### PR DESCRIPTION
The ConfigHub API renamed `Unit.ApplyGates` to `ValidationErrors` and
`ApplyWarnings` to `ValidationWarnings`. Three prose references here follow it.

Docs only — the installer has no code that reads either field.

Two small judgment calls:

- The list in `principles.md` §6 read "apply, ApplyGates, validation Triggers,
  …". A straight swap would have stuttered ("ValidationErrors, validation
  Triggers"), so it now reads "validation Triggers and the ValidationErrors they
  record", and the paragraph is reflowed to the file's width.
- "apply time" and "apply" are left alone. That is this repo's own vocabulary
  throughout, and changing one phrase would only make it inconsistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ge1C6Wm1qR3WUCxEZKPboc